### PR TITLE
Sample table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adage-frontend",
-  "version": "0.1.01",
+  "version": "0.1.02",
   "dependencies": {
     "color": "^3.1.2",
     "d3": "^5.15.0",

--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { Link as RouterLink } from 'react-router-dom';
 import { withRouter } from 'react-router-dom';
 
+import Tooltip from '../tooltip';
+
 import './index.css';
 
 let Link = ({
@@ -42,19 +44,21 @@ let Link = ({
   }
 
   return (
-    <RouterLink
-      className={
-        'clickable nowrap ' + (!icon ? 'field nowrap' : '') + ' ' + className
-      }
-      target={newTab ? '_blank' : undefined}
-      to={{ pathname: to, search: location.search }}
-      data-button={button}
-      data-text={text !== undefined}
-      data-icon={icon !== undefined}
-      {...props}
-    >
-      {content}
-    </RouterLink>
+    <Tooltip text={'View full details of ' + text}>
+      <RouterLink
+        className={
+          'clickable nowrap ' + (!icon ? 'field nowrap' : '') + ' ' + className
+        }
+        target={newTab ? '_blank' : undefined}
+        to={{ pathname: to, search: location.search }}
+        data-button={button}
+        data-text={text !== undefined}
+        data-icon={icon !== undefined}
+        {...props}
+      >
+        {content}
+      </RouterLink>
+    </Tooltip>
   );
 };
 

--- a/src/components/table/index.js
+++ b/src/components/table/index.js
@@ -28,7 +28,8 @@ const Table = ({
       column.render ? column.render(row.original) : String(cell.value || '-'),
     width: column.width,
     align: column.align,
-    padded: column.padded
+    padded: column.padded,
+    field: column.field ? true : false
   }));
 
   const {
@@ -122,10 +123,10 @@ const Table = ({
                     justifyContent: cell.column.align
                   }}
                 >
-                  {cell.value === undefined ? (
-                    cell.render('Cell')
-                  ) : (
+                  {cell.column.field ? (
                     <Field>{cell.render('Cell')}</Field>
+                  ) : (
+                    cell.render('Cell')
                   )}
                 </span>
               ))}

--- a/src/pages/experiments/index.js
+++ b/src/pages/experiments/index.js
@@ -5,6 +5,8 @@ import Main from '../main';
 import Footer from '../footer';
 import Section from '../../components/section';
 import Search from './search';
+import Selected from './selected';
+import { camelizeObject } from '../../util/object';
 import { humanizeObject } from '../../util/object';
 import { flattenObject } from '../../util/object';
 
@@ -17,7 +19,9 @@ const Experiments = () => (
       <Section text='Experiment Search'>
         <Search />
       </Section>
-      <Section text='Selected Experiment'></Section>
+      <Section text='Selected Experiment'>
+        <Selected />
+      </Section>
     </Main>
     <Footer />
   </>
@@ -25,11 +29,8 @@ const Experiments = () => (
 
 export default Experiments;
 
-export const mapExperiment = (experiment) => ({
-  accession: experiment.accession,
-  name: experiment.name,
-  description: experiment.description,
-  samples: (experiment.samples || []).map(mapSample)
-});
+export const mapExperiment = (experiment) =>
+  camelizeObject(flattenObject(experiment));
 
-export const mapSample = (sample) => humanizeObject(flattenObject(sample));
+export const mapExperimentDownload = (experiment) =>
+  humanizeObject(flattenObject(experiment));

--- a/src/pages/experiments/search/single-table/index.js
+++ b/src/pages/experiments/search/single-table/index.js
@@ -19,7 +19,6 @@ let Table = ({ results, highlightedIndex, select }) => {
       columns={[
         {
           name: ' ',
-          value: ' ',
           width: '30px',
           padded: false,
           render: (cell) => (
@@ -48,12 +47,14 @@ let Table = ({ results, highlightedIndex, select }) => {
           name: 'Samples',
           value: (row) => row?.samples?.length || '-',
           width: 'calc((100% - 30px) * 0.15)',
-          align: 'center'
+          align: 'center',
+          field: true
         },
         {
           name: 'Name',
           value: 'name',
-          width: 'calc((100% - 30px) * 0.6)'
+          width: 'calc((100% - 30px) * 0.6)',
+          field: true
         }
       ]}
       highlightedIndex={highlightedIndex}

--- a/src/pages/experiments/selected/controls/index.css
+++ b/src/pages/experiments/selected/controls/index.css
@@ -1,0 +1,7 @@
+.experiment_selected_controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 20px;
+}

--- a/src/pages/experiments/selected/controls/index.js
+++ b/src/pages/experiments/selected/controls/index.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import Tooltip from '../../../../components/tooltip';
+import Button from '../../../../components/button';
+import { downloadTsv } from '../../../../util/download.js';
+
+import { ReactComponent as Download } from '../../../../images/download.svg';
+
+import './index.css';
+import { humanizeObject, flattenObject } from '../../../../util/object';
+
+let Controls = ({ samples }) => (
+  <div className='experiment_selected_controls'>
+    <Tooltip text='Download this table as a .tsv file'>
+      <Button
+        text='Download'
+        icon={<Download />}
+        onClick={() => downloadTsv(samples, 'samples')}
+      />
+    </Tooltip>
+  </div>
+);
+
+const mapStateToProps = (state) => ({
+  samples: (state.experiment.selected.samples || []).map((sample) =>
+    humanizeObject(flattenObject(sample))
+  )
+});
+
+Controls = connect(mapStateToProps)(Controls);
+
+export default Controls;

--- a/src/pages/experiments/selected/details/index.css
+++ b/src/pages/experiments/selected/details/index.css
@@ -1,0 +1,3 @@
+.experiment_selected_details > * {
+  margin-bottom: 20px;
+}

--- a/src/pages/experiments/selected/details/index.js
+++ b/src/pages/experiments/selected/details/index.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import Link from '../../../../components/link';
+import { mapExperiment } from '../../';
+
+import './index.css';
+
+const limit = 150;
+
+let Details = ({ experiment }) => (
+  <div className='experiment_selected_details'>
+    <div className='medium'>
+      {(experiment.name?.substr(0, limit) || '') +
+        (experiment.name?.length >= limit ? '...' : '')}
+    </div>
+    <div>
+      {(experiment.description?.substr(0, limit) || '') +
+        (experiment.description?.length >= limit ? '...' : '')}
+    </div>
+    <Link
+      className='medium'
+      to={'/experiment/' + experiment.accession}
+      newTab
+      button={false}
+      text={experiment.accession || '-'}
+    />
+  </div>
+);
+
+const mapStateToProps = (state) => ({
+  experiment: mapExperiment(state.experiment.selected)
+});
+
+Details = connect(mapStateToProps)(Details);
+
+export default Details;

--- a/src/pages/experiments/selected/details/index.js
+++ b/src/pages/experiments/selected/details/index.js
@@ -6,7 +6,7 @@ import { mapExperiment } from '../../';
 
 import './index.css';
 
-const limit = 150;
+const limit = 200;
 
 let Details = ({ experiment }) => (
   <div className='experiment_selected_details'>

--- a/src/pages/experiments/selected/index.js
+++ b/src/pages/experiments/selected/index.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import Alert from '../../../components/alert';
+import Table from './table';
+import Controls from './controls';
+
+import './index.css';
+
+let Selected = ({ anySelected }) => (
+  <>
+    {anySelected === false && <Alert text='No experiment selected' />}
+    {anySelected === true && (
+      <>
+        <Table />
+        <Controls />
+      </>
+    )}
+  </>
+);
+
+const mapStateToProps = (state) => ({
+  anySelected: state.experiment.selected.accession ? true : false
+});
+
+Selected = connect(mapStateToProps)(Selected);
+
+export default Selected;

--- a/src/pages/experiments/selected/index.js
+++ b/src/pages/experiments/selected/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import Alert from '../../../components/alert';
+import Details from './details';
 import Table from './table';
 import Controls from './controls';
 
@@ -12,6 +13,7 @@ let Selected = ({ anySelected }) => (
     {anySelected === false && <Alert text='No experiment selected' />}
     {anySelected === true && (
       <>
+        <Details />
         <Table />
         <Controls />
       </>

--- a/src/pages/experiments/selected/table/index.js
+++ b/src/pages/experiments/selected/table/index.js
@@ -22,7 +22,6 @@ let Table = ({ samples, deselect }) => (
       },
       {
         name: 'Name',
-        value: 'name',
         width: 'calc((100% - 60px) * 0.25)',
         render: (cell) => (
           <Link
@@ -36,17 +35,20 @@ let Table = ({ samples, deselect }) => (
       {
         name: 'Genotype',
         value: 'genotype',
-        width: 'calc((100% - 60px) * 0.25)'
+        width: 'calc((100% - 60px) * 0.25)',
+        field: true
       },
       {
         name: 'Strain',
         value: 'strain',
-        width: 'calc((100% - 60px) * 0.10)'
+        width: 'calc((100% - 60px) * 0.10)',
+        field: true
       },
       {
         name: 'Description',
         value: 'description',
-        width: 'calc((100% - 60px) * 0.40)'
+        width: 'calc((100% - 60px) * 0.40)',
+        field: true
       }
     ]}
   />

--- a/src/pages/experiments/selected/table/index.js
+++ b/src/pages/experiments/selected/table/index.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import Link from '../../../../components/link';
+import TableComponent from '../../../../components/table';
+
+import { camelizeObject } from '../../../../util/object.js';
+import { flattenObject } from '../../../../util/object.js';
+
+import './index.css';
+
+let Table = ({ samples, deselect }) => (
+  <TableComponent
+    data={samples}
+    columns={[
+      {
+        name: 'Group',
+        value: 'group',
+        width: '60px',
+        padded: false,
+        render: (cell) => ''
+      },
+      {
+        name: 'Name',
+        value: 'name',
+        width: 'calc((100% - 60px) * 0.25)',
+        render: (cell) => (
+          <Link
+            to={'/sample/' + cell.id}
+            newTab
+            button={false}
+            text={cell.name || '-'}
+          />
+        )
+      },
+      {
+        name: 'Genotype',
+        value: 'genotype',
+        width: 'calc((100% - 60px) * 0.25)'
+      },
+      {
+        name: 'Strain',
+        value: 'strain',
+        width: 'calc((100% - 60px) * 0.10)'
+      },
+      {
+        name: 'Description',
+        value: 'description',
+        width: 'calc((100% - 60px) * 0.40)'
+      }
+    ]}
+  />
+);
+
+const mapStateToProps = (state) => ({
+  samples: (state.experiment.selected.samples || []).map((sample) =>
+    camelizeObject(flattenObject(sample))
+  )
+});
+
+const mapDispatchToProps = (dispatch) => ({});
+
+Table = connect(mapStateToProps, mapDispatchToProps)(Table);
+
+export default Table;

--- a/src/pages/genes/enriched/table/index.js
+++ b/src/pages/genes/enriched/table/index.js
@@ -37,7 +37,8 @@ let Table = ({ enrichedSignatures }) => (
                 newTab
                 button={false}
                 text={gene.name}
-              />{' '}
+              />
+              &nbsp;
             </Fragment>
           ))
       },
@@ -45,7 +46,8 @@ let Table = ({ enrichedSignatures }) => (
         name: 'p-value',
         value: 'pValue',
         width: '25%',
-        align: 'center'
+        align: 'center',
+        field: true
       }
     ]}
     defaultSort={[{ id: 'pValue', desc: false }]}

--- a/src/pages/genes/index.js
+++ b/src/pages/genes/index.js
@@ -9,6 +9,10 @@ import Selected from './selected';
 import Enriched from './enriched';
 import Network from './network';
 
+import { camelizeObject } from '../../util/object.js';
+import { humanizeObject } from '../../util/object.js';
+import { flattenObject } from '../../util/object.js';
+
 import './index.css';
 
 const Genes = () => (
@@ -35,21 +39,9 @@ const Genes = () => (
 export default Genes;
 
 export const mapGene = (gene) => ({
-  id: gene.id,
-  standardName: gene.standard_name,
-  systematicName: gene.systematic_name,
+  ...camelizeObject(flattenObject(gene)),
   name: gene.standard_name || gene.systematic_name || gene.entrezid || '???',
-  entrezId: gene.entrezid,
-  description: gene.description,
-  aliases: gene.aliases,
-  organism: gene.organism
+  entrezId: gene.entrezid
 });
 
-export const mapGeneDownload = (gene) => ({
-  'Standard Name': gene.standard_name || '-',
-  'Systematic Name': gene.systematic_name || '-',
-  'Entrez Id': gene.entrezid || '-',
-  'Description': gene.description || '-',
-  'Aliases': gene.aliases || '-',
-  'Organism': gene.organism || '-'
-});
+export const mapGeneDownload = (gene) => humanizeObject(flattenObject(gene));

--- a/src/pages/genes/network/controls/download.js
+++ b/src/pages/genes/network/controls/download.js
@@ -1,5 +1,3 @@
-import decode from 'unescape';
-
 import { svg } from '../graph';
 import { downloadSvg } from '../../../../util/download.js';
 
@@ -8,5 +6,5 @@ export const download = () => {
   const highlights = clone.querySelectorAll('g[id*="highlight"]');
   for (const highlight of highlights)
     highlight.remove();
-  downloadSvg(decode(clone.outerHTML), 'gene-network');
+  downloadSvg(clone.outerHTML, 'gene-network');
 };

--- a/src/pages/genes/selected/controls/index.js
+++ b/src/pages/genes/selected/controls/index.js
@@ -28,9 +28,7 @@ let Controls = ({ selected, deselectAll }) => (
 );
 
 const mapStateToProps = (state) => ({
-  selected: state.gene.selected.map((selected) =>
-    mapGeneDownload(selected)
-  )
+  selected: state.gene.selected.map(mapGeneDownload)
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/reducers/experiments.js
+++ b/src/reducers/experiments.js
@@ -40,7 +40,7 @@ const reducer = produce((draft, type, payload, meta) => {
 
     case 'SELECT_EXPERIMENTS_FROM_URL':
       if (!payload.accession)
-        draft.selected = [];
+        draft.selected = {};
       else
         draft.selected = { accession: payload.accession };
       break;
@@ -50,7 +50,7 @@ const reducer = produce((draft, type, payload, meta) => {
         break;
       draft.selected = draft.list.find(
         (experiment) => experiment.accession === draft.selected.accession
-      );
+      ) || {};
       break;
 
     default:

--- a/src/reducers/url.js
+++ b/src/reducers/url.js
@@ -39,7 +39,7 @@ export const querySync = reduxQuerySync.enhancer({
       action: (value) => ({
         type: 'SELECT_EXPERIMENTS_FROM_URL',
         payload: {
-          accession: Number(value) || null
+          accession: value || null
         }
       })
     }

--- a/src/util/download.js
+++ b/src/util/download.js
@@ -1,3 +1,5 @@
+import decode from 'unescape';
+
 export const downloadTsv = (data = [], filename = 'download') => {
   if (!data.length)
     return;
@@ -24,6 +26,7 @@ export const downloadTsv = (data = [], filename = 'download') => {
 };
 
 export const downloadSvg = (data, filename) => {
+  data = decode(data);
   const blob = new Blob([data], { type: 'image/svg+xml' });
   const url = window.URL.createObjectURL(blob);
   const link = document.createElement('a');

--- a/src/util/object.js
+++ b/src/util/object.js
@@ -1,5 +1,6 @@
 import { isObject } from './types';
 import { humanizeString } from './string';
+import { camelizeString } from './string';
 
 export const flattenObject = (object) => {
   if (!isObject(object))
@@ -19,6 +20,18 @@ export const humanizeObject = (object) => {
   object = { ...object };
   for (const key of Object.keys(object)) {
     const newKey = humanizeString(key);
+    if (key !== newKey) {
+      object[newKey] = object[key];
+      delete object[key];
+    }
+  }
+  return object;
+};
+
+export const camelizeObject = (object) => {
+  object = { ...object };
+  for (const key of Object.keys(object)) {
+    const newKey = camelizeString(key);
     if (key !== newKey) {
       object[newKey] = object[key];
       delete object[key];

--- a/src/util/string.js
+++ b/src/util/string.js
@@ -7,3 +7,13 @@ export const humanizeString = (string) => {
   string = string.join(' ');
   return string;
 };
+
+// convert underscore_case and dash-case to camelCase
+export const camelizeString = (string) => {
+  string = string.split(/_|-/);
+  string = string.map((word, index) =>
+    index > 0 ? word.charAt(0).toUpperCase() + word.substring(1) : word
+  );
+  string = string.join('');
+  return string;
+};


### PR DESCRIPTION
- add selected experiment info and sample table (will add group column buttons in next PR)
- generalize mapGene/mapExperiment/etc functions with camelizeObject (eg convert standard_name object key to standardName)
- add Tooltip to Link component
- change the way tables detect if a cell should be wrapped in a Field component (which includes a Tooltip): make table columns have to explicitly declare that they want to be a field
- fix experiment url persistence bug
- CSS tweaks

![image](https://user-images.githubusercontent.com/8326331/73947721-ecfd4580-48c5-11ea-8de6-5fe3a06bb0f8.png)

