### PR TITLE
fix router basename

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -12,7 +12,7 @@ import Help from './pages/help';
 import './app.css';
 
 const App = () => (
-  <BrowserRouter>
+  <BrowserRouter basename={process.env.PUBLIC_URL}>
     <Switch>
       <Route exact path='/' component={Home} />
       <Route path='/genes' component={Genes} />


### PR DESCRIPTION
The gh-pages deployment isn't working, and I'm fairly sure that is because `react-router` only works with absolute paths. So when I link to `/genes`, for example, it ends up really linking to `https://greenelab.github.io/genes` (which doesn't exist), instead of `https://greenelab.github.io/adage-frontend/genes`.

This PR adds the `basename` property to the router, which sets what the base url is for all of the links. I am setting it to `{process.env.PUBLIC_URL}`, per [this comment](https://github.com/facebook/create-react-app/issues/1765#issuecomment-327615099), which should hopefully turn into `https://greenelab.github.io/adage-frontend` when deployed.