### PR TITLE
hogan lab feedback 5/1/20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adage-frontend",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "dependencies": {
     "@greenelab/hclust": "^0.0.0",
     "@stdlib/stdlib": "^0.0.91",

--- a/src/backend/experiments.js
+++ b/src/backend/experiments.js
@@ -1,11 +1,12 @@
 import { server } from '.';
 import { defaultLimit } from '.';
+import { maxLimit } from '.';
 
 // functions to generate urls to fetch experiment-related data from
 
 const prefix = 'experiment/';
 
-export const urlExperimentList = ({ limit = defaultLimit }) => {
+export const urlExperimentList = ({ limit = maxLimit }) => {
   const params = new URLSearchParams();
   params.set('limit', limit);
 

--- a/src/backend/genes.js
+++ b/src/backend/genes.js
@@ -1,5 +1,6 @@
 import { server } from '.';
 import { defaultLimit } from '.';
+import { maxLimit } from '.';
 
 // functions to generate urls to fetch gene-related data from
 
@@ -7,7 +8,7 @@ const prefixA = 'gene/';
 const prefixB = 'participation/';
 const prefixC = 'edge/';
 
-export const urlGeneList = ({ organism, limit = defaultLimit }) => {
+export const urlGeneList = ({ organism, limit = maxLimit }) => {
   const params = new URLSearchParams();
   params.set('limit', limit);
   if (organism)
@@ -27,7 +28,7 @@ export const urlGeneSearch = ({ query, limit = defaultLimit }) => {
   return url;
 };
 
-export const urlGeneParticipations = ({ genes, limit = defaultLimit }) => {
+export const urlGeneParticipations = ({ genes, limit = maxLimit }) => {
   const params = new URLSearchParams();
   params.set('limit', limit);
   if (genes)
@@ -37,7 +38,7 @@ export const urlGeneParticipations = ({ genes, limit = defaultLimit }) => {
   return url;
 };
 
-export const urlGeneEdges = ({ model, genes, limit = defaultLimit }) => {
+export const urlGeneEdges = ({ model, genes, limit = maxLimit }) => {
   const params = new URLSearchParams();
   params.set('limit', limit);
   if (model)

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -7,4 +7,7 @@
 export const server = 'https://py3-adage.greenelab.com/api/v1/';
 
 // default result limit
-export const defaultLimit = 25;
+export const defaultLimit = 100;
+
+// max result limit
+export const maxLimit = 999999;

--- a/src/backend/samples.js
+++ b/src/backend/samples.js
@@ -1,12 +1,12 @@
 import { server } from '.';
-import { defaultLimit } from '.';
+import { maxLimit } from '.';
 
 // functions to generate urls to fetch sample-related data from
 
 const prefixA = 'sample/';
 const prefixB = 'activity/';
 
-export const urlSampleList = ({ limit = defaultLimit }) => {
+export const urlSampleList = ({ limit = maxLimit }) => {
   const params = new URLSearchParams();
   params.set('limit', limit);
 
@@ -17,7 +17,7 @@ export const urlSampleList = ({ limit = defaultLimit }) => {
 export const urlSampleActivities = ({
   model,
   samples,
-  limit = defaultLimit
+  limit = maxLimit
 }) => {
   const params = new URLSearchParams();
   params.set('limit', limit);

--- a/src/backend/signatures.js
+++ b/src/backend/signatures.js
@@ -1,5 +1,5 @@
 import { server } from '.';
-import { defaultLimit } from '.';
+import { maxLimit } from '.';
 
 // functions to generate urls to fetch signature-related data from
 
@@ -9,7 +9,7 @@ const prefixC = 'activity/';
 const tribeServer =
   'https://py3-adage.greenelab.com/api/v1/tribe_client/return_unpickled_genesets';
 
-export const urlSignatureList = ({ model, limit = defaultLimit }) => {
+export const urlSignatureList = ({ model, limit = maxLimit }) => {
   const params = new URLSearchParams();
   params.set('limit', limit);
   if (model)
@@ -21,7 +21,7 @@ export const urlSignatureList = ({ model, limit = defaultLimit }) => {
 
 export const urlSignatureParticipations = ({
   signature,
-  limit = defaultLimit
+  limit = maxLimit
 }) => {
   const params = new URLSearchParams();
   params.set('limit', limit);
@@ -35,7 +35,7 @@ export const urlSignatureParticipations = ({
 export const urlSignatureActivities = ({
   model,
   signatures,
-  limit = defaultLimit
+  limit = maxLimit
 }) => {
   const params = new URLSearchParams();
   params.set('limit', limit);

--- a/src/components/fetch-alert/index.js
+++ b/src/components/fetch-alert/index.js
@@ -16,12 +16,14 @@ const FetchAlert = ({
   text = '',
   className = ''
 }) => {
-  if (!text && status === actionStatuses.LOADING)
-    text = 'Loading ' + subject;
-  else if (!text && status === actionStatuses.EMPTY)
-    text = 'No ' + subject + ' found';
-  else if (!text && status === actionStatuses.ERROR)
-    text = 'Error loading ' + subject;
+  if (!text) {
+    if (status === actionStatuses.LOADING)
+      text = 'Loading ' + subject;
+    else if (status === actionStatuses.EMPTY)
+      text = 'No ' + subject + ' found';
+    else if (status === actionStatuses.ERROR)
+      text = 'Error loading ' + subject;
+  }
 
   return (
     <div

--- a/src/components/fetch-alert/index.js
+++ b/src/components/fetch-alert/index.js
@@ -13,18 +13,15 @@ import './index.css';
 const FetchAlert = ({
   status = '',
   subject = '',
-  extra = '',
+  text = '',
   className = ''
 }) => {
-  let text;
-  if (status === actionStatuses.LOADING)
-    text = 'Loading ' + subject + '.';
-  else if (status === actionStatuses.EMPTY)
-    text = 'No ' + subject + ' found.';
-  else if (status === actionStatuses.ERROR)
-    text = 'Error loading ' + subject + '.';
-  if (extra)
-    text += ' ' + extra;
+  if (!text && status === actionStatuses.LOADING)
+    text = 'Loading ' + subject;
+  else if (!text && status === actionStatuses.EMPTY)
+    text = 'No ' + subject + ' found';
+  else if (!text && status === actionStatuses.ERROR)
+    text = 'Error loading ' + subject;
 
   return (
     <div
@@ -41,7 +38,7 @@ const FetchAlert = ({
 FetchAlert.propTypes = {
   status: PropTypes.string.isRequired,
   subject: PropTypes.string.isRequired,
-  extra: PropTypes.string,
+  text: PropTypes.string,
   className: PropTypes.string
 };
 

--- a/src/components/table/index.css
+++ b/src/components/table/index.css
@@ -31,6 +31,9 @@
 .table[data-sortable='true'] .th:hover {
   color: var(--green);
 }
+.th[data-disabled='true'] {
+  cursor: unset;
+}
 .th[data-padded='true'],
 .td[data-padded='true'] {
   padding: 0 5px;

--- a/src/components/table/index.js
+++ b/src/components/table/index.js
@@ -225,8 +225,11 @@ const HeadCell = ({ column }) => {
       }}
       data-padded={padded === false ? false : true}
       title=''
-      onClick={() => changeSort(key)}
-      disabled={!sortable}
+      onClick={() => {
+        if (sortable)
+          changeSort(key);
+      }}
+      data-disabled={!sortable}
       aria-label=''
       data-tooltip-h-align={align === 'center' ? 'center' : undefined}
     >

--- a/src/components/table/index.js
+++ b/src/components/table/index.js
@@ -50,7 +50,8 @@ const Table = ({
   freezeRow = true,
   freezeCol = true,
   highlightedIndex,
-  onSort = () => null
+  onSort = () => null,
+  onFocusOut = () => null
 }) => {
   // internal state
   const [sortKey, setSortKey] = useState(defaultSortKey);
@@ -165,7 +166,11 @@ const Table = ({
       }}
     >
       <div
-        ref={ref}
+        ref={(element) => {
+          if (element)
+            element.addEventListener('focusout', onFocusOut);
+          return element;
+        }}
         className='table'
         data-sortable={sortable}
         data-freeze-row={freezeRow}

--- a/src/controllers/experiments.js
+++ b/src/controllers/experiments.js
@@ -3,14 +3,13 @@ import { useEffect } from 'react';
 import { connect } from 'react-redux';
 
 import { getExperimentList } from '../actions/experiments';
-import { MAX_INT } from './';
 import { makeMapDispatchToProps } from './util';
 
 // dispatch new actions in response to redux state changes
 let ExperimentController = ({ getExperimentList }) => {
   // get full experiment list
   useEffect(() => {
-    getExperimentList({ limit: MAX_INT });
+    getExperimentList();
   }, [getExperimentList]);
 
   return <></>;

--- a/src/controllers/genes.js
+++ b/src/controllers/genes.js
@@ -8,7 +8,6 @@ import { setEnrichedSignatures } from '../actions/genes';
 import { getGeneEdges } from '../actions/genes';
 import { isArray } from '../util/types';
 import { actionStatuses } from '../actions/fetch';
-import { MAX_INT } from './';
 import { makeMapDispatchToProps } from './util';
 
 import worker from 'workerize-loader!../util/math';
@@ -34,8 +33,7 @@ let GeneController = ({
       return;
 
     getGeneList({
-      organism: selectedOrganism.id,
-      limit: MAX_INT
+      organism: selectedOrganism.id
     });
   }, [selectedOrganism.id, getGeneList]);
 
@@ -49,7 +47,7 @@ let GeneController = ({
     getGeneParticipations({
       cancelType: 'GET_GENE_PARTICIPATIONS',
       genes: selectedGenes.map((gene) => gene.id),
-      limit: selectedGenes.length ? MAX_INT : 1
+      limit: !selectedGenes.length ? 1 : undefined
     });
   }, [selectedGenes, selectedGenesLoaded, getGeneParticipations]);
 
@@ -102,7 +100,7 @@ let GeneController = ({
       genes: selectedGenes.map((selected) => selected.id),
       // if no genes selected, still make query but with 1 result
       // to reset state.genes.edges and show "empty" alert in network section
-      limit: selectedGenes.length ? MAX_INT : 1
+      limit: !selectedGenes.length ? 1 : undefined
     });
   }, [selectedModel.id, selectedGenes, selectedGenesLoaded, getGeneEdges]);
 

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -9,8 +9,6 @@ import { SignatureController } from './signatures';
 
 // dispatch new actions in response to redux state changes
 
-export const MAX_INT = 9999999;
-
 const Controllers = () => (
   <>
     <ModelController />

--- a/src/controllers/samples.js
+++ b/src/controllers/samples.js
@@ -8,7 +8,6 @@ import { setVolcano } from '../actions/samples';
 import { selectSamples } from '../actions/samples';
 import { isArray } from '../util/types';
 import { actionStatuses } from '../actions/fetch';
-import { MAX_INT } from './';
 import { makeMapDispatchToProps } from './util';
 
 import worker from 'workerize-loader!../util/math';
@@ -29,7 +28,7 @@ let SampleController = ({
   // on first render
   // get full sample list
   useEffect(() => {
-    getSampleList({ limit: MAX_INT });
+    getSampleList();
   }, [getSampleList]);
 
   // when selected experiment changes
@@ -56,8 +55,7 @@ let SampleController = ({
 
     getSampleActivities({
       model: selectedModel.id,
-      samples: selectedExperiment.samples.map((sample) => sample.id),
-      limit: MAX_INT
+      samples: selectedExperiment.samples.map((sample) => sample.id)
     });
   }, [selectedModel.id, selectedExperiment, getSampleActivities]);
 

--- a/src/controllers/signatures.js
+++ b/src/controllers/signatures.js
@@ -10,7 +10,6 @@ import { setEnrichedGenes } from '../actions/signatures';
 import { isArray } from '../util/types';
 import { isObject } from '../util/types';
 import { actionStatuses } from '../actions/fetch';
-import { MAX_INT } from './';
 import { makeMapDispatchToProps } from './util';
 
 import worker from 'workerize-loader!../util/math';
@@ -36,8 +35,7 @@ let SignatureController = ({
       return;
 
     getSignatureList({
-      model: selectedModel.id,
-      limit: MAX_INT
+      model: selectedModel.id
     });
   }, [selectedModel.id, getSignatureList]);
 
@@ -50,8 +48,7 @@ let SignatureController = ({
 
     getSignatureParticipations({
       cancelType: 'GET_SIGNATURE_PARTICIPATIONS',
-      signature: selectedSignature.id,
-      limit: MAX_INT
+      signature: selectedSignature.id
     });
   }, [selectedSignature.id, getSignatureParticipations]);
 
@@ -64,8 +61,7 @@ let SignatureController = ({
 
     getSignatureActivities({
       model: selectedModel.id,
-      signatures: [selectedSignature.id],
-      limit: MAX_INT
+      signatures: [selectedSignature.id]
     });
   }, [selectedModel.id, selectedSignature.id, getSignatureActivities]);
 

--- a/src/pages/about/app.js
+++ b/src/pages/about/app.js
@@ -149,7 +149,7 @@ const App = () => {
         <a href='https://sites.dartmouth.edu/dartcf/'>
           Dartmouth Cystic Fibrosis Research Center
         </a>{' '}
-        (STANTO19R0).
+        (Cystic Fibrosis Foundation STANTO19R0).
       </p>
       <p className='help_centered'>
         <a className='help_image' href='https://www.moore.org/'>

--- a/src/pages/about/app.js
+++ b/src/pages/about/app.js
@@ -147,7 +147,7 @@ const App = () => {
         </a>{' '}
         (GBMF4552) and the{' '}
         <a href='https://sites.dartmouth.edu/dartcf/'>
-          Dartmouth Cystic Fibrosis Research Center
+          Dartmouth Cystic Fibrosis Research Development Program
         </a>{' '}
         (Cystic Fibrosis Foundation STANTO19R0).
       </p>

--- a/src/pages/experiments/activities/heatmap/index.js
+++ b/src/pages/experiments/activities/heatmap/index.js
@@ -136,7 +136,7 @@ const Heatmap = ({ activities }) => {
         <div>
           {orderedSamples.map((sample, index) => (
             <div key={index}>
-              <SampleLink sample={sample} />
+              <SampleLink sample={sample} extraTooltip={sample.description} />
             </div>
           ))}
         </div>

--- a/src/pages/experiments/search/single/index.js
+++ b/src/pages/experiments/search/single/index.js
@@ -14,7 +14,17 @@ import './index.css';
 let Single = ({ results, highlightedIndex }) => (
   <>
     {isArray(results) && (
-      <SingleTable results={results} highlightedIndex={highlightedIndex} />
+      <>
+        <SingleTable results={results} highlightedIndex={highlightedIndex} />
+        <div className='search_results_note'>
+          <span
+            className='size_small'
+            aria-label='Search to find specific result'
+          >
+            Top {results.length} results
+          </span>
+        </div>
+      </>
     )}
     {isString(results) && (
       <FetchAlert

--- a/src/pages/experiments/volcano/index.js
+++ b/src/pages/experiments/volcano/index.js
@@ -11,13 +11,17 @@ import './index.css';
 
 // volcano plot section
 
-let Volcano = ({ volcano }) => (
+let Volcano = ({ volcano, diamond, spade }) => (
   <>
     {isString(volcano) && (
       <FetchAlert
         status={volcano}
         subject='volcano data'
-        extra='Put at least two samples in each group.'
+        text={
+          diamond.length < 2 || spade.length < 2 ?
+            'Put at least two samples in each group' :
+            ''
+        }
       />
     )}
     {isArray(volcano) && (
@@ -30,7 +34,9 @@ let Volcano = ({ volcano }) => (
 );
 
 const mapStateToProps = (state) => ({
-  volcano: state.samples.volcano
+  volcano: state.samples.volcano,
+  diamond: state.samples.groups.diamond,
+  spade: state.samples.groups.spade
 });
 
 Volcano = connect(mapStateToProps)(Volcano);

--- a/src/pages/genes/search/single/index.css
+++ b/src/pages/genes/search/single/index.css
@@ -1,3 +1,10 @@
 .search_results_single_alert {
   height: calc(2 * 30px);
 }
+.search_results_note {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 10px;
+  color: var(--gray);
+}

--- a/src/pages/genes/search/single/index.js
+++ b/src/pages/genes/search/single/index.js
@@ -14,7 +14,17 @@ import './index.css';
 let Single = ({ results, highlightedIndex }) => (
   <>
     {isArray(results) && (
-      <SingleTable results={results} highlightedIndex={highlightedIndex} />
+      <>
+        <SingleTable results={results} highlightedIndex={highlightedIndex} />
+        <div className='search_results_note'>
+          <span
+            className='size_small'
+            aria-label='Search to find specific result'
+          >
+            Top {results.length} results
+          </span>
+        </div>
+      </>
     )}
     {isString(results) && (
       <FetchAlert

--- a/src/pages/organism/index.js
+++ b/src/pages/organism/index.js
@@ -12,7 +12,6 @@ import { actionStatuses } from '../../actions/fetch';
 import { isArray } from '../../util/types';
 import { isObject } from '../../util/types';
 import { isString } from '../../util/types';
-import { flatten } from '../../util/object';
 import { humanizeKeys } from '../../util/object';
 
 import { ReactComponent as OrganismIcon } from '../../images/organism.svg';
@@ -37,7 +36,6 @@ let Organism = ({ organisms }) => {
       details = actionStatuses.EMPTY;
     else {
       details = { ...found };
-      details = flatten(details, 1);
       details = humanizeKeys(details);
     }
   }

--- a/src/pages/sample/index.js
+++ b/src/pages/sample/index.js
@@ -14,7 +14,6 @@ import { actionStatuses } from '../../actions/fetch';
 import { isArray } from '../../util/types';
 import { isObject } from '../../util/types';
 import { isString } from '../../util/types';
-import { flatten } from '../../util/object';
 import { humanizeKeys } from '../../util/object';
 
 import { ReactComponent as SampleIcon } from '../../images/sample.svg';
@@ -37,7 +36,6 @@ let Sample = ({ samples }) => {
       details = actionStatuses.EMPTY;
     else {
       details = { ...found };
-      details = flatten(details, 1);
       if (details.experiments) {
         details.experiments = (
           <>

--- a/src/pages/sample/link.js
+++ b/src/pages/sample/link.js
@@ -4,7 +4,7 @@ import Clickable from '../../components/clickable';
 
 // link to sample details page
 
-const SampleLink = ({ sample = {} }) => {
+const SampleLink = ({ sample = {}, extraTooltip = '' }) => {
   const { id, name } = sample;
   const label = name || id || '-';
 
@@ -13,7 +13,11 @@ const SampleLink = ({ sample = {} }) => {
       to={'/sample/' + id}
       text={label}
       link
-      aria-label={'Open details page for sample ' + label}
+      aria-label={
+        'Open details page for sample ' +
+        label +
+        (extraTooltip ? ' (' + extraTooltip + ')' : '')
+      }
     />
   );
 };

--- a/src/pages/signatures/activities/index.js
+++ b/src/pages/signatures/activities/index.js
@@ -38,7 +38,9 @@ export const mapActivities = (activities, state) => {
     !isArray(activities) ||
     !activities.length ||
     !isArray(state.experiments.list) ||
-    !state.experiments.list.length
+    !state.experiments.list.length ||
+    !isArray(state.samples.list) ||
+    !state.samples.list.length
   )
     return { bySignature: {}, byExperiment: [] };
 
@@ -48,15 +50,17 @@ export const mapActivities = (activities, state) => {
   const max = Math.max(...values);
   const bySignature = { values, min, max };
 
+  // get sample info out of activities
+  const findSample = (sample) => ({
+    ...sample,
+    value: activities.find((activity) => activity.sample === sample.id)?.value
+  });
+
   // get activities by experiment
   const byExperiment = state.experiments.list
     .map((experiment) => {
       // get experiment samples info
-      const samples = experiment.samples.map((sample) => ({
-        ...sample,
-        value: activities.find((activity) => activity.sample === sample.id)
-          ?.value
-      }));
+      const samples = experiment.samples.map(findSample);
       // get activity value of each sample
       const values = samples
         .map((sample) => sample.value)

--- a/src/pages/signatures/activities/table/barcode.css
+++ b/src/pages/signatures/activities/table/barcode.css
@@ -1,5 +1,15 @@
 .barcode {
+  width: 100%;
+  height: 100%;
+}
+.barcode_button {
   width: 150px;
   height: 30px;
-  cursor: pointer;
+  border: solid 2px transparent;
+  transition: border-color var(--fast);
+}
+.barcode_button:hover,
+.barcode_button:focus {
+  border-color: var(--green);
+  box-shadow: none;
 }

--- a/src/pages/signatures/search/single/index.js
+++ b/src/pages/signatures/search/single/index.js
@@ -14,7 +14,17 @@ import './index.css';
 let Single = ({ results, highlightedIndex }) => (
   <>
     {isArray(results) && (
-      <SingleTable results={results} highlightedIndex={highlightedIndex} />
+      <>
+        <SingleTable results={results} highlightedIndex={highlightedIndex} />
+        <div className='search_results_note'>
+          <span
+            className='size_small'
+            aria-label='Search to find specific result'
+          >
+            Top {results.length} results
+          </span>
+        </div>
+      </>
     )}
     {isString(results) && (
       <FetchAlert

--- a/src/reducers/samples.js
+++ b/src/reducers/samples.js
@@ -39,6 +39,13 @@ const reducer = produce((draft, type, payload, meta) => {
 
     case 'SELECT_SAMPLES': {
       draft.selected = payload.ids.map((id) => ({ id }));
+      // ungroup samples not in selected experiment
+      for (const index of ['diamond', 'spade']) {
+        for (const id of draft.groups[index] || []) {
+          if (!draft.selected.find((sample) => sample.id === id))
+            draft.groups = filterGrouped(draft.groups, id);
+        }
+      }
       break;
     }
 
@@ -57,6 +64,7 @@ const reducer = produce((draft, type, payload, meta) => {
 
     case 'GROUP_SAMPLES_FROM_URL': {
       const { index, ids } = payload;
+      draft.groups = {};
       if (!index)
         break;
       if (!isArray(ids) || !ids.length)

--- a/src/reducers/samples.js
+++ b/src/reducers/samples.js
@@ -64,7 +64,6 @@ const reducer = produce((draft, type, payload, meta) => {
 
     case 'GROUP_SAMPLES_FROM_URL': {
       const { index, ids } = payload;
-      draft.groups = {};
       if (!index)
         break;
       if (!isArray(ids) || !ids.length)

--- a/src/reducers/samples.js
+++ b/src/reducers/samples.js
@@ -32,6 +32,8 @@ const reducer = produce((draft, type, payload, meta) => {
   switch (type) {
     case 'GET_SAMPLE_LIST': {
       draft.list = payload;
+      if (isArray(draft.list))
+        draft.list = draft.list.map((sample) => flatten(sample, 1));
       break;
     }
 
@@ -92,7 +94,7 @@ const reducer = produce((draft, type, payload, meta) => {
     for (const [key, selected] of Object.entries(draft.selected)) {
       const found = draft.list.find((sample) => sample.id === selected.id);
       if (found && !sampleIsLoaded(selected))
-        draft.selected[key] = flatten(found, 1);
+        draft.selected[key] = found;
     }
   }
 

--- a/src/reducers/signatures.js
+++ b/src/reducers/signatures.js
@@ -7,6 +7,7 @@ import { isEmpty } from '../util/types';
 import { split } from '../util/string';
 import { includes } from '../util/object';
 import { actionStatuses } from '../actions/fetch';
+import { defaultLimit } from '../backend';
 
 // type check for key variables, run before and after reducer
 const typeCheck = (draft) => {
@@ -46,7 +47,7 @@ const reducer = produce((draft, type, payload, meta) => {
           results = actionStatuses.EMPTY;
       } else
         results = actionStatuses.LOADING;
-      draft.searches[meta.index].results = results;
+      draft.searches[meta.index].results = results.slice(0, defaultLimit);
       break;
     }
 


### PR DESCRIPTION
- add sample description to "inspect barcode view" table
- fix glitch where grouping some samples, switching to another experiment, and grouping more samples doesn't display volcano data
- add sample description to heatmap tooltip
- ungroup samples when switching experiments
- make more obvious that barcode can be clicked
- show amount of results below each search table to indicate it's not everything available in the database
- add tooltip on disabled col header buttons
- clarify volcano error message
- update dartmouth logo and text
- change MAX_INT to maxLimit, move from controllers to backend functions

closes #172 