### PR TITLE
remove basename, add versioning checks, add version on hover

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - test:
+      - test
       - deploy:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ workflows:
   version: 2
   build:
     jobs:
+      - test:
       - deploy:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
       - run:
           name: Frontend tests
           command: |
-            export REACT_APP_BASENAME=/adage-frontend
             npm install
             npm test
             npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - test:
-          filters:
-            branches:
-              ignore: gh-pages
       - deploy:
           requires:
             - test

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "create-react-app-boilerplate",
+  "name": "adage-frontend",
   "version": "0.0.1",
   "homepage": "./",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-react-app-boilerplate",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "homepage": "./",
   "dependencies": {
     "immer": "^5.0.0",

--- a/src/pages/header/title/index.js
+++ b/src/pages/header/title/index.js
@@ -5,8 +5,10 @@ import { ReactComponent as Logo } from '../../../images/logo-small.svg';
 
 import './index.css';
 
+import packageJson from '../../../../package.json';
+
 const Title = () => (
-  <Link to='/' className='page_header_column'>
+  <Link to='/' className='page_header_column' title={packageJson.version}>
     <Logo className='logo_small' />
     <span className='text_large'>adage</span>
   </Link>


### PR DESCRIPTION
- removes `adage-frontend` basename
- adds version on hover over logo/title
- ~adds check to circleci deployment to make sure version number has changed~ (we'll do this later instead)