### PR TITLE
fix router in better way than previous PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-react-app-boilerplate",
   "version": "0.1.0",
-  "homepage": "./",
+  "homepage": "./adage-frontend",
   "dependencies": {
     "immer": "^5.0.0",
     "lodash": "^4.17.15",

--- a/src/app.js
+++ b/src/app.js
@@ -11,12 +11,8 @@ import Help from './pages/help';
 
 import './app.css';
 
-console.log('process.env', process.env);
-
-const basename = '/adage-frontend';
-
 const App = () => (
-  <BrowserRouter basename={basename}>
+  <BrowserRouter basename={process.env.PUBLIC_URL}>
     <Switch>
       <Route exact path='/' component={Home} />
       <Route path='/genes' component={Genes} />


### PR DESCRIPTION
Okay, one more time. This should do it.

Based on the `console.log`, I think `process.env.PUBLIC_URL` isn't automatically set/detected. It's actually just whatever you set as the `homepage` in your `package.json`. As such, changing the solution to "hard-coding" the basename there in the `package.json`, rather than in `app.js`.