### PR TITLE
change homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adage-frontend",
   "version": "0.0.1",
-  "homepage": "./",
+  "homepage": "/",
   "dependencies": {
     "immer": "^5.0.0",
     "lodash": "^4.17.15",


### PR DESCRIPTION
@dongbohu Nevermind, I forgot about the `homepage` key in `package.json` again. I believe what is in that field just gets prepended to the `static/js/main.js` path that is referenced/included in `index.html`.

Therefore, changing `./` to `/` should make `index.html` always look for the css and js relative to the root. 