### PR TITLE
Cancel async

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adage-frontend",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "homepage": "/",
   "dependencies": {
     "immer": "^5.0.0",

--- a/src/app.css
+++ b/src/app.css
@@ -55,6 +55,9 @@ section {
   margin: 40px 0;
   padding: 0 20px;
 }
+img {
+  max-width: 90%;
+}
 .semibold {
   font-weight: 500;
 }
@@ -76,8 +79,8 @@ section {
 .flip_vertically {
   transform: scaleY(-1);
 }
-
-
-img {
-  max-width: 90%;
+.nowrap {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -3,12 +3,11 @@ import { sleep } from '../util/debug.js';
 export const server = 'https://py3-adage.greenelab.com/api/v1/';
 
 export const fetchJson = async (url) => {
+  await sleep(Math.random() * 1000);
+
   const cachedResponse = window.sessionStorage.getItem(url);
   if (cachedResponse)
     return JSON.parse(cachedResponse);
-
-  // artificial delay for testing
-  await sleep(500 + Math.round(Math.random() * 500));
 
   let response = await fetch(url);
   if (!response.ok)

--- a/src/components/alert/index.css
+++ b/src/components/alert/index.css
@@ -1,4 +1,5 @@
 .alert {
+  box-sizing: border-box;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/alert/index.js
+++ b/src/components/alert/index.js
@@ -24,7 +24,7 @@ const Alert = ({ status = '', subject = '', className = '' }) => {
     >
       {status === thunkActionStatuses.LOADING && <Loading />}
       {status !== thunkActionStatuses.LOADING && <AlertIcon />}
-      <span>{text}</span>
+      <span className='nowrap'>{text}</span>
     </div>
   );
 };

--- a/src/components/details/index.css
+++ b/src/components/details/index.css
@@ -13,9 +13,6 @@
   flex-grow: 0;
   flex-shrink: 0;
   margin-right: 10px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 .detail_row > span:nth-child(2) {
   flex-grow: 1;

--- a/src/components/details/index.js
+++ b/src/components/details/index.js
@@ -15,7 +15,7 @@ const Details = ({ data = {} }) => {
       {Object.keys(data).map((key, index, array) => (
         <React.Fragment key={index}>
           <div className='detail_row'>
-            <span className='text_small semibold'>{key}</span>
+            <span className='text_small semibold nowrap'>{key}</span>
             <span className='text_small'>
               <Linkify>{format(data[key])}</Linkify>
             </span>

--- a/src/components/popup/index.js
+++ b/src/components/popup/index.js
@@ -2,12 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { createPortal } from 'react-dom';
 
-import { useBbox } from '../../util/hooks.js';
-
 import './index.css';
 
-const distance = 5;
-const padding = 20;
+const distance = 10;
 
 const Portal = ({
   anchorBbox = {},
@@ -15,43 +12,21 @@ const Portal = ({
   close = () => null,
   children,
   ...props
-}) => {
-  const [popupBbox, popupRef] = useBbox();
-
-  let x = -99999;
-  let y = -99999;
-
-  if (popupBbox) {
-    x = popupBbox.left;
-    y = popupBbox.top;
-  }
-
-  if (anchorBbox && popupBbox) {
-    x = anchorBbox.right - popupBbox.width;
-    y = anchorBbox.bottom + distance;
-  }
-
-  if (popupBbox) {
-    if (x > window.innerWidth - padding)
-      x = window.innerWidth - padding;
-    if (x < padding)
-      x = padding;
-  }
-
-  return (
-    <div className='popup_overlay' onClick={close}>
-      <div
-        ref={popupRef}
-        className={'popup_content ' + className}
-        {...props}
-        onClick={(event) => event.stopPropagation()}
-        style={{ left: x, top: y }}
-      >
-        {children}
-      </div>
+}) => (
+  <div className='popup_overlay' onClick={close}>
+    <div
+      className={'popup_content ' + className}
+      {...props}
+      onClick={(event) => event.stopPropagation()}
+      style={{
+        right: window.innerWidth - anchorBbox.right,
+        top: anchorBbox.bottom + distance
+      }}
+    >
+      {children}
     </div>
-  );
-};
+  </div>
+);
 
 const Popup = ({ isOpen, ...props }) => {
   if (isOpen)

--- a/src/pages/genes/search-box/index.js
+++ b/src/pages/genes/search-box/index.js
@@ -2,26 +2,31 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import Input from '../../../components/input';
+import { cancelAction } from '../../../util/thunk-actions.js';
 import { getGeneSearch } from '../../../actions/genes.js';
 import { clearGeneSearch } from '../../../actions/genes.js';
 
 import './index.css';
 
-let SearchBox = ({ ...props }) => (
+let SearchBox = ({ dispatch }) => (
   <Input
     multi
     placeholder='search for a gene'
     multiPlaceholder='search for a list of genes'
-    onChangeExpanded={props.onChangeExpanded}
     onChange={(value) => {
       const strings = value
         .split('\n')
         .map((search) => search.trim())
         .filter((search, index, array) => search || array.length === 1);
       const actions = strings.map((string, index) =>
-        getGeneSearch({ index: index, query: string })
+        getGeneSearch({
+          index: index,
+          query: string,
+          cancelType: 'GENE_SEARCH_' + index
+        })
       );
-      props.dispatch([clearGeneSearch(), [...actions]]);
+      cancelAction({ cancelTypeRegex: /GENE_SEARCH.*/ });
+      dispatch([clearGeneSearch(), [...actions]]);
     }}
   />
 );

--- a/src/pages/genes/search-results/index.css
+++ b/src/pages/genes/search-results/index.css
@@ -1,3 +1,8 @@
 .gene_search_results {
   margin-top: 20px;
 }
+.gene_search_result_field {
+  box-sizing: border-box;
+  display: inline-block;
+  padding: 0 5px;
+}

--- a/src/pages/genes/search-results/multi-controls/index.css
+++ b/src/pages/genes/search-results/multi-controls/index.css
@@ -2,5 +2,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-wrap: wrap;
   margin-top: 10px;
 }

--- a/src/pages/genes/search-results/multi-row/index.js
+++ b/src/pages/genes/search-results/multi-row/index.js
@@ -139,6 +139,7 @@ const ResultButton = ({
         gene_search_result_multi_details
         gene_search_result_field
         text_small
+        nowrap
       `}
     >
       {col1}
@@ -148,6 +149,7 @@ const ResultButton = ({
         gene_search_result_multi_details
         gene_search_result_field
         text_small
+        nowrap
       `}
     >
       {col2}

--- a/src/pages/genes/search-results/multi/index.css
+++ b/src/pages/genes/search-results/multi/index.css
@@ -1,3 +1,4 @@
 .gene_search_results_multi_alert {
   height: calc(1 * 30px);
+  padding: 0 10px;
 }

--- a/src/pages/genes/search-results/single-row/index.css
+++ b/src/pages/genes/search-results/single-row/index.css
@@ -21,14 +21,6 @@
 .gene_search_result_single_summary {
   width: calc(100% - 30px);
 }
-.gene_search_result_field {
-  box-sizing: border-box;
-  display: inline-block;
-  padding: 0 5px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
 .gene_search_result_single .gene_search_result_field:nth-child(1),
 .gene_search_result_single .gene_search_result_field:nth-child(2),
 .gene_search_result_single .gene_search_result_field:nth-child(3) {

--- a/src/pages/genes/search-results/single-row/index.js
+++ b/src/pages/genes/search-results/single-row/index.js
@@ -29,10 +29,42 @@ const SingleRow = ({
         {!selected && <Unchecked />}
       </div>
       <div className='gene_search_result_single_summary'>
-        <span className='gene_search_result_field text_small'>{col1}</span>
-        <span className='gene_search_result_field text_small'>{col2}</span>
-        <span className='gene_search_result_field text_small'>{col3}</span>
-        <span className='gene_search_result_field text_small'>{col4}</span>
+        <span
+          className={`
+            gene_search_result_field
+            text_small
+            nowrap
+          `}
+        >
+          {col1}
+        </span>
+        <span
+          className={`
+            gene_search_result_field
+            text_small
+            nowrap
+          `}
+        >
+          {col2}
+        </span>
+        <span
+          className={`
+            gene_search_result_field
+            text_small
+            nowrap
+          `}
+        >
+          {col3}
+        </span>
+        <span
+          className={`
+            gene_search_result_field
+            text_small
+            nowrap
+          `}
+        >
+          {col4}
+        </span>
       </div>
     </Button>
     <LinkIcon

--- a/src/pages/header/model-select/item/index.css
+++ b/src/pages/header/model-select/item/index.css
@@ -26,9 +26,6 @@
 }
 .model_summary > * {
   line-height: 1em;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
 }
 .model_info {
   display: inline-flex;

--- a/src/util/debug.js
+++ b/src/util/debug.js
@@ -1,2 +1,3 @@
 // add artificial delay for testing
-export const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+export const sleep = (ms) =>
+  new Promise((resolve) => setTimeout(resolve, Math.round(ms)));

--- a/src/util/debug.js
+++ b/src/util/debug.js
@@ -1,2 +1,3 @@
 // add artificial delay for testing
-export const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+export const sleep = (ms) =>
+  new Promise((resolve) => window.setTimeout(resolve, ms));

--- a/src/util/debug.js
+++ b/src/util/debug.js
@@ -1,3 +1,2 @@
 // add artificial delay for testing
-export const sleep = (ms) =>
-  new Promise((resolve) => setTimeout(resolve, Math.round(ms)));
+export const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/util/thunk-actions.js
+++ b/src/util/thunk-actions.js
@@ -12,7 +12,7 @@ export const thunkActionStatuses = {
   ERROR: 'ERROR'
 };
 
-export const actionStore = {};
+const actionStore = {};
 
 export const createActionThunk = (type, func) => ({ ...props }) => async (
   dispatch
@@ -56,7 +56,7 @@ export const createActionThunk = (type, func) => ({ ...props }) => async (
 
 const generateActionId = () => Math.random();
 
-export const isStaleAction = ({ cancelType, actionId }) =>
+const isStaleAction = ({ cancelType, actionId }) =>
   cancelType && actionStore[cancelType] !== actionId;
 
 export const cancelAction = ({ cancelTypeRegex }) => {

--- a/src/util/thunk-actions.js
+++ b/src/util/thunk-actions.js
@@ -3,6 +3,16 @@ import { createAction } from 'redux-actions';
 import { isArray } from './types.js';
 
 // replacement for redux-thunk-actions
+// provide the "cancelType" prop to any action made by this creator
+// any new action will cancel all previous in-progress actions of the same type
+
+export const thunkActionStatuses = {
+  LOADING: 'LOADING',
+  EMPTY: 'EMPTY',
+  ERROR: 'ERROR'
+};
+
+export const actionStore = {};
 
 export const createActionThunk = (type, func) => ({ ...props }) => async (
   dispatch
@@ -10,11 +20,24 @@ export const createActionThunk = (type, func) => ({ ...props }) => async (
   const meta = () => ({ ...props });
   const action = createAction(type, null, meta);
 
+  const cancelType = props.cancelType;
+  delete props.cancelType;
+
+  let actionId = null;
+  if (cancelType) {
+    actionId = generateActionId();
+    actionStore[cancelType] = actionId;
+  }
+
   dispatch(action(thunkActionStatuses.LOADING));
 
   let payload;
   try {
     payload = await func({ ...props });
+
+    if (isStaleAction({ cancelType, actionId }))
+      return;
+
     if (
       (isArray(payload) && payload.length) ||
       (payload !== null && Object.keys(payload).length)
@@ -23,13 +46,22 @@ export const createActionThunk = (type, func) => ({ ...props }) => async (
     else
       dispatch(action(thunkActionStatuses.EMPTY));
   } catch (error) {
+    if (isStaleAction({ cancelType, actionId }))
+      return;
+
     console.error(error);
     dispatch(action(thunkActionStatuses.ERROR));
   }
 };
 
-export const thunkActionStatuses = {
-  LOADING: 'LOADING',
-  EMPTY: 'EMPTY',
-  ERROR: 'ERROR'
+const generateActionId = () => Math.random();
+
+export const isStaleAction = ({ cancelType, actionId }) =>
+  cancelType && actionStore[cancelType] !== actionId;
+
+export const cancelAction = ({ cancelTypeRegex }) => {
+  for (const key of Object.keys(actionStore)) {
+    if (key.match(cancelTypeRegex))
+      delete actionStore[key];
+  }
 };


### PR DESCRIPTION
- incorporates a way to track which async action was the latest to START, and cancel all previous ones
- simplifies popup component
- tweaks some css

@dongbohu Essentially this is how it works. There's a persistent action store that stores all the running async actions (like backend queries). The store also checks for a certain type, because we never want, say, a model details lookup action to cancel a gene search action. We only want a gene search action to cancel another gene search action.

Whenever a new async action (a backend query) comes in, it gets a unique id, and pushed to the store as the most recent one of that type to start. If, by the time it finishes getting the data from the backend, its action id doesn't match what's in the store, that means another more recent action should take precedence, and it (the old action) is canceled (it doesn't continue dispatching).