### PR TITLE
sample groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adage-frontend",
-  "version": "0.1.03",
+  "version": "0.1.04",
   "dependencies": {
     "color": "^3.1.2",
     "d3": "^5.15.0",

--- a/src/actions/samples.js
+++ b/src/actions/samples.js
@@ -1,3 +1,4 @@
+import { createAction } from 'redux-actions';
 import { createFetchAction } from './fetch';
 
 import { urlSampleDetails } from '../backend/samples';
@@ -9,3 +10,12 @@ export const getSampleDetails = createFetchAction(
   'GET_SAMPLE_DETAILS',
   urlSampleDetails
 );
+
+// place sample (id) in specified group (index)
+export const groupSample = createAction('GROUP_SAMPLE');
+
+// remove sample (id) from all groups
+export const ungroupSample = createAction('UNGROUP_SAMPLE');
+
+// remove all samples from groups
+export const ungroupAllSamples = createAction('UNGROUP_ALL_SAMPLES');

--- a/src/images/diamond.svg
+++ b/src/images/diamond.svg
@@ -5,7 +5,7 @@
   viewBox="0 0 100 100"
 >
   <path
-    transform="translate(50,50) scale(0.75) translate(-50,-50)"
+    transform="translate(50,50) scale(0.90) translate(-50,-50)"
     fill="currentColor"
     d="
       M 50 0

--- a/src/images/spade.svg
+++ b/src/images/spade.svg
@@ -5,7 +5,7 @@
   viewBox="0 0 100 100"
 >
   <path
-    transform="translate(50,50) scale(0.75) translate(-50,-50)"
+    transform="translate(50,50) scale(0.90) translate(-50,-50)"
     fill="currentColor"
     d="
       M 50 0

--- a/src/pages/experiments/selected/controls/index.js
+++ b/src/pages/experiments/selected/controls/index.js
@@ -5,15 +5,24 @@ import Tooltip from '../../../../components/tooltip';
 import Button from '../../../../components/button';
 import { downloadTsv } from '../../../../util/download';
 import { normalize } from '../../../../util/object';
+import { ungroupAllSamples } from '../../../../actions/samples';
 
+import { ReactComponent as CrossIcon } from '../../../../images/cross.svg';
 import { ReactComponent as DownloadIcon } from '../../../../images/download.svg';
 
 import './index.css';
 
 // controls below selected experiment samples table
 
-let Controls = ({ samples }) => (
+let Controls = ({ samples, ungroupAll }) => (
   <div className='experiment_selected_controls'>
+    <Tooltip text='Ungroup all samples'>
+      <Button
+        text='Ungroup all'
+        icon={<CrossIcon />}
+        onClick={ungroupAll}
+      />
+    </Tooltip>
     <Tooltip text='Download this table as a .tsv file'>
       <Button
         text='Download'
@@ -30,6 +39,10 @@ const mapStateToProps = (state) => ({
   )
 });
 
-Controls = connect(mapStateToProps)(Controls);
+const mapDispatchToProps = (dispatch) => ({
+  ungroupAll: () => dispatch(ungroupAllSamples())
+});
+
+Controls = connect(mapStateToProps, mapDispatchToProps)(Controls);
 
 export default Controls;

--- a/src/pages/experiments/selected/details/index.css
+++ b/src/pages/experiments/selected/details/index.css
@@ -1,3 +1,20 @@
-.experiment_selected_details > * {
+.selected_experiment_info > * {
   margin-bottom: 20px;
+}
+.sample_table_info {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 20px;
+  margin-bottom: 10px;
+}
+.sample_table_info > span {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0 20px;
+}
+.sample_table_info > span > svg {
+  margin-right: 10px;
 }

--- a/src/pages/experiments/selected/details/index.js
+++ b/src/pages/experiments/selected/details/index.js
@@ -1,34 +1,53 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import Tooltip from '../../../../components/tooltip';
 import Link from '../../../../components/link';
 import { mapExperiment } from '../../';
 
 import './index.css';
+
+import { ReactComponent as ExperimentIcon } from '../../../../images/experiment.svg';
+import { ReactComponent as SampleIcon } from '../../../../images/sample.svg';
 
 const limit = 200;
 
 // main details of selected experiment
 
 let Details = ({ experiment }) => (
-  <div className='experiment_selected_details'>
-    <div className='medium'>
-      {(experiment.name?.substr(0, limit) || '') +
-        (experiment.name?.length >= limit ? '...' : '')}
+  <>
+    <div className='selected_experiment_info'>
+      <div className='medium'>
+        {(experiment.name?.substr(0, limit) || '') +
+          (experiment.name?.length >= limit ? '...' : '')}
+      </div>
+      <div>
+        {(experiment.description?.substr(0, limit) || '') +
+          (experiment.description?.length >= limit ? '...' : '')}
+      </div>
     </div>
-    <div>
-      {(experiment.description?.substr(0, limit) || '') +
-        (experiment.description?.length >= limit ? '...' : '')}
+    <div className='sample_table_info medium'>
+      <span>
+        <ExperimentIcon />
+        <Link
+          className='medium'
+          to={'/experiment/' + experiment.accession}
+          newTab
+          button={false}
+          text={experiment.accession}
+          tooltip={'Open details page for experiment ' + experiment.accession}
+        />
+      </span>
+      <Tooltip
+        text={'Showing ' + (experiment.samples?.length || 0) + ' samples'}
+      >
+        <span>
+          <SampleIcon />
+          {experiment.samples?.length || 0}
+        </span>
+      </Tooltip>
     </div>
-    <Link
-      className='medium'
-      to={'/experiment/' + experiment.accession}
-      newTab
-      button={false}
-      text={experiment.accession}
-      tooltip={'Open details page for experiment ' + experiment.accession}
-    />
-  </div>
+  </>
 );
 
 const mapStateToProps = (state) => ({

--- a/src/pages/experiments/selected/table/index.js
+++ b/src/pages/experiments/selected/table/index.js
@@ -102,10 +102,11 @@ let GroupButton = ({ sample, index, name, color, Icon, group, ungroup }) => {
       }
     >
       <Button
-        icon={<Icon style={{ color: grouped ? color : defaultColor }} />}
+        icon={<Icon />}
         onClick={() =>
           (grouped ? ungroup : group)({ index: index, id: sample.id })
         }
+        style={{ color: grouped ? color : defaultColor }}
       />
     </Tooltip>
   );

--- a/src/pages/experiments/selected/table/index.js
+++ b/src/pages/experiments/selected/table/index.js
@@ -1,16 +1,23 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import Tooltip from '../../../../components/tooltip';
+import Button from '../../../../components/button';
 import Link from '../../../../components/link';
 import TableComponent from '../../../../components/table';
-
+import { groupSample } from '../../../../actions/samples';
+import { ungroupSample } from '../../../../actions/samples';
 import { normalize } from '../../../../util/object';
+import { isGrouped } from '../../../../reducers/samples';
+
+import { ReactComponent as DiamondIcon } from '../../../../images/diamond.svg';
+import { ReactComponent as SpadeIcon } from '../../../../images/spade.svg';
 
 import './index.css';
 
 // table of samples for selected experiment
 
-let Table = ({ samples, deselect }) => (
+let Table = ({ samples, group, ungroup }) => (
   <TableComponent
     data={samples}
     columns={[
@@ -18,11 +25,30 @@ let Table = ({ samples, deselect }) => (
         name: 'Group',
         value: 'group',
         width: '60px',
+        align: 'center',
         padded: false,
-        render: (cell) => ''
+        render: (cell) => (
+          <>
+            <GroupButton
+              sample={cell}
+              index={1}
+              name='Diamond'
+              color='var(--blue)'
+              Icon={DiamondIcon}
+            />
+            <GroupButton
+              sample={cell}
+              index={2}
+              name='Spade'
+              color='var(--red)'
+              Icon={SpadeIcon}
+            />
+          </>
+        )
       },
       {
         name: 'Name',
+        value: 'name',
         width: 'calc((100% - 60px) * 0.25)',
         render: (cell) => (
           <Link
@@ -54,13 +80,40 @@ let Table = ({ samples, deselect }) => (
 );
 
 const mapStateToProps = (state) => ({
-  samples: (state.experiment.selected.samples || []).map((sample) =>
-    normalize(sample, false, 1)
-  )
+  samples: (state.experiment.selected.samples || [])
+    .map((sample) => normalize(sample, false, 1))
+    .map((sample) => ({
+      ...sample,
+      group: isGrouped(state.sample.groups, sample.id)
+    }))
 });
 
-const mapDispatchToProps = (dispatch) => ({});
-
-Table = connect(mapStateToProps, mapDispatchToProps)(Table);
+Table = connect(mapStateToProps)(Table);
 
 export default Table;
+
+let GroupButton = ({ sample, index, name, color, Icon, group, ungroup }) => {
+  const grouped = sample.group === index;
+  const defaultColor = 'var(--light-gray)';
+  return (
+    <Tooltip
+      text={
+        grouped ? 'Ungroup this sample' : 'Put this sample in group ' + name
+      }
+    >
+      <Button
+        icon={<Icon style={{ color: grouped ? color : defaultColor }} />}
+        onClick={() =>
+          (grouped ? ungroup : group)({ index: index, id: sample.id })
+        }
+      />
+    </Tooltip>
+  );
+};
+
+const mapDispatchToProps = (dispatch) => ({
+  group: (...args) => dispatch(groupSample(...args)),
+  ungroup: (...args) => dispatch(ungroupSample(...args))
+});
+
+GroupButton = connect(null, mapDispatchToProps)(GroupButton);

--- a/src/pages/genes/network/filters/index.css
+++ b/src/pages/genes/network/filters/index.css
@@ -1,7 +1,10 @@
 .gene_network_info {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
   margin-top: 20px;
   margin-bottom: 10px;
-  text-align: center;
 }
 .gene_network_info > span {
   display: inline-flex;

--- a/src/pages/genes/network/graph/tooltip.js
+++ b/src/pages/genes/network/graph/tooltip.js
@@ -68,7 +68,7 @@ export const openTooltip = (...args) => {
 // when tooltip closes
 export const closeTooltip = () => {
   window.clearTimeout(timer);
-  tooltip.hide();
+  tooltip.destroy();
 };
 
 const mapGeneTooltip = (gene) => ({

--- a/src/reducers/samples.js
+++ b/src/reducers/samples.js
@@ -1,12 +1,16 @@
 import produce from 'immer';
 
 import { isString } from '../util/types';
+import { isArray } from '../util/types';
 import { isObject } from '../util/types';
 
 // type check for key variables, run before and after reducer
 const typeCheck = (draft) => {
   if (!isString(draft.details) && !isObject(draft.details))
     draft.details = {};
+
+  if (!isArray(draft.groups))
+    draft.groups = [];
 };
 
 // defines how state (redux store) changes in response to dispatched actions
@@ -18,6 +22,21 @@ const reducer = produce((draft, type, payload, meta) => {
       draft.details = payload;
       break;
 
+    case 'UNGROUP_SAMPLE':
+      draft.groups = filterGrouped(draft.groups, payload.id);
+      break;
+
+    case 'GROUP_SAMPLE':
+      draft.groups = filterGrouped(draft.groups, payload.id);
+      if (!isArray(draft.groups[payload.index]))
+        draft.groups[payload.index] = [];
+      draft.groups[payload.index].push(payload.id);
+      break;
+
+    case 'UNGROUP_ALL_SAMPLES':
+      draft.groups = [];
+      break;
+
     default:
       break;
   }
@@ -26,3 +45,17 @@ const reducer = produce((draft, type, payload, meta) => {
 }, {});
 
 export default reducer;
+
+export const isGrouped = (groups, id) => {
+  for (const [index, group] of Object.entries(groups)) {
+    if (group.includes(id))
+      return Number(index);
+  }
+
+  return -1;
+};
+
+export const filterGrouped = (groups, id) =>
+  groups.map((group) =>
+    isArray(group) ? group.filter((sample) => sample !== id) : []
+  );

--- a/src/reducers/samples.js
+++ b/src/reducers/samples.js
@@ -8,7 +8,6 @@ import { isObject } from '../util/types';
 const typeCheck = (draft) => {
   if (!isString(draft.details) && !isObject(draft.details))
     draft.details = {};
-
   if (!isArray(draft.groups))
     draft.groups = [];
 };


### PR DESCRIPTION
- add sample group actions and reducers
- add group buttons to sample table
- add sample count info over table
- fix d3-tooltip bug where tooltip wasn't being removed from dom when hidden

![image](https://user-images.githubusercontent.com/8326331/74046975-8fd4c300-499d-11ea-8b52-5611ae298fc8.png)

