### PR TITLE
refactor normalize, simplify selectors, add sample list, more

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adage-frontend",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "dependencies": {
     "color": "^3.1.2",
     "d3": "^5.15.0",

--- a/src/actions/fetch.js
+++ b/src/actions/fetch.js
@@ -3,6 +3,9 @@ import sizeof from 'object-sizeof';
 
 // import { sleep } from '../util/debug';
 import { isEmpty } from '../util/types';
+import { isObject } from '../util/types';
+import { isArray } from '../util/types';
+import { normalize } from '../util/object';
 
 // replacement for redux-thunk-actions
 // provide the "cancelType" prop to any action made by this creator
@@ -108,7 +111,13 @@ const fetchJson = async (url) => {
   const json = await fetchResponse.json();
 
   // get results key within json, if it exists
-  const results = json?.results || json;
+  let results = json?.results || json;
+
+  // normalize results
+  if (isObject(results))
+    results = normalize(results);
+  else if (isArray(results))
+    results = results.map(normalize);
 
   // add response to cache, if not over size limit
   const size = sizeof(results);

--- a/src/actions/genes.js
+++ b/src/actions/genes.js
@@ -4,7 +4,7 @@ import { createFetchAction } from './fetch';
 import { urlGeneDetails } from '../backend/genes';
 import { urlGeneList } from '../backend/genes';
 import { urlGeneSearch } from '../backend/genes';
-import { urlGeneEnrichedSignatures } from '../backend/genes';
+import { urlEnrichedSignatures } from '../backend/genes';
 import { urlGeneEdges } from '../backend/genes';
 
 // actions related to "gene" sub-object of state
@@ -46,9 +46,9 @@ export const deselectFirstGenes = createAction('DESELECT_FIRST_GENES');
 export const getGeneSelectedDetails = createAction('GET_GENE_SELECTED_DETAILS');
 
 // get gene participations and calculate enriched signatures
-export const getGeneEnrichedSignatures = createFetchAction(
-  'GET_GENE_ENRICHED_SIGNATURES',
-  urlGeneEnrichedSignatures
+export const getEnrichedSignatures = createFetchAction(
+  'GET_ENRICHED_SIGNATURES',
+  urlEnrichedSignatures
 );
 
 // get edges to create network

--- a/src/actions/samples.js
+++ b/src/actions/samples.js
@@ -2,6 +2,7 @@ import { createAction } from 'redux-actions';
 import { createFetchAction } from './fetch';
 
 import { urlSampleDetails } from '../backend/samples';
+import { urlSampleList } from '../backend/samples';
 
 // actions related to the "sample" sub-object of the state
 
@@ -9,6 +10,12 @@ import { urlSampleDetails } from '../backend/samples';
 export const getSampleDetails = createFetchAction(
   'GET_SAMPLE_DETAILS',
   urlSampleDetails
+);
+
+// get full list of all samples
+export const getSampleList = createFetchAction(
+  'GET_SAMPLE_LIST',
+  urlSampleList
 );
 
 // place sample (id) in specified group (index)

--- a/src/actions/samples.js
+++ b/src/actions/samples.js
@@ -26,3 +26,11 @@ export const ungroupSample = createAction('UNGROUP_SAMPLE');
 
 // remove all samples from groups
 export const ungroupAllSamples = createAction('UNGROUP_ALL_SAMPLES');
+
+// select samples based on experiment id
+export const selectSamples = createAction('SELECT_SAMPLES');
+
+// fill in remaining details of selected samples
+export const getSampleSelectedDetails = createAction(
+  'GET_SAMPLE_SELECTED_DETAILS'
+);

--- a/src/backend/genes.js
+++ b/src/backend/genes.js
@@ -32,7 +32,7 @@ export const urlGeneSearch = ({ query, limit = defaultLimit }) => {
   return url;
 };
 
-export const urlGeneEnrichedSignatures = ({ ids, limit = defaultLimit }) => {
+export const urlEnrichedSignatures = ({ ids, limit = defaultLimit }) => {
   const params = new URLSearchParams();
   params.set('limit', limit);
   if (ids)

--- a/src/backend/samples.js
+++ b/src/backend/samples.js
@@ -1,4 +1,5 @@
 import { server } from '.';
+import { defaultLimit } from '.';
 
 // functions to generate urls to fetch sample-related data from
 
@@ -6,5 +7,13 @@ const prefix = 'sample/';
 
 export const urlSampleDetails = ({ id }) => {
   const url = server + prefix + id;
+  return url;
+};
+
+export const urlSampleList = ({ limit = defaultLimit }) => {
+  const params = new URLSearchParams();
+  params.set('limit', limit);
+
+  const url = server + prefix + '?' + params.toString();
   return url;
 };

--- a/src/components/table/index.js
+++ b/src/components/table/index.js
@@ -66,7 +66,7 @@ const Table = ({
   useEffect(() => {
     const element = document.querySelector('*[data-shade="true"]');
     if (element)
-      element.scrollIntoView({ block: 'nearest' });
+      element.scrollIntoView({ block: 'center' });
   });
 
   return (

--- a/src/controller.js
+++ b/src/controller.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { getModelList } from './actions/models';
 import { getGeneList } from './actions/genes';
 import { getExperimentList } from './actions/experiments';
+import { getSampleList } from './actions/samples';
 import { getSignatureList } from './actions/signatures';
 import { getGeneSelectedDetails } from './actions/genes';
 import { getExperimentSelectedDetails } from './actions/experiments';
@@ -30,6 +31,7 @@ let Controller = ({
   getModelList,
   getGeneList,
   getExperimentList,
+  getSampleList,
   getSignatureList,
   getGeneSelectedDetails,
   getExperimentSelectedDetails,
@@ -42,6 +44,18 @@ let Controller = ({
     getModelList();
   }, [getModelList]);
 
+  // on first render
+  // get full experiment list
+  useEffect(() => {
+    getExperimentList({ limit: MAX_INT });
+  }, [getExperimentList]);
+
+  // on first render
+  // get full sample list
+  useEffect(() => {
+    getSampleList({ limit: MAX_INT });
+  }, [getSampleList]);
+
   // when selected model (and thus selected organism) changes
   // get full gene list
   useEffect(() => {
@@ -52,12 +66,6 @@ let Controller = ({
       });
     }
   }, [selectedOrganism, getGeneList]);
-
-  // on first render
-  // get full experiment list
-  useEffect(() => {
-    getExperimentList({ limit: MAX_INT });
-  }, [getExperimentList]);
 
   // when selected model changes
   // get full signature list
@@ -149,7 +157,7 @@ const mapStateToProps = (state) => ({
     ).organism || null :
     null,
   selectedGenesLoaded: state.gene.selected.every(
-    (selected) => selected.standard_name
+    (selected) => selected.name
   ),
   selectedGenes: state.gene.selected,
   selectedExperimentAccession: state.experiment.selected.accession
@@ -163,6 +171,7 @@ const mapDispatchToProps = (dispatch) => {
     getModelList: () => delayedDispatch(getModelList()),
     getGeneList: (...args) => delayedDispatch(getGeneList(...args)),
     getExperimentList: (...args) => delayedDispatch(getExperimentList(...args)),
+    getSampleList: (...args) => delayedDispatch(getSampleList(...args)),
     getSignatureList: (...args) => delayedDispatch(getSignatureList(...args)),
     getGeneSelectedDetails: () => delayedDispatch(getGeneSelectedDetails()),
     getExperimentSelectedDetails: () =>

--- a/src/controller.js
+++ b/src/controller.js
@@ -9,25 +9,29 @@ import { getSampleList } from './actions/samples';
 import { getSignatureList } from './actions/signatures';
 import { getGeneSelectedDetails } from './actions/genes';
 import { getExperimentSelectedDetails } from './actions/experiments';
-import { selectModel } from './actions/models';
-import { getGeneEnrichedSignatures } from './actions/genes';
+import { getSampleSelectedDetails } from './actions/samples';
+import { getEnrichedSignatures } from './actions/genes';
 import { getGeneEdges } from './actions/genes';
+import { selectModel } from './actions/models';
+import { selectSamples } from './actions/samples';
 import { isArray } from './util/types';
 
 const MAX_INT = 9999999;
 
 // dispatch new actions in response to redux state changes
 let Controller = ({
-  models,
-  genes,
-  experiments,
-  signatures,
-  selectModel,
+  modelList,
+  geneList,
+  experimentList,
+  sampleList,
+  signatureList,
   selectedOrganism,
   selectedModel,
-  selectedGenesLoaded,
   selectedGenes,
-  selectedExperimentAccession,
+  selectedExperiment,
+  selectedGenesLoaded,
+  selectedExperimentLoaded,
+  selectedSamplesLoaded,
   getModelList,
   getGeneList,
   getExperimentList,
@@ -35,8 +39,11 @@ let Controller = ({
   getSignatureList,
   getGeneSelectedDetails,
   getExperimentSelectedDetails,
+  getSampleSelectedDetails,
   getEnrichedSignatures,
-  getGeneEdges
+  getGeneEdges,
+  selectModel,
+  selectSamples
 }) => {
   // on first render
   // get full model list
@@ -45,17 +52,6 @@ let Controller = ({
   }, [getModelList]);
 
   // on first render
-  // get full experiment list
-  useEffect(() => {
-    getExperimentList({ limit: MAX_INT });
-  }, [getExperimentList]);
-
-  // on first render
-  // get full sample list
-  useEffect(() => {
-    getSampleList({ limit: MAX_INT });
-  }, [getSampleList]);
-
   // when selected model (and thus selected organism) changes
   // get full gene list
   useEffect(() => {
@@ -66,6 +62,17 @@ let Controller = ({
       });
     }
   }, [selectedOrganism, getGeneList]);
+
+  // get full experiment list
+  useEffect(() => {
+    getExperimentList({ limit: MAX_INT });
+  }, [getExperimentList]);
+
+  // on first render
+  // get full sample list
+  useEffect(() => {
+    getSampleList({ limit: MAX_INT });
+  }, [getSampleList]);
 
   // when selected model changes
   // get full signature list
@@ -82,39 +89,58 @@ let Controller = ({
   // select model (first in list if not specified)
   useEffect(() => {
     selectModel();
-  }, [models, selectModel]);
+  }, [modelList, selectModel]);
 
-  // when full gene list or selected genes change
+  // when selected experiment changes
+  // select samples
+  useEffect(() => {
+    if (selectedExperiment.samples) {
+      selectSamples({
+        ids: selectedExperiment.samples.map((sample) => sample.id)
+      });
+    }
+  }, [selectedExperiment, selectSamples]);
+
+  // when full list loads or when new gene selected
   // fill in full details of selected genes
   useEffect(() => {
-    getGeneSelectedDetails();
-  }, [genes.length, selectedGenes.length, getGeneSelectedDetails]);
+    if (!selectedGenesLoaded)
+      getGeneSelectedDetails();
+  }, [geneList.length, selectedGenesLoaded, getGeneSelectedDetails]);
 
-  // when full experiment list or selected experiments change
+  // when full list loads or when new experiment selected
   // fill in full details of selected experiments
   useEffect(() => {
-    getExperimentSelectedDetails();
+    if (!selectedExperimentLoaded)
+      getExperimentSelectedDetails();
   }, [
-    experiments.length,
-    selectedExperimentAccession,
+    experimentList.length,
+    selectedExperimentLoaded,
     getExperimentSelectedDetails
   ]);
+
+  // when full list loads or when new sample selected
+  // fill in full details of selected samples
+  useEffect(() => {
+    if (!selectedSamplesLoaded)
+      getSampleSelectedDetails();
+  }, [sampleList.length, selectedSamplesLoaded, getSampleSelectedDetails]);
 
   // when full gene list, selected genes, or full signature list change
   // recompute enriched signatures
   useEffect(() => {
     if (
-      isArray(genes) &&
-      genes.length &&
-      isArray(signatures) &&
-      signatures.length &&
+      isArray(geneList) &&
+      geneList.length &&
+      isArray(signatureList) &&
+      signatureList.length &&
       selectedGenesLoaded
     ) {
       getEnrichedSignatures({
-        cancelType: 'GET_GENE_ENRICHED_SIGNATURES',
+        cancelType: 'GET_ENRICHED_SIGNATURES',
         ids: selectedGenes.map((gene) => gene.id),
-        genes: genes,
-        signatures: signatures,
+        geneList: geneList,
+        signatureList: signatureList,
         selectedGenes: selectedGenes,
         limit: selectedGenes.length ? MAX_INT : 1
       });
@@ -122,8 +148,8 @@ let Controller = ({
   }, [
     selectedGenesLoaded,
     selectedGenes,
-    genes,
-    signatures,
+    geneList,
+    signatureList,
     getEnrichedSignatures
   ]);
 
@@ -145,10 +171,11 @@ let Controller = ({
 };
 
 const mapStateToProps = (state) => ({
-  models: state.model.list,
-  genes: state.gene.list,
-  experiments: state.experiment.list,
-  signatures: state.signature.list,
+  modelList: state.model.list,
+  geneList: state.gene.list,
+  experimentList: state.experiment.list,
+  sampleList: state.sample.list,
+  signatureList: state.signature.list,
   selectedModel: state.model.selected,
   selectedOrganism: isArray(state.model.list) ?
     (
@@ -156,31 +183,36 @@ const mapStateToProps = (state) => ({
         {}
     ).organism || null :
     null,
-  selectedGenesLoaded: state.gene.selected.every(
-    (selected) => selected.name
-  ),
   selectedGenes: state.gene.selected,
-  selectedExperimentAccession: state.experiment.selected.accession
+  selectedExperiment: state.experiment.selected,
+  selectedGenesLoaded: state.gene.selected.every((selected) => selected.name),
+  selectedExperimentLoaded: state.experiment.selected.name ? true : false,
+  selectedSamplesLoaded: state.sample.selected.every(
+    (selected) => selected.name
+  )
 });
 
 const mapDispatchToProps = (dispatch) => {
-  const delayedDispatch = (...args) =>
-    window.setTimeout(() => dispatch(...args), 100);
-
-  return {
-    getModelList: () => delayedDispatch(getModelList()),
-    getGeneList: (...args) => delayedDispatch(getGeneList(...args)),
-    getExperimentList: (...args) => delayedDispatch(getExperimentList(...args)),
-    getSampleList: (...args) => delayedDispatch(getSampleList(...args)),
-    getSignatureList: (...args) => delayedDispatch(getSignatureList(...args)),
-    getGeneSelectedDetails: () => delayedDispatch(getGeneSelectedDetails()),
-    getExperimentSelectedDetails: () =>
-      delayedDispatch(getExperimentSelectedDetails()),
-    selectModel: () => delayedDispatch(selectModel()),
-    getEnrichedSignatures: (...args) =>
-      delayedDispatch(getGeneEnrichedSignatures(...args)),
-    getGeneEdges: (...args) => delayedDispatch(getGeneEdges(...args))
+  const actions = {
+    getModelList: getModelList,
+    getGeneList: getGeneList,
+    getExperimentList: getExperimentList,
+    getSampleList: getSampleList,
+    getSignatureList: getSignatureList,
+    getGeneSelectedDetails: getGeneSelectedDetails,
+    getExperimentSelectedDetails: getExperimentSelectedDetails,
+    getSampleSelectedDetails: getSampleSelectedDetails,
+    getEnrichedSignatures: getEnrichedSignatures,
+    getGeneEdges: getGeneEdges,
+    selectModel: selectModel,
+    selectSamples: selectSamples
   };
+  for (const [funcName, func] of Object.entries(actions)) {
+    actions[funcName] = (...args) =>
+      window.setTimeout(() => dispatch(func(...args)), 100);
+  }
+
+  return actions;
 };
 
 Controller = connect(mapStateToProps, mapDispatchToProps)(Controller);

--- a/src/pages/experiment/index.js
+++ b/src/pages/experiment/index.js
@@ -14,7 +14,8 @@ import FetchAlert from '../../components/fetch-alert';
 import { getExperimentDetails } from '../../actions/experiments';
 import { isObject } from '../../util/types';
 import { isString } from '../../util/types';
-import { normalize } from '../../util/object';
+import { filterKeys } from '../../util/object';
+import { humanizeKeys } from '../../util/object';
 
 import { ReactComponent as ExperimentIcon } from '../../images/experiment.svg';
 
@@ -56,11 +57,11 @@ const mapStateToProps = (state) => {
   let details = state.experiment.details;
 
   if (isObject(details)) {
-    details = normalize(details, true, null, ['Max Similarity Field']);
-    if (details.Samples) {
-      details.Samples = (
+    details = filterKeys(details, ['maxSimilarityField']);
+    if (details.samples) {
+      details.samples = (
         <>
-          {details.Samples.map((sample, index) => (
+          {details.samples.map((sample, index) => (
             <Fragment key={index}>
               <SampleLink sample={sample} />
               <br />
@@ -69,6 +70,7 @@ const mapStateToProps = (state) => {
         </>
       );
     }
+    details = humanizeKeys(details);
   }
 
   return { details };

--- a/src/pages/experiments/index.js
+++ b/src/pages/experiments/index.js
@@ -6,7 +6,6 @@ import Footer from '../footer';
 import Section from '../../components/section';
 import Search from './search';
 import Selected from './selected';
-import { normalize } from '../../util/object';
 
 import './index.css';
 
@@ -28,7 +27,3 @@ const Experiments = () => (
 );
 
 export default Experiments;
-
-export const mapExperiment = (experiment) => normalize(experiment);
-
-export const mapExperimentDownload = (experiment) => normalize(experiment, true);

--- a/src/pages/experiments/search/index.js
+++ b/src/pages/experiments/search/index.js
@@ -5,7 +5,6 @@ import SearchComponent from '../../../components/search';
 import Single from './single';
 import { getExperimentSearch } from '../../../actions/experiments';
 import { selectExperiment } from '../../../actions/experiments';
-import { isObject } from '../../../util/types';
 import { isArray } from '../../../util/types';
 import { isSelected } from '../../../reducers/experiments';
 import { toCamelCase } from '../../../util/string';
@@ -34,12 +33,7 @@ let Search = ({ results, select, search }) => (
 );
 
 const mapStateToProps = (state) => ({
-  results:
-    state.experiment.searches.length === 1 &&
-    isArray(state.experiment.searches[0].results) &&
-    state.experiment.searches[0].results.length ?
-      mapExperimentSearchPayload(state.experiment.searches[0], state) :
-      []
+  results: mapExperimentSearch(state.experiment.searches[0] || {}, state)
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -50,15 +44,6 @@ const mapDispatchToProps = (dispatch) => ({
 Search = connect(mapStateToProps, mapDispatchToProps)(Search);
 
 export default Search;
-
-export const mapExperimentSearchPayload = (payload, state) => {
-  if (isObject(payload))
-    return mapExperimentSearch(payload, state);
-  else if (isArray(payload))
-    return payload.map((search) => mapExperimentSearch(search, state));
-  else
-    return payload;
-};
 
 export const mapExperimentSearch = (search, state) => ({
   query: search.query,

--- a/src/pages/experiments/selected/controls/index.js
+++ b/src/pages/experiments/selected/controls/index.js
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 
 import Button from '../../../../components/button';
 import { downloadTsv } from '../../../../util/download';
-import { normalize } from '../../../../util/object';
 import { ungroupAllSamples } from '../../../../actions/samples';
 
 import { ReactComponent as CrossIcon } from '../../../../images/cross.svg';
@@ -31,9 +30,7 @@ let Controls = ({ samples, ungroupAll }) => (
 );
 
 const mapStateToProps = (state) => ({
-  samples: (state.experiment.selected.samples || []).map((sample) =>
-    normalize(sample, true)
-  )
+  samples: state.experiment.selected.samples
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/pages/experiments/selected/details/index.js
+++ b/src/pages/experiments/selected/details/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import ExperimentLink from '../../../experiment/link';
-import { mapExperiment } from '../../';
+import { mapExperimentResult } from '../../search';
 
 import './index.css';
 
@@ -41,7 +41,7 @@ let Details = ({ experiment }) => (
 );
 
 const mapStateToProps = (state) => ({
-  experiment: mapExperiment(state.experiment.selected)
+  experiment: mapExperimentResult(state.experiment.selected, state)
 });
 
 Details = connect(mapStateToProps)(Details);

--- a/src/pages/experiments/selected/table/index.js
+++ b/src/pages/experiments/selected/table/index.js
@@ -70,11 +70,10 @@ let Table = ({ samples }) => (
 );
 
 const mapStateToProps = (state) => ({
-  samples: (state.experiment.selected.samples || [])
-    .map((sample) => ({
-      ...sample,
-      group: isGrouped(state.sample.groups, sample.id)
-    }))
+  samples: state.sample.selected.map((sample) => ({
+    ...sample,
+    group: isGrouped(state.sample.groups, sample.id)
+  }))
 });
 
 Table = connect(mapStateToProps)(Table);

--- a/src/pages/experiments/selected/table/index.js
+++ b/src/pages/experiments/selected/table/index.js
@@ -6,7 +6,6 @@ import SampleLink from '../../../sample/link';
 import TableComponent from '../../../../components/table';
 import { groupSample } from '../../../../actions/samples';
 import { ungroupSample } from '../../../../actions/samples';
-import { normalize } from '../../../../util/object';
 import { isGrouped } from '../../../../reducers/samples';
 
 import { ReactComponent as DiamondIcon } from '../../../../images/diamond.svg';
@@ -72,7 +71,6 @@ let Table = ({ samples }) => (
 
 const mapStateToProps = (state) => ({
   samples: (state.experiment.selected.samples || [])
-    .map((sample) => normalize(sample, false, 1))
     .map((sample) => ({
       ...sample,
       group: isGrouped(state.sample.groups, sample.id)

--- a/src/pages/genes/enriched/table/index.js
+++ b/src/pages/genes/enriched/table/index.js
@@ -3,9 +3,8 @@ import { Fragment } from 'react';
 import { connect } from 'react-redux';
 
 import TableComponent from '../../../../components/table';
-import Link from '../../../../components/link';
+import SignatureLink from '../../../signature/link';
 import GeneLink from '../../../gene/link';
-import { mapGene } from '../../';
 
 import './index.css';
 
@@ -19,15 +18,7 @@ let Table = ({ enrichedSignatures }) => (
         name: 'Name',
         value: 'name',
         width: '25%',
-        render: (cell) => (
-          <Link
-            to={'/signature/' + cell.id}
-            newTab
-            button={false}
-            text={cell.name}
-            aria-label={'Open details page for signature ' + cell.name}
-          />
-        )
+        render: (cell) => <SignatureLink signature={cell} />
       },
       {
         name: 'Overlapping Genes',
@@ -57,7 +48,7 @@ const mapStateToProps = (state) => ({
   enrichedSignatures: state.gene.enrichedSignatures.map((signature) => ({
     id: signature.id,
     name: signature.name,
-    genes: signature.matchedGenes.map(mapGene),
+    genes: signature.matchedGenes,
     pValue: signature.pValue
   }))
 });

--- a/src/pages/genes/index.js
+++ b/src/pages/genes/index.js
@@ -9,8 +9,6 @@ import Selected from './selected';
 import Enriched from './enriched';
 import Network from './network';
 
-import { normalize } from '../../util/object';
-
 import './index.css';
 
 // genes page
@@ -37,11 +35,3 @@ const Genes = () => (
 );
 
 export default Genes;
-
-export const mapGene = (gene) => ({
-  ...normalize(gene),
-  name: gene.standard_name || gene.systematic_name || gene.entrezid || '-',
-  entrezId: gene.entrezid
-});
-
-export const mapGeneDownload = (gene) => normalize(gene, true);

--- a/src/pages/genes/network/graph/link-highlights.js
+++ b/src/pages/genes/network/graph/link-highlights.js
@@ -3,7 +3,7 @@ import * as d3 from 'd3';
 import { openTooltip } from './tooltip';
 import { closeTooltip } from './tooltip';
 
-import { linkData } from './';
+import { linkData } from '.';
 
 import { strokeWidth } from './constants';
 

--- a/src/pages/genes/network/graph/link-lines.js
+++ b/src/pages/genes/network/graph/link-lines.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 
-import { linkData } from './';
+import { linkData } from '.';
 
 import { strokeWidth, fillA } from './constants';
 

--- a/src/pages/genes/network/graph/node-circles.js
+++ b/src/pages/genes/network/graph/node-circles.js
@@ -1,6 +1,6 @@
 import * as d3 from 'd3';
 
-import { nodeData } from './';
+import { nodeData } from '.';
 
 import { nodeRadius, fillA, fillB, stroke, strokeWidth } from './constants';
 

--- a/src/pages/genes/network/graph/node-highlights.js
+++ b/src/pages/genes/network/graph/node-highlights.js
@@ -4,7 +4,7 @@ import { dragHandler } from './drag';
 import { openTooltip } from './tooltip';
 import { closeTooltip } from './tooltip';
 
-import { nodeData } from './';
+import { nodeData } from '.';
 
 import { nodeRadius, strokeWidth } from './constants';
 

--- a/src/pages/genes/network/graph/node-labels.js
+++ b/src/pages/genes/network/graph/node-labels.js
@@ -3,7 +3,7 @@ import * as color from 'color';
 
 import { tooltip } from './tooltip';
 
-import { nodeData } from './';
+import { nodeData } from '.';
 
 import { fillA, fillB, fontSize } from './constants';
 

--- a/src/pages/genes/network/graph/simulation.js
+++ b/src/pages/genes/network/graph/simulation.js
@@ -9,8 +9,8 @@ import { autoFit } from './view';
 import { setAutoFit } from './view';
 import { fitView } from './view';
 
-import { nodeData } from './';
-import { linkData } from './';
+import { nodeData } from '.';
+import { linkData } from '.';
 
 import {
   nodeRadius,

--- a/src/pages/genes/network/graph/tooltip.js
+++ b/src/pages/genes/network/graph/tooltip.js
@@ -3,7 +3,9 @@ import { renderToString } from 'react-dom/server';
 import * as d3 from 'd3';
 import tip from 'd3-tip';
 
-import { svg } from './';
+import { svg } from '.';
+import { humanizeKeys } from '../../../../util/object';
+import { filterKeys } from '../../../../util/object';
 
 const delay = 100;
 
@@ -35,11 +37,13 @@ export const initTooltip = () => {
 // tooltip component to render as string
 
 const Tooltip = (d) => {
-  let fields = {};
-  if (d.node)
-    fields = { ...fields, ...mapGeneTooltip(d) };
-  if (d.link)
-    fields = { ...fields, ...mapEdgeTooltip(d) };
+  const fields = humanizeKeys(
+    filterKeys(
+      d,
+      ['standardName', 'systematicName', 'entrezId', 'description', 'weight'],
+      true
+    )
+  );
 
   if (!Object.keys(fields).length)
     return <></>;
@@ -70,16 +74,3 @@ export const closeTooltip = () => {
   window.clearTimeout(timer);
   tooltip.destroy();
 };
-
-const mapGeneTooltip = (gene) => ({
-  'Standard Name': gene.standardName,
-  'Systematic Name': gene.systematicName,
-  'Entrez Id': gene.entrezId,
-  'Description': gene.description,
-  'Aliases': gene.aliases,
-  'Organism': gene.organism
-});
-
-const mapEdgeTooltip = (link) => ({
-  Weight: link.weight.toFixed(4) || '-'
-});

--- a/src/pages/genes/network/graph/view.js
+++ b/src/pages/genes/network/graph/view.js
@@ -1,8 +1,8 @@
 import * as d3 from 'd3';
 
 import { fitPadding, minZoom, maxZoom } from './constants';
-import { svg } from './';
-import { view } from './';
+import { svg } from '.';
+import { view } from '.';
 
 export let viewHandler = () => null;
 

--- a/src/pages/genes/network/index.js
+++ b/src/pages/genes/network/index.js
@@ -4,11 +4,9 @@ import { useMemo } from 'react';
 import { connect } from 'react-redux';
 
 import FetchAlert from '../../../components/fetch-alert';
-import { mapGene } from '../';
 import { isArray } from '../../../util/types';
 import { isString } from '../../../util/types';
 import { xor } from '../../../util/math';
-import { normalize } from '../../../util/object';
 import Filters from './filters';
 import Graph from './graph';
 import Controls from './controls';
@@ -65,12 +63,19 @@ const constructGraph = ({ list, selected, edges }) => {
   // if we dont have all we need, exit
   if (
     !isArray(list) ||
+    !list.length ||
     !isArray(edges) ||
     !edges.length ||
     !isArray(selected) ||
     !selected.length
   )
     return;
+
+  // copy objects to make them extensible
+  // (objects coming from immer state are frozen by default)
+  list = list.map((gene) => ({ ...gene }));
+  selected = selected.map((gene) => ({ ...gene }));
+  edges = edges.map((edge) => ({ ...edge }));
 
   // init nodes and links
   let nodes = new Set();
@@ -174,15 +179,9 @@ const filterGraph = ({ fullGraph, edgeWeightCutoff, nodeCutoff }) => {
 };
 
 const mapStateToProps = (state) => ({
-  list: isArray(state.gene.list) ?
-    state.gene.list.map(mapGene).map((gene) => normalize(gene)) :
-    state.gene.list,
-  selected: isArray(state.gene.selected) ?
-    state.gene.selected.map(mapGene).map((selected) => normalize(selected)) :
-    state.gene.selected,
-  edges: isArray(state.gene.edges) ?
-    state.gene.edges.map((edge) => normalize(edge)) :
-    state.gene.edges
+  list: state.gene.list,
+  selected: state.gene.selected,
+  edges: state.gene.edges
 });
 
 Network = connect(mapStateToProps)(Network);

--- a/src/pages/genes/search/index.js
+++ b/src/pages/genes/search/index.js
@@ -10,7 +10,6 @@ import { cancelAction } from '../../../actions/fetch';
 import { selectGene } from '../../../actions/genes';
 import { deselectGene } from '../../../actions/genes';
 import { isArray } from '../../../util/types';
-import { isObject } from '../../../util/types';
 import { toCamelCase } from '../../../util/string';
 import { isSelected } from '../../../reducers/genes';
 
@@ -20,7 +19,7 @@ import './index.css';
 
 let Search = ({ results, select, deselect, dispatch }) => (
   <SearchComponent
-    length={results.length}
+    length={results?.length || 0}
     multi
     placeholder='search for a gene'
     multiPlaceholder='search for a list of genes'
@@ -55,12 +54,7 @@ let Search = ({ results, select, deselect, dispatch }) => (
 );
 
 const mapStateToProps = (state) => ({
-  results:
-    state.gene.searches.length === 1 &&
-    isArray(state.gene.searches[0].results) &&
-    state.gene.searches[0].results.length ?
-      mapGeneSearchPayload(state.gene.searches[0], state) :
-      []
+  results: mapGeneSearch(state.gene.searches[0] || {}, state)?.results
 });
 
 const mapDispatchToProps = (dispatch) => ({
@@ -72,15 +66,6 @@ const mapDispatchToProps = (dispatch) => ({
 Search = connect(mapStateToProps, mapDispatchToProps)(Search);
 
 export default Search;
-
-export const mapGeneSearchPayload = (payload, state) => {
-  if (isObject(payload))
-    return mapGeneSearch(payload, state);
-  else if (isArray(payload))
-    return payload.map((search) => mapGeneSearch(search, state));
-  else
-    return payload;
-};
 
 export const mapGeneSearch = (search, state) => ({
   query: search.query,

--- a/src/pages/genes/search/multi/index.js
+++ b/src/pages/genes/search/multi/index.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import HorizontalLine from '../../../../components/horizontal-line';
 import MultiRow from '../multi-row';
 import MultiControls from '../multi-controls';
-import { mapGeneSearchPayload } from '../';
+import { mapGeneSearch } from '../';
 
 import './index.css';
 
@@ -24,7 +24,7 @@ let Multi = ({ searches }) => (
 );
 
 const mapStateToProps = (state) => ({
-  searches: mapGeneSearchPayload(state.gene.searches, state)
+  searches: state.gene.searches.map((search) => mapGeneSearch(search, state))
 });
 
 Multi = connect(mapStateToProps)(Multi);

--- a/src/pages/genes/search/multi/index.js
+++ b/src/pages/genes/search/multi/index.js
@@ -5,8 +5,7 @@ import { connect } from 'react-redux';
 import HorizontalLine from '../../../../components/horizontal-line';
 import MultiRow from '../multi-row';
 import MultiControls from '../multi-controls';
-import { isArray } from '../../../../util/types';
-import { mapGeneResult } from '../';
+import { mapGeneSearchPayload } from '../';
 
 import './index.css';
 
@@ -25,12 +24,7 @@ let Multi = ({ searches }) => (
 );
 
 const mapStateToProps = (state) => ({
-  searches: state.gene.searches.map((search) => ({
-    query: search.query,
-    results: isArray(search.results) ?
-      search.results.map((result) => mapGeneResult(result, state)) :
-      search.results
-  }))
+  searches: mapGeneSearchPayload(state.gene.searches, state)
 });
 
 Multi = connect(mapStateToProps)(Multi);

--- a/src/pages/genes/search/single/index.js
+++ b/src/pages/genes/search/single/index.js
@@ -5,7 +5,7 @@ import SingleTable from '../single-table';
 import FetchAlert from '../../../../components/fetch-alert';
 import { isArray } from '../../../../util/types';
 import { isString } from '../../../../util/types';
-import { mapGeneSearchPayload } from '../';
+import { mapGeneSearch } from '../';
 
 import './index.css';
 
@@ -27,7 +27,7 @@ let Single = ({ results, highlightedIndex }) => (
 );
 
 const mapStateToProps = (state) => ({
-  results: mapGeneSearchPayload(state.gene.searches[0], state)?.results
+  results: mapGeneSearch(state.gene.searches[0] || {}, state)?.results
 });
 
 Single = connect(mapStateToProps)(Single);

--- a/src/pages/genes/search/single/index.js
+++ b/src/pages/genes/search/single/index.js
@@ -5,7 +5,7 @@ import SingleTable from '../single-table';
 import FetchAlert from '../../../../components/fetch-alert';
 import { isArray } from '../../../../util/types';
 import { isString } from '../../../../util/types';
-import { mapGeneResult } from '../';
+import { mapGeneSearchPayload } from '../';
 
 import './index.css';
 
@@ -27,13 +27,7 @@ let Single = ({ results, highlightedIndex }) => (
 );
 
 const mapStateToProps = (state) => ({
-  results: state.gene.searches[0] ?
-    isArray(state.gene.searches[0].results) ?
-      state.gene.searches[0].results.map((result) =>
-        mapGeneResult(result, state)
-      ) :
-      state.gene.searches[0].results :
-    ''
+  results: mapGeneSearchPayload(state.gene.searches[0], state)?.results
 });
 
 Single = connect(mapStateToProps)(Single);

--- a/src/pages/genes/selected/controls/index.js
+++ b/src/pages/genes/selected/controls/index.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { deselectAllGenes } from '../../../../actions/genes';
 import Button from '../../../../components/button';
 import { downloadTsv } from '../../../../util/download';
-import { mapGeneDownload } from '../../';
+import { humanizeKeys } from '../../../../util/object';
 
 import { ReactComponent as CrossIcon } from '../../../../images/cross.svg';
 import { ReactComponent as DownloadIcon } from '../../../../images/download.svg';
@@ -31,7 +31,7 @@ let Controls = ({ selected, deselectAll }) => (
 );
 
 const mapStateToProps = (state) => ({
-  selected: state.gene.selected.map(mapGeneDownload)
+  selected: state.gene.selected.map(humanizeKeys)
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/pages/genes/selected/table/index.js
+++ b/src/pages/genes/selected/table/index.js
@@ -5,7 +5,6 @@ import GeneLink from '../../../gene/link';
 import Button from '../../../../components/button';
 import TableComponent from '../../../../components/table';
 import { deselectGene } from '../../../../actions/genes';
-import { mapGene } from '../../';
 
 import { ReactComponent as CrossIcon } from '../../../../images/cross.svg';
 
@@ -56,7 +55,7 @@ let Table = ({ selected, deselect }) => (
 );
 
 const mapStateToProps = (state) => ({
-  selected: state.gene.selected.map((selected) => mapGene(selected))
+  selected: state.gene.selected
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/pages/header/model-select/item/index.css
+++ b/src/pages/header/model-select/item/index.css
@@ -6,7 +6,7 @@
   height: 40px;
 }
 .model_button {
-  display: inline-flex;
+  display: inline-flex !important;
   justify-content: flex-start;
   align-items: stretch;
   width: calc(100% - 30px);

--- a/src/pages/model/index.js
+++ b/src/pages/model/index.js
@@ -12,7 +12,8 @@ import FetchAlert from '../../components/fetch-alert';
 import { getModelDetails } from '../../actions/models';
 import { isObject } from '../../util/types';
 import { isString } from '../../util/types';
-import { normalize } from '../../util/object';
+import { filterKeys } from '../../util/object';
+import { humanizeKeys } from '../../util/object';
 
 import { ReactComponent as ModelIcon } from '../../images/model.svg';
 
@@ -54,12 +55,13 @@ const mapStateToProps = (state) => {
   let details = state.model.details;
 
   if (isObject(details)) {
-    details = normalize(details, true, null, [
-      'Id',
-      'Directed G2g Edge',
-      'G2g Edge Cutoff',
-      'Organism'
+    details = filterKeys(details, [
+      'id',
+      'directedG2gEdge',
+      'g2gEdgeCutoff',
+      'organism'
     ]);
+    details = humanizeKeys(details);
   }
 
   return { details };

--- a/src/pages/sample/index.js
+++ b/src/pages/sample/index.js
@@ -14,7 +14,8 @@ import FetchAlert from '../../components/fetch-alert';
 import { getSampleDetails } from '../../actions/samples';
 import { isObject } from '../../util/types';
 import { isString } from '../../util/types';
-import { normalize } from '../../util/object';
+import { filterKeys, flatten } from '../../util/object';
+import { humanizeKeys } from '../../util/object';
 
 import { ReactComponent as SampleIcon } from '../../images/sample.svg';
 
@@ -56,11 +57,12 @@ const mapStateToProps = (state) => {
   let details = state.sample.details;
 
   if (isObject(details)) {
-    details = normalize(details, true, 1, ['Id']);
-    if (details.Experiments) {
-      details.Experiments = (
+    details = flatten(details, 1);
+    details = filterKeys(details, ['id']);
+    if (details.experiments) {
+      details.experiments = (
         <>
-          {details.Experiments.map((experiment, index) => (
+          {details.experiments.map((experiment, index) => (
             <Fragment key={index}>
               {console.log(experiment)}
               <ExperimentLink experiment={experiment} />
@@ -70,6 +72,7 @@ const mapStateToProps = (state) => {
         </>
       );
     }
+    details = humanizeKeys(details);
   }
 
   return { details };

--- a/src/pages/sample/index.js
+++ b/src/pages/sample/index.js
@@ -15,7 +15,6 @@ import { getSampleDetails } from '../../actions/samples';
 import { isObject } from '../../util/types';
 import { isString } from '../../util/types';
 import { filterKeys } from '../../util/object';
-import { flatten } from '../../util/object';
 import { humanizeKeys } from '../../util/object';
 
 import { ReactComponent as SampleIcon } from '../../images/sample.svg';
@@ -58,7 +57,6 @@ const mapStateToProps = (state) => {
   let details = state.sample.details;
 
   if (isObject(details)) {
-    details = flatten(details, 1);
     details = filterKeys(details, ['id']);
     if (details.experiments) {
       details.experiments = (

--- a/src/pages/sample/index.js
+++ b/src/pages/sample/index.js
@@ -14,7 +14,8 @@ import FetchAlert from '../../components/fetch-alert';
 import { getSampleDetails } from '../../actions/samples';
 import { isObject } from '../../util/types';
 import { isString } from '../../util/types';
-import { filterKeys, flatten } from '../../util/object';
+import { filterKeys } from '../../util/object';
+import { flatten } from '../../util/object';
 import { humanizeKeys } from '../../util/object';
 
 import { ReactComponent as SampleIcon } from '../../images/sample.svg';

--- a/src/pages/signature/link.js
+++ b/src/pages/signature/link.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import Link from '../../components/link';
+
+// link to signature details page
+
+const SignatureLink = ({ signature = {} }) => (
+  <Link
+    to={'/signature/' + signature.id}
+    newTab
+    button={false}
+    text={signature.name}
+    aria-label={'Open details page for signature ' + signature.name}
+  />
+);
+
+export default SignatureLink;

--- a/src/reducers/experiments.js
+++ b/src/reducers/experiments.js
@@ -3,8 +3,6 @@ import produce from 'immer';
 import { isString } from '../util/types';
 import { isArray } from '../util/types';
 import { isObject } from '../util/types';
-import { normalize } from '../util/object';
-import { mapFetchPayload } from '.';
 
 // type check for key variables, run before and after reducer
 const typeCheck = (draft) => {
@@ -24,18 +22,18 @@ const reducer = produce((draft, type, payload, meta) => {
 
   switch (type) {
     case 'GET_EXPERIMENT_DETAILS':
-      draft.details = mapFetchPayload(payload, normalize);
+      draft.details = payload;
       break;
 
     case 'GET_EXPERIMENT_LIST':
-      draft.list = mapFetchPayload(payload, normalize);
+      draft.list = payload;
       break;
 
     case 'GET_EXPERIMENT_SEARCH':
       if (!isObject(draft.searches[meta.index]))
         draft.searches[meta.index] = {};
       draft.searches[meta.index].query = meta.query;
-      draft.searches[meta.index].results = mapFetchPayload(payload, normalize);
+      draft.searches[meta.index].results = payload;
       break;
 
     case 'SELECT_EXPERIMENT':

--- a/src/reducers/experiments.js
+++ b/src/reducers/experiments.js
@@ -3,6 +3,8 @@ import produce from 'immer';
 import { isString } from '../util/types';
 import { isArray } from '../util/types';
 import { isObject } from '../util/types';
+import { normalize } from '../util/object';
+import { mapFetchPayload } from '.';
 
 // type check for key variables, run before and after reducer
 const typeCheck = (draft) => {
@@ -22,18 +24,18 @@ const reducer = produce((draft, type, payload, meta) => {
 
   switch (type) {
     case 'GET_EXPERIMENT_DETAILS':
-      draft.details = payload;
+      draft.details = mapFetchPayload(payload, normalize);
       break;
 
     case 'GET_EXPERIMENT_LIST':
-      draft.list = payload;
+      draft.list = mapFetchPayload(payload, normalize);
       break;
 
     case 'GET_EXPERIMENT_SEARCH':
       if (!isObject(draft.searches[meta.index]))
         draft.searches[meta.index] = {};
       draft.searches[meta.index].query = meta.query;
-      draft.searches[meta.index].results = payload;
+      draft.searches[meta.index].results = mapFetchPayload(payload, normalize);
       break;
 
     case 'SELECT_EXPERIMENT':
@@ -50,9 +52,10 @@ const reducer = produce((draft, type, payload, meta) => {
     case 'GET_EXPERIMENT_SELECTED_DETAILS':
       if (!isArray(draft.list) || !draft.list.length)
         break;
-      draft.selected = draft.list.find(
-        (experiment) => experiment.accession === draft.selected.accession
-      ) || {};
+      draft.selected =
+        draft.list.find(
+          (experiment) => experiment.accession === draft.selected.accession
+        ) || {};
       break;
 
     default:
@@ -64,7 +67,5 @@ const reducer = produce((draft, type, payload, meta) => {
 
 export default reducer;
 
-export const isSelected = (result, state) =>
-  result?.accession &&
-  state?.experiment?.selected?.accession &&
-  result.accession === state.experiment.selected.accession;
+export const isSelected = (selected, accession) =>
+  selected.accession === accession;

--- a/src/reducers/genes.js
+++ b/src/reducers/genes.js
@@ -6,6 +6,8 @@ import { isEmpty } from '../util/types';
 import { isString } from '../util/types';
 import { isArray } from '../util/types';
 import { isObject } from '../util/types';
+import { normalize } from '../util/object';
+import { mapFetchPayload } from '.';
 
 // type check for key variables, run before and after reducer
 const typeCheck = (draft) => {
@@ -29,18 +31,18 @@ const reducer = produce((draft, type, payload, meta) => {
 
   switch (type) {
     case 'GET_GENE_DETAILS':
-      draft.details = payload;
+      draft.details = mapFetchPayload(payload, mapGene);
       break;
 
     case 'GET_GENE_LIST':
-      draft.list = payload;
+      draft.list = mapFetchPayload(payload, mapGene);
       break;
 
     case 'GET_GENE_SEARCH':
       if (!isObject(draft.searches[meta.index]))
         draft.searches[meta.index] = {};
       draft.searches[meta.index].query = meta.query;
-      draft.searches[meta.index].results = payload;
+      draft.searches[meta.index].results = mapFetchPayload(payload, mapGene);
       break;
 
     case 'CLEAR_GENE_SEARCH':
@@ -69,9 +71,9 @@ const reducer = produce((draft, type, payload, meta) => {
             search.results[0] :
             null;
         if (!firstResult)
-          break;
+          continue;
         if (isSelected(draft.selected, firstResult.id))
-          break;
+          continue;
         draft.selected.push({ id: firstResult.id });
       }
       break;
@@ -83,8 +85,7 @@ const reducer = produce((draft, type, payload, meta) => {
             search.results[0] :
             null;
         if (!firstResult)
-          break;
-
+          continue;
         draft.selected = filterSelected(draft.selected, firstResult.id);
       }
       break;
@@ -144,3 +145,9 @@ export const isSelected = (selected, id) =>
 
 export const filterSelected = (selected, id) =>
   selected.filter((selected) => !(selected.id === id));
+
+export const mapGene = (gene) => ({
+  ...normalize(gene),
+  name: gene.standard_name || gene.systematic_name || gene.entrezid || '-',
+  entrezId: gene.entrezid
+});

--- a/src/reducers/genes.js
+++ b/src/reducers/genes.js
@@ -106,12 +106,12 @@ const reducer = produce((draft, type, payload, meta) => {
     case 'GET_ENRICHED_SIGNATURES':
       const participations = payload;
       if (isArray(participations)) {
-        const { selectedGenes, genes, signatures } = meta;
+        const { selectedGenes, geneList, signatureList } = meta;
         const result = calculateEnrichedSignatures({
           selectedGenes,
           participations,
-          genes,
-          signatures
+          geneList,
+          signatureList
         });
         if (isEmpty(result))
           draft.enrichedSignatures = actionStatuses.EMPTY;

--- a/src/reducers/genes.js
+++ b/src/reducers/genes.js
@@ -103,7 +103,7 @@ const reducer = produce((draft, type, payload, meta) => {
       );
       break;
 
-    case 'GET_GENE_ENRICHED_SIGNATURES':
+    case 'GET_ENRICHED_SIGNATURES':
       const participations = payload;
       if (isArray(participations)) {
         const { selectedGenes, genes, signatures } = meta;

--- a/src/reducers/genes.js
+++ b/src/reducers/genes.js
@@ -6,8 +6,6 @@ import { isEmpty } from '../util/types';
 import { isString } from '../util/types';
 import { isArray } from '../util/types';
 import { isObject } from '../util/types';
-import { normalize } from '../util/object';
-import { mapFetchPayload } from '.';
 
 // type check for key variables, run before and after reducer
 const typeCheck = (draft) => {
@@ -31,18 +29,18 @@ const reducer = produce((draft, type, payload, meta) => {
 
   switch (type) {
     case 'GET_GENE_DETAILS':
-      draft.details = mapFetchPayload(payload, mapGene);
+      draft.details = mapGene(payload);
       break;
 
     case 'GET_GENE_LIST':
-      draft.list = mapFetchPayload(payload, mapGene);
+      draft.list = mapGene(payload);
       break;
 
     case 'GET_GENE_SEARCH':
       if (!isObject(draft.searches[meta.index]))
         draft.searches[meta.index] = {};
       draft.searches[meta.index].query = meta.query;
-      draft.searches[meta.index].results = mapFetchPayload(payload, mapGene);
+      draft.searches[meta.index].results = mapGene(payload);
       break;
 
     case 'CLEAR_GENE_SEARCH':
@@ -146,8 +144,12 @@ export const isSelected = (selected, id) =>
 export const filterSelected = (selected, id) =>
   selected.filter((selected) => !(selected.id === id));
 
-export const mapGene = (gene) => ({
-  ...normalize(gene),
-  name: gene.standard_name || gene.systematic_name || gene.entrezid || '-',
-  entrezId: gene.entrezid
-});
+export const mapGene = (gene) =>
+  isArray(gene) ?
+    gene.map((gene) => ({
+      ...gene,
+      name:
+          gene.standard_name || gene.systematic_name || gene.entrezid || '-',
+      entrezId: gene.entrezid
+    })) :
+    gene;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -3,6 +3,8 @@ import genes from './genes';
 import experiments from './experiments';
 import samples from './samples';
 import signatures from './signatures';
+import { isArray } from '../util/types';
+import { isObject } from '../util/types';
 
 // master reducer
 // split into sub-reducers that handle one specific slice of state each
@@ -19,3 +21,12 @@ const reducer = (state = {}, action = {}) => {
 };
 
 export default reducer;
+
+export const mapFetchPayload = (payload, func) => {
+  if (isObject(payload))
+    return func(payload);
+  else if (isArray(payload))
+    return payload.map(func);
+  else
+    return payload;
+};

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -3,8 +3,6 @@ import genes from './genes';
 import experiments from './experiments';
 import samples from './samples';
 import signatures from './signatures';
-import { isArray } from '../util/types';
-import { isObject } from '../util/types';
 
 // master reducer
 // split into sub-reducers that handle one specific slice of state each
@@ -21,12 +19,3 @@ const reducer = (state = {}, action = {}) => {
 };
 
 export default reducer;
-
-export const mapFetchPayload = (payload, func) => {
-  if (isObject(payload))
-    return func(payload);
-  else if (isArray(payload))
-    return payload.map(func);
-  else
-    return payload;
-};

--- a/src/reducers/models.js
+++ b/src/reducers/models.js
@@ -3,8 +3,6 @@ import produce from 'immer';
 import { isString } from '../util/types';
 import { isArray } from '../util/types';
 import { isObject } from '../util/types';
-import { normalize } from '../util/object';
-import { mapFetchPayload } from '.';
 
 // type check for key variables, run before and after reducer
 const typeCheck = (draft) => {
@@ -20,11 +18,11 @@ const reducer = produce((draft, type, payload, meta) => {
 
   switch (type) {
     case 'GET_MODEL_DETAILS':
-      draft.details = mapFetchPayload(payload, normalize);
+      draft.details = payload;
       break;
 
     case 'GET_MODEL_LIST':
-      draft.list = mapFetchPayload(payload, normalize);
+      draft.list = payload;
       break;
 
     case 'SELECT_MODEL':

--- a/src/reducers/models.js
+++ b/src/reducers/models.js
@@ -3,6 +3,8 @@ import produce from 'immer';
 import { isString } from '../util/types';
 import { isArray } from '../util/types';
 import { isObject } from '../util/types';
+import { normalize } from '../util/object';
+import { mapFetchPayload } from '.';
 
 // type check for key variables, run before and after reducer
 const typeCheck = (draft) => {
@@ -18,11 +20,11 @@ const reducer = produce((draft, type, payload, meta) => {
 
   switch (type) {
     case 'GET_MODEL_DETAILS':
-      draft.details = payload;
+      draft.details = mapFetchPayload(payload, normalize);
       break;
 
     case 'GET_MODEL_LIST':
-      draft.list = payload;
+      draft.list = mapFetchPayload(payload, normalize);
       break;
 
     case 'SELECT_MODEL':

--- a/src/reducers/samples.js
+++ b/src/reducers/samples.js
@@ -3,11 +3,15 @@ import produce from 'immer';
 import { isString } from '../util/types';
 import { isArray } from '../util/types';
 import { isObject } from '../util/types';
+import { normalize } from '../util/object';
+import { mapFetchPayload } from '.';
 
 // type check for key variables, run before and after reducer
 const typeCheck = (draft) => {
   if (!isString(draft.details) && !isObject(draft.details))
     draft.details = {};
+  if (!isString(draft.list) && !isArray(draft.list))
+    draft.list = [];
   if (!isArray(draft.groups))
     draft.groups = [];
 };
@@ -18,7 +22,11 @@ const reducer = produce((draft, type, payload, meta) => {
 
   switch (type) {
     case 'GET_SAMPLE_DETAILS':
-      draft.details = payload;
+      draft.details = mapFetchPayload(payload, normalize);
+      break;
+
+    case 'GET_SAMPLE_LIST':
+      draft.list = mapFetchPayload(payload, normalize);
       break;
 
     case 'UNGROUP_SAMPLE':

--- a/src/reducers/samples.js
+++ b/src/reducers/samples.js
@@ -10,6 +10,8 @@ const typeCheck = (draft) => {
     draft.details = {};
   if (!isString(draft.list) && !isArray(draft.list))
     draft.list = [];
+  if (!isArray(draft.selected))
+    draft.selected = [];
   if (!isArray(draft.groups))
     draft.groups = [];
 };
@@ -25,6 +27,18 @@ const reducer = produce((draft, type, payload, meta) => {
 
     case 'GET_SAMPLE_LIST':
       draft.list = payload;
+      break;
+
+    case 'SELECT_SAMPLES':
+      draft.selected = payload.ids.map((id) => ({ id }));
+      break;
+
+    case 'GET_SAMPLE_SELECTED_DETAILS':
+      if (!isArray(draft.list) || !draft.list.length)
+        break;
+      draft.selected = draft.selected.map((selected) =>
+        draft.list.find((sample) => sample.id === selected.id)
+      );
       break;
 
     case 'UNGROUP_SAMPLE':

--- a/src/reducers/samples.js
+++ b/src/reducers/samples.js
@@ -3,8 +3,6 @@ import produce from 'immer';
 import { isString } from '../util/types';
 import { isArray } from '../util/types';
 import { isObject } from '../util/types';
-import { normalize } from '../util/object';
-import { mapFetchPayload } from '.';
 
 // type check for key variables, run before and after reducer
 const typeCheck = (draft) => {
@@ -22,11 +20,11 @@ const reducer = produce((draft, type, payload, meta) => {
 
   switch (type) {
     case 'GET_SAMPLE_DETAILS':
-      draft.details = mapFetchPayload(payload, normalize);
+      draft.details = payload;
       break;
 
     case 'GET_SAMPLE_LIST':
-      draft.list = mapFetchPayload(payload, normalize);
+      draft.list = payload;
       break;
 
     case 'UNGROUP_SAMPLE':

--- a/src/reducers/signatures.js
+++ b/src/reducers/signatures.js
@@ -3,8 +3,6 @@ import produce from 'immer';
 import { isString } from '../util/types';
 import { isArray } from '../util/types';
 import { isObject } from '../util/types';
-import { normalize } from '../util/object';
-import { mapFetchPayload } from '.';
 
 // type check for key variables, run before and after reducer
 const typeCheck = (draft) => {
@@ -20,11 +18,11 @@ const reducer = produce((draft, type, payload, meta) => {
 
   switch (type) {
     case 'GET_SIGNATURE_DETAILS':
-      draft.details = mapFetchPayload(payload, normalize);
+      draft.details = payload;
       break;
 
     case 'GET_SIGNATURE_LIST':
-      draft.list = mapFetchPayload(payload, normalize);
+      draft.list = payload;
       break;
 
     default:

--- a/src/reducers/signatures.js
+++ b/src/reducers/signatures.js
@@ -3,6 +3,8 @@ import produce from 'immer';
 import { isString } from '../util/types';
 import { isArray } from '../util/types';
 import { isObject } from '../util/types';
+import { normalize } from '../util/object';
+import { mapFetchPayload } from '.';
 
 // type check for key variables, run before and after reducer
 const typeCheck = (draft) => {
@@ -18,11 +20,11 @@ const reducer = produce((draft, type, payload, meta) => {
 
   switch (type) {
     case 'GET_SIGNATURE_DETAILS':
-      draft.details = payload;
+      draft.details = mapFetchPayload(payload, normalize);
       break;
 
     case 'GET_SIGNATURE_LIST':
-      draft.list = payload;
+      draft.list = mapFetchPayload(payload, normalize);
       break;
 
     default:

--- a/src/util/math.js
+++ b/src/util/math.js
@@ -37,22 +37,22 @@ export const hyperGeometricTest = (k, K, n, N) => {
 export const calculateEnrichedSignatures = ({
   selectedGenes,
   participations,
-  genes,
-  signatures
+  geneList,
+  signatureList
 }) => {
   if (
     !isArray(selectedGenes) ||
     !selectedGenes.length ||
     !isArray(participations) ||
     !participations.length ||
-    !isArray(genes) ||
-    !genes.length ||
-    !isArray(signatures) ||
-    !signatures.length
+    !isArray(geneList) ||
+    !geneList.length ||
+    !isArray(signatureList) ||
+    !signatureList.length
   )
     return [];
 
-  let enrichedSignatures = signatures
+  let enrichedSignatures = signatureList
     // for each signature
     .map((signature) => {
       const participatingGenes = participations
@@ -73,10 +73,10 @@ export const calculateEnrichedSignatures = ({
       return { ...signature, participatingGenes, matchedGenes };
     })
     // remove signatures with no participating genes
-    .filter((signatures) => signatures.participatingGenes.length)
+    .filter((signature) => signature.participatingGenes.length)
     // compute p value of enriched signature
     .map((signature) => {
-      const N = genes.length;
+      const N = geneList.length;
       const K = selectedGenes.length;
       const n = signature.participatingGenes.length;
       const k = signature.matchedGenes.length;

--- a/src/util/object.js
+++ b/src/util/object.js
@@ -9,6 +9,8 @@ import { toCamelCase } from './string';
 // flatten object to a certain depth
 // eg { a: 2, b: { c: 3 } } --> { a: 2, c: 3 }
 export const flatten = (object, depth = 0) => {
+  object = { ...object };
+
   if (depth <= 0 || !isObject(object))
     return object;
 
@@ -54,11 +56,11 @@ export const camelizeKeys = (object) => {
 };
 
 // go through keys of object and delete unwanted
-export const filterKeys = (object, filter = []) => {
+export const filterKeys = (object, filter = [], whiteList = false) => {
   object = { ...object };
 
   for (const key of Object.keys(object)) {
-    if (filter.includes(key))
+    if (filter.includes(key) !== whiteList)
       delete object[key];
   }
 
@@ -91,15 +93,18 @@ export const cleanValues = (object) => {
 };
 
 // flatten, case-ize, filter, and clean object
-export const normalize = (object, human, depth, filter) => {
-  object = flatten(object, depth);
-  if (human)
-    object = humanizeKeys(object);
-  else
-    object = camelizeKeys(object);
-  if (filter)
-    object = filterKeys(object, filter);
+export const normalize = (object) => {
+  object = flatten(object);
+  object = camelizeKeys(object);
   object = cleanValues(object);
+
+  // TEMPORARY
+  if (object.samples) {
+    object.samples = object.samples.map((sample) => ({
+      id: sample.id,
+      name: sample.name
+    }));
+  }
 
   return object;
 };

--- a/src/util/object.js
+++ b/src/util/object.js
@@ -94,7 +94,6 @@ export const cleanValues = (object) => {
 
 // flatten, case-ize, filter, and clean object
 export const normalize = (object) => {
-  object = flatten(object);
   object = camelizeKeys(object);
   object = cleanValues(object);
 

--- a/src/util/object.js
+++ b/src/util/object.js
@@ -94,16 +94,9 @@ export const cleanValues = (object) => {
 
 // flatten, case-ize, filter, and clean object
 export const normalize = (object) => {
+  object = flatten(object, 1);
   object = camelizeKeys(object);
   object = cleanValues(object);
-
-  // TEMPORARY
-  if (object.samples) {
-    object.samples = object.samples.map((sample) => ({
-      id: sample.id,
-      name: sample.name
-    }));
-  }
 
   return object;
 };

--- a/src/util/string.js
+++ b/src/util/string.js
@@ -1,6 +1,6 @@
 // convert underscore_case and dash-case to Human Case
 export const toHumanCase = (string) => {
-  string = string.split(/_|-/);
+  string = string.replace(/([a-z0-9])([A-Z0-9])/g, '$1 $2').split(/_|-|\s+/);
   string = string.map(
     (word) => word.charAt(0).toUpperCase() + word.substring(1)
   );
@@ -10,7 +10,7 @@ export const toHumanCase = (string) => {
 
 // convert underscore_case and dash-case to camelCase
 export const toCamelCase = (string) => {
-  string = string.split(/_|-/);
+  string = string.replace(/([a-z0-9])([A-Z0-9])/g, '$1 $2').split(/_|-|\s+/);
   string = string.map((word, index) =>
     index > 0 ? word.charAt(0).toUpperCase() + word.substring(1) : word
   );


### PR DESCRIPTION
- apply normalization (flattening, camel casing, and cleaning) and mapping (like mapGene) right at the fetch response level or state reducer level, instead of at the selector level, removing the need to re-normalize or re-map on every render (huge performance improvement)
- move sample information from experiment part of state to sample part of state
- simplify selectors for search components
- simplify graph tooltips
- fix bug in "select/deselect first" multi gene search buttons
- extend filterKeys to work either by blacklist or whitelist
- extend toHumanCase to support more cases
- rename some variables for extra clarity
- css tweaks