### PR TITLE
switch from accession to id for id'ing experiments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adage-frontend",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "dependencies": {
     "@greenelab/hclust": "^0.0.0",
     "@stdlib/stdlib": "^0.0.91",

--- a/src/app.js
+++ b/src/app.js
@@ -70,7 +70,7 @@ const App = () => (
         <Route path='/model/:id' component={Model} />
         <Route path='/organism/:id' component={Organism} />
         <Route path='/gene/:id' component={Gene} />
-        <Route path='/experiment/:accession' component={Experiment} />
+        <Route path='/experiment/:id' component={Experiment} />
         <Route path='/sample/:id' component={Sample} />
         <Route path='/' component={Home} />
       </Switch>

--- a/src/controllers/samples.js
+++ b/src/controllers/samples.js
@@ -38,7 +38,7 @@ let SampleController = ({
       return;
 
     selectSamples({
-      ids: selectedExperiment.samples.map((sample) => sample.id)
+      ids: selectedExperiment.samples
     });
   }, [selectedExperiment, selectSamples]);
 
@@ -55,7 +55,7 @@ let SampleController = ({
 
     getSampleActivities({
       model: selectedModel.id,
-      samples: selectedExperiment.samples.map((sample) => sample.id)
+      samples: selectedExperiment.samples
     });
   }, [selectedModel.id, selectedExperiment, getSampleActivities]);
 

--- a/src/dummy-data/gene-list.json
+++ b/src/dummy-data/gene-list.json
@@ -1,7 +1,6 @@
 [
   {
     "id": 1,
-    "entrezid": 877569,
     "description": "pyocin S5",
     "aliases": "-",
     "obsolete": false,
@@ -14,7 +13,6 @@
   },
   {
     "id": 2,
-    "entrezid": 877570,
     "description": "enoyl-CoA hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -27,7 +25,6 @@
   },
   {
     "id": 3,
-    "entrezid": 877571,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -40,7 +37,6 @@
   },
   {
     "id": 4,
-    "entrezid": 877572,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53,7 +49,6 @@
   },
   {
     "id": 5,
-    "entrezid": 877573,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -66,7 +61,6 @@
   },
   {
     "id": 6,
-    "entrezid": 877574,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -79,7 +73,6 @@
   },
   {
     "id": 7,
-    "entrezid": 877575,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -92,7 +85,6 @@
   },
   {
     "id": 8,
-    "entrezid": 877576,
     "description": "lysophosphatidic acid acyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -105,7 +97,6 @@
   },
   {
     "id": 9,
-    "entrezid": 877577,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -118,7 +109,6 @@
   },
   {
     "id": 10,
-    "entrezid": 877578,
     "description": "C4-dicarboxylate transporter DctA",
     "aliases": "-",
     "obsolete": false,
@@ -131,7 +121,6 @@
   },
   {
     "id": 11,
-    "entrezid": 877579,
     "description": "cold-shock protein",
     "aliases": "-",
     "obsolete": false,
@@ -144,7 +133,6 @@
   },
   {
     "id": 12,
-    "entrezid": 877580,
     "description": "dihydropyrimidine dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -157,7 +145,6 @@
   },
   {
     "id": 13,
-    "entrezid": 877581,
     "description": "cytosine permease",
     "aliases": "-",
     "obsolete": false,
@@ -170,7 +157,6 @@
   },
   {
     "id": 14,
-    "entrezid": 877582,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -183,7 +169,6 @@
   },
   {
     "id": 15,
-    "entrezid": 877583,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -196,7 +181,6 @@
   },
   {
     "id": 16,
-    "entrezid": 877584,
     "description": "heme d1 biosynthesis protein NirH",
     "aliases": "-",
     "obsolete": false,
@@ -209,7 +193,6 @@
   },
   {
     "id": 17,
-    "entrezid": 877585,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -222,7 +205,6 @@
   },
   {
     "id": 18,
-    "entrezid": 877586,
     "description": "cytosine deaminase",
     "aliases": "-",
     "obsolete": false,
@@ -235,7 +217,6 @@
   },
   {
     "id": 19,
-    "entrezid": 877587,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -248,7 +229,6 @@
   },
   {
     "id": 20,
-    "entrezid": 877588,
     "description": "alkyl hydroperoxide reductase",
     "aliases": "-",
     "obsolete": false,
@@ -261,7 +241,6 @@
   },
   {
     "id": 21,
-    "entrezid": 877589,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -274,7 +253,6 @@
   },
   {
     "id": 22,
-    "entrezid": 877590,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -287,7 +265,6 @@
   },
   {
     "id": 23,
-    "entrezid": 877591,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -300,7 +277,6 @@
   },
   {
     "id": 24,
-    "entrezid": 877592,
     "description": "PpiC-type peptidyl-prolyl cis-trans isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -313,7 +289,6 @@
   },
   {
     "id": 25,
-    "entrezid": 877593,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -326,7 +301,6 @@
   },
   {
     "id": 26,
-    "entrezid": 877594,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -339,7 +313,6 @@
   },
   {
     "id": 27,
-    "entrezid": 877595,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -352,7 +325,6 @@
   },
   {
     "id": 28,
-    "entrezid": 877596,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -365,7 +337,6 @@
   },
   {
     "id": 29,
-    "entrezid": 877597,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -378,7 +349,6 @@
   },
   {
     "id": 30,
-    "entrezid": 877598,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -391,7 +361,6 @@
   },
   {
     "id": 31,
-    "entrezid": 877599,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -404,7 +373,6 @@
   },
   {
     "id": 32,
-    "entrezid": 877600,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -417,7 +385,6 @@
   },
   {
     "id": 33,
-    "entrezid": 877601,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -430,7 +397,6 @@
   },
   {
     "id": 34,
-    "entrezid": 877602,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -443,7 +409,6 @@
   },
   {
     "id": 35,
-    "entrezid": 877603,
     "description": "flagellar basal-body rod protein FlgB",
     "aliases": "-",
     "obsolete": false,
@@ -456,7 +421,6 @@
   },
   {
     "id": 36,
-    "entrezid": 877604,
     "description": "low molecular weight phosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -469,7 +433,6 @@
   },
   {
     "id": 37,
-    "entrezid": 877605,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -482,7 +445,6 @@
   },
   {
     "id": 38,
-    "entrezid": 877606,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -495,7 +457,6 @@
   },
   {
     "id": 39,
-    "entrezid": 877607,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -508,7 +469,6 @@
   },
   {
     "id": 40,
-    "entrezid": 877608,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -521,7 +481,6 @@
   },
   {
     "id": 41,
-    "entrezid": 877609,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -534,7 +493,6 @@
   },
   {
     "id": 42,
-    "entrezid": 877610,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -547,7 +505,6 @@
   },
   {
     "id": 43,
-    "entrezid": 877611,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -560,7 +517,6 @@
   },
   {
     "id": 44,
-    "entrezid": 877612,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -573,7 +529,6 @@
   },
   {
     "id": 45,
-    "entrezid": 877613,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -586,7 +541,6 @@
   },
   {
     "id": 46,
-    "entrezid": 877614,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -599,7 +553,6 @@
   },
   {
     "id": 47,
-    "entrezid": 877615,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -612,7 +565,6 @@
   },
   {
     "id": 48,
-    "entrezid": 877616,
     "description": "GTP cyclohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -625,7 +577,6 @@
   },
   {
     "id": 49,
-    "entrezid": 877617,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -638,7 +589,6 @@
   },
   {
     "id": 50,
-    "entrezid": 877618,
     "description": "multifunctional tRNA nucleotidyl transferase/2'3'-cyclic phosphodiesterase/2'nucleotidase/phosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -651,7 +601,6 @@
   },
   {
     "id": 51,
-    "entrezid": 877619,
     "description": "FkbP-type peptidyl-prolyl cis-trans isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -664,7 +613,6 @@
   },
   {
     "id": 52,
-    "entrezid": 877620,
     "description": "lipoprotein signal peptidase",
     "aliases": "-",
     "obsolete": false,
@@ -677,7 +625,6 @@
   },
   {
     "id": 53,
-    "entrezid": 877621,
     "description": "two-component sensor PilS",
     "aliases": "-",
     "obsolete": false,
@@ -690,7 +637,6 @@
   },
   {
     "id": 54,
-    "entrezid": 877622,
     "description": "two-component response regulator PilR",
     "aliases": "-",
     "obsolete": false,
@@ -703,7 +649,6 @@
   },
   {
     "id": 55,
-    "entrezid": 877623,
     "description": "divalent metal cation transporter MntH",
     "aliases": "-",
     "obsolete": false,
@@ -716,7 +661,6 @@
   },
   {
     "id": 56,
-    "entrezid": 877624,
     "description": "5-(carboxyamino)imidazole ribonucleotide mutase",
     "aliases": "-",
     "obsolete": false,
@@ -729,7 +673,6 @@
   },
   {
     "id": 57,
-    "entrezid": 877625,
     "description": "alcohol dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -742,7 +685,6 @@
   },
   {
     "id": 58,
-    "entrezid": 877626,
     "description": "spermidine ABC transporter substrate-binding protein SpuE",
     "aliases": "-",
     "obsolete": false,
@@ -755,7 +697,6 @@
   },
   {
     "id": 59,
-    "entrezid": 877627,
     "description": "methylthioribulose-1-phosphate dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -768,7 +709,6 @@
   },
   {
     "id": 60,
-    "entrezid": 877629,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -781,7 +721,6 @@
   },
   {
     "id": 61,
-    "entrezid": 877630,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -794,7 +733,6 @@
   },
   {
     "id": 62,
-    "entrezid": 877631,
     "description": "peptide chain release factor-like protein",
     "aliases": "-",
     "obsolete": false,
@@ -807,7 +745,6 @@
   },
   {
     "id": 63,
-    "entrezid": 877632,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -820,7 +757,6 @@
   },
   {
     "id": 64,
-    "entrezid": 877633,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -833,7 +769,6 @@
   },
   {
     "id": 65,
-    "entrezid": 877634,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -846,7 +781,6 @@
   },
   {
     "id": 66,
-    "entrezid": 877636,
     "description": "polyamine transporter PotG",
     "aliases": "-",
     "obsolete": false,
@@ -859,7 +793,6 @@
   },
   {
     "id": 67,
-    "entrezid": 877637,
     "description": "trigger factor",
     "aliases": "-",
     "obsolete": false,
@@ -872,7 +805,6 @@
   },
   {
     "id": 68,
-    "entrezid": 877638,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -885,7 +817,6 @@
   },
   {
     "id": 69,
-    "entrezid": 877639,
     "description": "glucose dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -898,7 +829,6 @@
   },
   {
     "id": 70,
-    "entrezid": 877640,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -911,7 +841,6 @@
   },
   {
     "id": 71,
-    "entrezid": 877641,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -924,7 +853,6 @@
   },
   {
     "id": 72,
-    "entrezid": 877642,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -937,7 +865,6 @@
   },
   {
     "id": 73,
-    "entrezid": 877643,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -950,7 +877,6 @@
   },
   {
     "id": 74,
-    "entrezid": 877644,
     "description": "sulfate.thiosulfate ABC transporter ATP-binding protein CysA",
     "aliases": "-",
     "obsolete": false,
@@ -963,7 +889,6 @@
   },
   {
     "id": 75,
-    "entrezid": 877645,
     "description": "pyoverdine biosynthesis protein PvdE",
     "aliases": "-",
     "obsolete": false,
@@ -976,7 +901,6 @@
   },
   {
     "id": 76,
-    "entrezid": 877646,
     "description": "30S ribosomal protein S6",
     "aliases": "-",
     "obsolete": false,
@@ -989,7 +913,6 @@
   },
   {
     "id": 77,
-    "entrezid": 877647,
     "description": "23S rRNA (guanosine(2251)-2'-O)-methyltransferase RlmB",
     "aliases": "-",
     "obsolete": false,
@@ -1002,7 +925,6 @@
   },
   {
     "id": 78,
-    "entrezid": 877648,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1015,7 +937,6 @@
   },
   {
     "id": 79,
-    "entrezid": 877649,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -1028,7 +949,6 @@
   },
   {
     "id": 80,
-    "entrezid": 877650,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1041,7 +961,6 @@
   },
   {
     "id": 81,
-    "entrezid": 877651,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1054,7 +973,6 @@
   },
   {
     "id": 82,
-    "entrezid": 877652,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1067,7 +985,6 @@
   },
   {
     "id": 83,
-    "entrezid": 877653,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -1080,7 +997,6 @@
   },
   {
     "id": 84,
-    "entrezid": 877654,
     "description": "DNA polymerase III subunit epsilon",
     "aliases": "-",
     "obsolete": false,
@@ -1093,7 +1009,6 @@
   },
   {
     "id": 85,
-    "entrezid": 877655,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -1106,7 +1021,6 @@
   },
   {
     "id": 86,
-    "entrezid": 877656,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1119,7 +1033,6 @@
   },
   {
     "id": 87,
-    "entrezid": 877657,
     "description": "adenylosuccinate synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -1132,7 +1045,6 @@
   },
   {
     "id": 88,
-    "entrezid": 877658,
     "description": "ATP phosphoribosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -1145,7 +1057,6 @@
   },
   {
     "id": 89,
-    "entrezid": 877659,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -1158,7 +1069,6 @@
   },
   {
     "id": 90,
-    "entrezid": 877660,
     "description": "beta-glucosidase",
     "aliases": "-",
     "obsolete": false,
@@ -1171,7 +1081,6 @@
   },
   {
     "id": 91,
-    "entrezid": 877661,
     "description": "molybdenum ABC transporter substrate-binding protein ModA",
     "aliases": "-",
     "obsolete": false,
@@ -1184,7 +1093,6 @@
   },
   {
     "id": 92,
-    "entrezid": 877662,
     "description": "5-methyltetrahydropteroyltriglutamate--homocysteine methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -1197,7 +1105,6 @@
   },
   {
     "id": 93,
-    "entrezid": 877663,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1210,7 +1117,6 @@
   },
   {
     "id": 94,
-    "entrezid": 877664,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1223,7 +1129,6 @@
   },
   {
     "id": 95,
-    "entrezid": 877665,
     "description": "rhamnosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -1236,7 +1141,6 @@
   },
   {
     "id": 96,
-    "entrezid": 877666,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -1249,7 +1153,6 @@
   },
   {
     "id": 97,
-    "entrezid": 877667,
     "description": "radical activating enzyme",
     "aliases": "-",
     "obsolete": false,
@@ -1262,7 +1165,6 @@
   },
   {
     "id": 98,
-    "entrezid": 877668,
     "description": "biotin synthase",
     "aliases": "-",
     "obsolete": false,
@@ -1275,7 +1177,6 @@
   },
   {
     "id": 99,
-    "entrezid": 877669,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -1288,7 +1189,6 @@
   },
   {
     "id": 100,
-    "entrezid": 877670,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1301,7 +1201,6 @@
   },
   {
     "id": 101,
-    "entrezid": 877671,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1314,7 +1213,6 @@
   },
   {
     "id": 102,
-    "entrezid": 877672,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1327,7 +1225,6 @@
   },
   {
     "id": 103,
-    "entrezid": 877673,
     "description": "porphobilinogen deaminase",
     "aliases": "-",
     "obsolete": false,
@@ -1340,7 +1237,6 @@
   },
   {
     "id": 104,
-    "entrezid": 877674,
     "description": "alginate biosynthesis regulatory protein AlgR",
     "aliases": "-",
     "obsolete": false,
@@ -1353,7 +1249,6 @@
   },
   {
     "id": 105,
-    "entrezid": 877675,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1366,7 +1261,6 @@
   },
   {
     "id": 106,
-    "entrezid": 877676,
     "description": "tRNA uridine 5-carboxymethylaminomethyl modification protein GidA",
     "aliases": "-",
     "obsolete": false,
@@ -1379,7 +1273,6 @@
   },
   {
     "id": 107,
-    "entrezid": 877677,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1392,7 +1285,6 @@
   },
   {
     "id": 108,
-    "entrezid": 877678,
     "description": "(R)-3-hydroxydecanoyl-ACP:CoA transacylase",
     "aliases": "-",
     "obsolete": false,
@@ -1405,7 +1297,6 @@
   },
   {
     "id": 109,
-    "entrezid": 877679,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -1418,7 +1309,6 @@
   },
   {
     "id": 110,
-    "entrezid": 877680,
     "description": "acetyl-CoA carboxylase carboxyltransferase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -1431,7 +1321,6 @@
   },
   {
     "id": 111,
-    "entrezid": 877681,
     "description": "N-(5'-phosphoribosyl)anthranilate isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -1444,7 +1333,6 @@
   },
   {
     "id": 112,
-    "entrezid": 877682,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1457,7 +1345,6 @@
   },
   {
     "id": 113,
-    "entrezid": 877683,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1470,7 +1357,6 @@
   },
   {
     "id": 114,
-    "entrezid": 877684,
     "description": "glutamate/aspartate:proton symporter",
     "aliases": "-",
     "obsolete": false,
@@ -1483,7 +1369,6 @@
   },
   {
     "id": 115,
-    "entrezid": 877685,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1496,7 +1381,6 @@
   },
   {
     "id": 116,
-    "entrezid": 877686,
     "description": "D-erythro-7,8-dihydroneopterin triphosphate 2'-epimerase",
     "aliases": "-",
     "obsolete": false,
@@ -1509,7 +1393,6 @@
   },
   {
     "id": 117,
-    "entrezid": 877687,
     "description": "thiamine biosynthesis protein ThiI",
     "aliases": "-",
     "obsolete": false,
@@ -1522,7 +1405,6 @@
   },
   {
     "id": 118,
-    "entrezid": 877688,
     "description": "glutamine synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -1535,7 +1417,6 @@
   },
   {
     "id": 119,
-    "entrezid": 877689,
     "description": "permease",
     "aliases": "-",
     "obsolete": false,
@@ -1548,7 +1429,6 @@
   },
   {
     "id": 120,
-    "entrezid": 877690,
     "description": "undecaprenyl-diphosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -1561,7 +1441,6 @@
   },
   {
     "id": 121,
-    "entrezid": 877691,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1574,7 +1453,6 @@
   },
   {
     "id": 122,
-    "entrezid": 877692,
     "description": "ribonucleotide-diphosphate reductase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -1587,7 +1465,6 @@
   },
   {
     "id": 123,
-    "entrezid": 877693,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -1600,7 +1477,6 @@
   },
   {
     "id": 124,
-    "entrezid": 877694,
     "description": "D-alanyl-D-alanine endopeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -1613,7 +1489,6 @@
   },
   {
     "id": 125,
-    "entrezid": 877695,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1626,7 +1501,6 @@
   },
   {
     "id": 126,
-    "entrezid": 877696,
     "description": "two-component response regulator AlgB",
     "aliases": "-",
     "obsolete": false,
@@ -1639,7 +1513,6 @@
   },
   {
     "id": 127,
-    "entrezid": 877697,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1652,7 +1525,6 @@
   },
   {
     "id": 128,
-    "entrezid": 877698,
     "description": "2-hydroxyacid dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -1665,7 +1537,6 @@
   },
   {
     "id": 129,
-    "entrezid": 877699,
     "description": "two-component response regulator NtrC",
     "aliases": "-",
     "obsolete": false,
@@ -1678,7 +1549,6 @@
   },
   {
     "id": 130,
-    "entrezid": 877700,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1691,7 +1561,6 @@
   },
   {
     "id": 131,
-    "entrezid": 877701,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1704,7 +1573,6 @@
   },
   {
     "id": 132,
-    "entrezid": 877702,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -1717,7 +1585,6 @@
   },
   {
     "id": 133,
-    "entrezid": 877703,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1730,7 +1597,6 @@
   },
   {
     "id": 134,
-    "entrezid": 877704,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1743,7 +1609,6 @@
   },
   {
     "id": 135,
-    "entrezid": 877705,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1756,7 +1621,6 @@
   },
   {
     "id": 136,
-    "entrezid": 877706,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1769,7 +1633,6 @@
   },
   {
     "id": 137,
-    "entrezid": 877707,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -1782,7 +1645,6 @@
   },
   {
     "id": 138,
-    "entrezid": 877708,
     "description": "heme d1 biosynthesis protein NirG",
     "aliases": "-",
     "obsolete": false,
@@ -1795,7 +1657,6 @@
   },
   {
     "id": 139,
-    "entrezid": 877709,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1808,7 +1669,6 @@
   },
   {
     "id": 140,
-    "entrezid": 877710,
     "description": "glycolate oxidase iron-sulfur subunit",
     "aliases": "-",
     "obsolete": false,
@@ -1821,7 +1681,6 @@
   },
   {
     "id": 141,
-    "entrezid": 877711,
     "description": "glycolate oxidase FAD binding subunit",
     "aliases": "-",
     "obsolete": false,
@@ -1834,7 +1693,6 @@
   },
   {
     "id": 142,
-    "entrezid": 877712,
     "description": "acetyl-CoA carboxylase biotin carboxylase subunit",
     "aliases": "-",
     "obsolete": false,
@@ -1847,7 +1705,6 @@
   },
   {
     "id": 143,
-    "entrezid": 877713,
     "description": "protein AmpDh3",
     "aliases": "-",
     "obsolete": false,
@@ -1860,7 +1717,6 @@
   },
   {
     "id": 144,
-    "entrezid": 877714,
     "description": "assimilatory nitrite reductase large subunit",
     "aliases": "-",
     "obsolete": false,
@@ -1873,7 +1729,6 @@
   },
   {
     "id": 145,
-    "entrezid": 877715,
     "description": "beta-ketoadipyl CoA thiolase",
     "aliases": "-",
     "obsolete": false,
@@ -1886,7 +1741,6 @@
   },
   {
     "id": 146,
-    "entrezid": 877716,
     "description": "ribonucleotide-diphosphate reductase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -1899,7 +1753,6 @@
   },
   {
     "id": 147,
-    "entrezid": 877717,
     "description": "2-ketogluconate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -1912,7 +1765,6 @@
   },
   {
     "id": 148,
-    "entrezid": 877718,
     "description": "copper resistance protein A",
     "aliases": "-",
     "obsolete": false,
@@ -1925,7 +1777,6 @@
   },
   {
     "id": 149,
-    "entrezid": 877719,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1938,7 +1789,6 @@
   },
   {
     "id": 150,
-    "entrezid": 877720,
     "description": "transcriptional regulator PrtN",
     "aliases": "-",
     "obsolete": false,
@@ -1951,7 +1801,6 @@
   },
   {
     "id": 151,
-    "entrezid": 877721,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -1964,7 +1813,6 @@
   },
   {
     "id": 152,
-    "entrezid": 877722,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1977,7 +1825,6 @@
   },
   {
     "id": 153,
-    "entrezid": 877723,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -1990,7 +1837,6 @@
   },
   {
     "id": 154,
-    "entrezid": 877724,
     "description": "N-acetylmuramoyl-L-alanine amidase",
     "aliases": "-",
     "obsolete": false,
@@ -2003,7 +1849,6 @@
   },
   {
     "id": 155,
-    "entrezid": 877725,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2016,7 +1861,6 @@
   },
   {
     "id": 156,
-    "entrezid": 877726,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2029,7 +1873,6 @@
   },
   {
     "id": 157,
-    "entrezid": 877727,
     "description": "tryptophan permease",
     "aliases": "-",
     "obsolete": false,
@@ -2042,7 +1885,6 @@
   },
   {
     "id": 158,
-    "entrezid": 877728,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2055,7 +1897,6 @@
   },
   {
     "id": 159,
-    "entrezid": 877729,
     "description": "choline transporter",
     "aliases": "-",
     "obsolete": false,
@@ -2068,7 +1909,6 @@
   },
   {
     "id": 160,
-    "entrezid": 877730,
     "description": "phosphorylcholine phosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -2081,7 +1921,6 @@
   },
   {
     "id": 161,
-    "entrezid": 877731,
     "description": "thiol:disulfide interchange protein DsbA",
     "aliases": "-",
     "obsolete": false,
@@ -2094,7 +1933,6 @@
   },
   {
     "id": 162,
-    "entrezid": 877732,
     "description": "cytochrome C4",
     "aliases": "-",
     "obsolete": false,
@@ -2107,7 +1945,6 @@
   },
   {
     "id": 163,
-    "entrezid": 877733,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2120,7 +1957,6 @@
   },
   {
     "id": 164,
-    "entrezid": 877734,
     "description": "sensor/response regulator hybrid protein",
     "aliases": "-",
     "obsolete": false,
@@ -2133,7 +1969,6 @@
   },
   {
     "id": 165,
-    "entrezid": 877735,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2146,7 +1981,6 @@
   },
   {
     "id": 166,
-    "entrezid": 877736,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2159,7 +1993,6 @@
   },
   {
     "id": 167,
-    "entrezid": 877737,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2172,7 +2005,6 @@
   },
   {
     "id": 168,
-    "entrezid": 877738,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2185,7 +2017,6 @@
   },
   {
     "id": 169,
-    "entrezid": 877739,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2198,7 +2029,6 @@
   },
   {
     "id": 170,
-    "entrezid": 877740,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2211,7 +2041,6 @@
   },
   {
     "id": 171,
-    "entrezid": 877741,
     "description": "ferredoxin",
     "aliases": "-",
     "obsolete": false,
@@ -2224,7 +2053,6 @@
   },
   {
     "id": 172,
-    "entrezid": 877742,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2237,7 +2065,6 @@
   },
   {
     "id": 173,
-    "entrezid": 877743,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2250,7 +2077,6 @@
   },
   {
     "id": 174,
-    "entrezid": 877744,
     "description": "adenylate cyclase",
     "aliases": "-",
     "obsolete": false,
@@ -2263,7 +2089,6 @@
   },
   {
     "id": 175,
-    "entrezid": 877745,
     "description": "homogentisate 1,2-dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -2276,7 +2101,6 @@
   },
   {
     "id": 176,
-    "entrezid": 877746,
     "description": "adenosylhomocysteinase",
     "aliases": "-",
     "obsolete": false,
@@ -2289,7 +2113,6 @@
   },
   {
     "id": 177,
-    "entrezid": 877747,
     "description": "enoyl-CoA hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -2302,7 +2125,6 @@
   },
   {
     "id": 178,
-    "entrezid": 877748,
     "description": "nitrate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -2315,7 +2137,6 @@
   },
   {
     "id": 179,
-    "entrezid": 877749,
     "description": "diaminopimelate decarboxylase",
     "aliases": "-",
     "obsolete": false,
@@ -2328,7 +2149,6 @@
   },
   {
     "id": 180,
-    "entrezid": 877750,
     "description": "diaminopimelate epimerase",
     "aliases": "-",
     "obsolete": false,
@@ -2341,7 +2161,6 @@
   },
   {
     "id": 181,
-    "entrezid": 877751,
     "description": "ATP synthase subunit gamma",
     "aliases": "-",
     "obsolete": false,
@@ -2354,7 +2173,6 @@
   },
   {
     "id": 182,
-    "entrezid": 877752,
     "description": "ATP synthase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -2367,7 +2185,6 @@
   },
   {
     "id": 183,
-    "entrezid": 877753,
     "description": "frataxin-like protein",
     "aliases": "-",
     "obsolete": false,
@@ -2380,7 +2197,6 @@
   },
   {
     "id": 184,
-    "entrezid": 877754,
     "description": "lipopeptide LppL",
     "aliases": "-",
     "obsolete": false,
@@ -2393,7 +2209,6 @@
   },
   {
     "id": 185,
-    "entrezid": 877755,
     "description": "protease subunit HflK",
     "aliases": "-",
     "obsolete": false,
@@ -2406,7 +2221,6 @@
   },
   {
     "id": 186,
-    "entrezid": 877756,
     "description": "GTP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -2419,7 +2233,6 @@
   },
   {
     "id": 187,
-    "entrezid": 877757,
     "description": "rRNA methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -2432,7 +2245,6 @@
   },
   {
     "id": 188,
-    "entrezid": 877758,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2445,7 +2257,6 @@
   },
   {
     "id": 189,
-    "entrezid": 877759,
     "description": "copper resistance protein B",
     "aliases": "-",
     "obsolete": false,
@@ -2458,7 +2269,6 @@
   },
   {
     "id": 190,
-    "entrezid": 877760,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2471,7 +2281,6 @@
   },
   {
     "id": 191,
-    "entrezid": 877761,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2484,7 +2293,6 @@
   },
   {
     "id": 192,
-    "entrezid": 877762,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2497,7 +2305,6 @@
   },
   {
     "id": 193,
-    "entrezid": 877763,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2510,7 +2317,6 @@
   },
   {
     "id": 194,
-    "entrezid": 877764,
     "description": "acireductone dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -2523,7 +2329,6 @@
   },
   {
     "id": 195,
-    "entrezid": 877765,
     "description": "5,10-methylenetetrahydrofolate reductase",
     "aliases": "-",
     "obsolete": false,
@@ -2536,7 +2341,6 @@
   },
   {
     "id": 196,
-    "entrezid": 877766,
     "description": "DNA-dependent helicase II",
     "aliases": "-",
     "obsolete": false,
@@ -2549,7 +2353,6 @@
   },
   {
     "id": 197,
-    "entrezid": 877767,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2562,7 +2365,6 @@
   },
   {
     "id": 198,
-    "entrezid": 877768,
     "description": "flagellar hook-associated protein FlgL",
     "aliases": "-",
     "obsolete": false,
@@ -2575,7 +2377,6 @@
   },
   {
     "id": 199,
-    "entrezid": 877769,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -2588,7 +2389,6 @@
   },
   {
     "id": 200,
-    "entrezid": 877770,
     "description": "uroporphyrin-III C-methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -2601,7 +2401,6 @@
   },
   {
     "id": 201,
-    "entrezid": 877771,
     "description": "chitin-binding protein CbpD",
     "aliases": "-",
     "obsolete": false,
@@ -2614,7 +2413,6 @@
   },
   {
     "id": 202,
-    "entrezid": 877772,
     "description": "dicarboxylate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -2627,7 +2425,6 @@
   },
   {
     "id": 203,
-    "entrezid": 877773,
     "description": "C4-dicarboxylate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -2640,7 +2437,6 @@
   },
   {
     "id": 204,
-    "entrezid": 877774,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2653,7 +2449,6 @@
   },
   {
     "id": 205,
-    "entrezid": 877775,
     "description": "selenide, water dikinase",
     "aliases": "-",
     "obsolete": false,
@@ -2666,7 +2461,6 @@
   },
   {
     "id": 206,
-    "entrezid": 877776,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -2679,7 +2473,6 @@
   },
   {
     "id": 207,
-    "entrezid": 877777,
     "description": "chromosome partitioning protein Soj",
     "aliases": "-",
     "obsolete": false,
@@ -2692,7 +2485,6 @@
   },
   {
     "id": 208,
-    "entrezid": 877778,
     "description": "16S rRNA methyltransferase GidB",
     "aliases": "-",
     "obsolete": false,
@@ -2705,7 +2497,6 @@
   },
   {
     "id": 209,
-    "entrezid": 877779,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2718,7 +2509,6 @@
   },
   {
     "id": 210,
-    "entrezid": 877780,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2731,7 +2521,6 @@
   },
   {
     "id": 211,
-    "entrezid": 877781,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2744,7 +2533,6 @@
   },
   {
     "id": 212,
-    "entrezid": 877782,
     "description": "helix destabilizing protein of bacteriophage Pf1",
     "aliases": "-",
     "obsolete": false,
@@ -2757,7 +2545,6 @@
   },
   {
     "id": 213,
-    "entrezid": 877783,
     "description": "succinyl-diaminopimelate desuccinylase",
     "aliases": "-",
     "obsolete": false,
@@ -2770,7 +2557,6 @@
   },
   {
     "id": 214,
-    "entrezid": 877784,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2783,7 +2569,6 @@
   },
   {
     "id": 215,
-    "entrezid": 877785,
     "description": "glutathione transferase FosA",
     "aliases": "-",
     "obsolete": false,
@@ -2796,7 +2581,6 @@
   },
   {
     "id": 216,
-    "entrezid": 877786,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2809,7 +2593,6 @@
   },
   {
     "id": 217,
-    "entrezid": 877787,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2822,7 +2605,6 @@
   },
   {
     "id": 218,
-    "entrezid": 877788,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2835,7 +2617,6 @@
   },
   {
     "id": 219,
-    "entrezid": 877789,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2848,7 +2629,6 @@
   },
   {
     "id": 220,
-    "entrezid": 877790,
     "description": "acetate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -2861,7 +2641,6 @@
   },
   {
     "id": 221,
-    "entrezid": 877791,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2874,7 +2653,6 @@
   },
   {
     "id": 222,
-    "entrezid": 877792,
     "description": "cytochrome",
     "aliases": "-",
     "obsolete": false,
@@ -2887,7 +2665,6 @@
   },
   {
     "id": 223,
-    "entrezid": 877793,
     "description": "ribosome biogenesis GTP-binding protein YsxC",
     "aliases": "-",
     "obsolete": false,
@@ -2900,7 +2677,6 @@
   },
   {
     "id": 224,
-    "entrezid": 877794,
     "description": "DNA polymerase I",
     "aliases": "-",
     "obsolete": false,
@@ -2913,7 +2689,6 @@
   },
   {
     "id": 225,
-    "entrezid": 877795,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2926,7 +2701,6 @@
   },
   {
     "id": 226,
-    "entrezid": 877796,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -2939,7 +2713,6 @@
   },
   {
     "id": 227,
-    "entrezid": 877797,
     "description": "glucosamine--fructose-6-phosphate aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -2952,7 +2725,6 @@
   },
   {
     "id": 228,
-    "entrezid": 877798,
     "description": "aliphatic amidase expression-regulating protein",
     "aliases": "-",
     "obsolete": false,
@@ -2965,7 +2737,6 @@
   },
   {
     "id": 229,
-    "entrezid": 877799,
     "description": "chaperone",
     "aliases": "-",
     "obsolete": false,
@@ -2978,7 +2749,6 @@
   },
   {
     "id": 230,
-    "entrezid": 877800,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -2991,7 +2761,6 @@
   },
   {
     "id": 231,
-    "entrezid": 877801,
     "description": "cyanate hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -3004,7 +2773,6 @@
   },
   {
     "id": 232,
-    "entrezid": 877802,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -3017,7 +2785,6 @@
   },
   {
     "id": 233,
-    "entrezid": 877803,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3030,7 +2797,6 @@
   },
   {
     "id": 234,
-    "entrezid": 877804,
     "description": "type II secretion system protein E",
     "aliases": "-",
     "obsolete": false,
@@ -3043,7 +2809,6 @@
   },
   {
     "id": 235,
-    "entrezid": 877805,
     "description": "type II secretion system protein N",
     "aliases": "-",
     "obsolete": false,
@@ -3056,7 +2821,6 @@
   },
   {
     "id": 236,
-    "entrezid": 877806,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3069,7 +2833,6 @@
   },
   {
     "id": 237,
-    "entrezid": 877807,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3082,7 +2845,6 @@
   },
   {
     "id": 238,
-    "entrezid": 877808,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3095,7 +2857,6 @@
   },
   {
     "id": 239,
-    "entrezid": 877809,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -3108,7 +2869,6 @@
   },
   {
     "id": 240,
-    "entrezid": 877810,
     "description": "glycosyl transferase",
     "aliases": "-",
     "obsolete": false,
@@ -3121,7 +2881,6 @@
   },
   {
     "id": 241,
-    "entrezid": 877811,
     "description": "transcriptional regulator PtxS",
     "aliases": "-",
     "obsolete": false,
@@ -3134,7 +2893,6 @@
   },
   {
     "id": 242,
-    "entrezid": 877812,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3147,7 +2905,6 @@
   },
   {
     "id": 243,
-    "entrezid": 877813,
     "description": "50S ribosomal protein L33",
     "aliases": "-",
     "obsolete": false,
@@ -3160,7 +2917,6 @@
   },
   {
     "id": 244,
-    "entrezid": 877814,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3173,7 +2929,6 @@
   },
   {
     "id": 245,
-    "entrezid": 877815,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -3186,7 +2941,6 @@
   },
   {
     "id": 246,
-    "entrezid": 877816,
     "description": "acylamide amidohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -3199,7 +2953,6 @@
   },
   {
     "id": 247,
-    "entrezid": 877817,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3212,7 +2965,6 @@
   },
   {
     "id": 248,
-    "entrezid": 877818,
     "description": "CoA transferase subunit B",
     "aliases": "-",
     "obsolete": false,
@@ -3225,7 +2977,6 @@
   },
   {
     "id": 249,
-    "entrezid": 877819,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3238,7 +2989,6 @@
   },
   {
     "id": 250,
-    "entrezid": 877820,
     "description": "nucleoside diphosphate kinase regulator",
     "aliases": "-",
     "obsolete": false,
@@ -3251,7 +3001,6 @@
   },
   {
     "id": 251,
-    "entrezid": 877821,
     "description": "translocation protein in type III secretion",
     "aliases": "-",
     "obsolete": false,
@@ -3264,7 +3013,6 @@
   },
   {
     "id": 252,
-    "entrezid": 877822,
     "description": "ATP-dependent RNA helicase",
     "aliases": "-",
     "obsolete": false,
@@ -3277,7 +3025,6 @@
   },
   {
     "id": 253,
-    "entrezid": 877823,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3290,7 +3037,6 @@
   },
   {
     "id": 254,
-    "entrezid": 877824,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3303,7 +3049,6 @@
   },
   {
     "id": 255,
-    "entrezid": 877825,
     "description": "homoserine kinase",
     "aliases": "-",
     "obsolete": false,
@@ -3316,7 +3061,6 @@
   },
   {
     "id": 256,
-    "entrezid": 877826,
     "description": "Na(+)/H(+) antiporter NhaB",
     "aliases": "-",
     "obsolete": false,
@@ -3329,7 +3073,6 @@
   },
   {
     "id": 257,
-    "entrezid": 877827,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -3342,7 +3085,6 @@
   },
   {
     "id": 258,
-    "entrezid": 877828,
     "description": "glutaredoxin",
     "aliases": "-",
     "obsolete": false,
@@ -3355,7 +3097,6 @@
   },
   {
     "id": 259,
-    "entrezid": 877829,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3368,7 +3109,6 @@
   },
   {
     "id": 260,
-    "entrezid": 877830,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -3381,7 +3121,6 @@
   },
   {
     "id": 261,
-    "entrezid": 877831,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3394,7 +3133,6 @@
   },
   {
     "id": 262,
-    "entrezid": 877832,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -3407,7 +3145,6 @@
   },
   {
     "id": 263,
-    "entrezid": 877833,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -3420,7 +3157,6 @@
   },
   {
     "id": 264,
-    "entrezid": 877834,
     "description": "2-ketogluconate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -3433,7 +3169,6 @@
   },
   {
     "id": 265,
-    "entrezid": 877835,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3446,7 +3181,6 @@
   },
   {
     "id": 266,
-    "entrezid": 877836,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3459,7 +3193,6 @@
   },
   {
     "id": 267,
-    "entrezid": 877837,
     "description": "ATP-dependent protease",
     "aliases": "-",
     "obsolete": false,
@@ -3472,7 +3205,6 @@
   },
   {
     "id": 268,
-    "entrezid": 877838,
     "description": "pyridoxal-phosphate dependent protein",
     "aliases": "-",
     "obsolete": false,
@@ -3485,7 +3217,6 @@
   },
   {
     "id": 269,
-    "entrezid": 877839,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3498,7 +3229,6 @@
   },
   {
     "id": 270,
-    "entrezid": 877840,
     "description": "ribonucleoside-diphosphate reductase",
     "aliases": "-",
     "obsolete": false,
@@ -3511,7 +3241,6 @@
   },
   {
     "id": 271,
-    "entrezid": 877841,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3524,7 +3253,6 @@
   },
   {
     "id": 272,
-    "entrezid": 877842,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3537,7 +3265,6 @@
   },
   {
     "id": 273,
-    "entrezid": 877843,
     "description": "tRNA 5-methylaminomethyl-2-thiouridine biosynthesis bifunctional protein MnmC",
     "aliases": "-",
     "obsolete": false,
@@ -3550,7 +3277,6 @@
   },
   {
     "id": 274,
-    "entrezid": 877844,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3563,7 +3289,6 @@
   },
   {
     "id": 275,
-    "entrezid": 877845,
     "description": "hydroxylase large subunit",
     "aliases": "-",
     "obsolete": false,
@@ -3576,7 +3301,6 @@
   },
   {
     "id": 276,
-    "entrezid": 877846,
     "description": "peptidase",
     "aliases": "-",
     "obsolete": false,
@@ -3589,7 +3313,6 @@
   },
   {
     "id": 277,
-    "entrezid": 877847,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3602,7 +3325,6 @@
   },
   {
     "id": 278,
-    "entrezid": 877848,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3615,7 +3337,6 @@
   },
   {
     "id": 279,
-    "entrezid": 877849,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -3628,7 +3349,6 @@
   },
   {
     "id": 280,
-    "entrezid": 877850,
     "description": "exotoxin A",
     "aliases": "-",
     "obsolete": false,
@@ -3641,7 +3361,6 @@
   },
   {
     "id": 281,
-    "entrezid": 877851,
     "description": "outer membrane protein OprM",
     "aliases": "-",
     "obsolete": false,
@@ -3654,7 +3373,6 @@
   },
   {
     "id": 282,
-    "entrezid": 877852,
     "description": "multidrug resistance protein MexB",
     "aliases": "-",
     "obsolete": false,
@@ -3667,7 +3385,6 @@
   },
   {
     "id": 283,
-    "entrezid": 877853,
     "description": "zinc transporter ZnuC",
     "aliases": "-",
     "obsolete": false,
@@ -3680,7 +3397,6 @@
   },
   {
     "id": 284,
-    "entrezid": 877854,
     "description": "zinc ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -3693,7 +3409,6 @@
   },
   {
     "id": 285,
-    "entrezid": 877855,
     "description": "multidrug resistance protein MexA",
     "aliases": "-",
     "obsolete": false,
@@ -3706,7 +3421,6 @@
   },
   {
     "id": 286,
-    "entrezid": 877856,
     "description": "kynureninase KynU",
     "aliases": "-",
     "obsolete": false,
@@ -3719,7 +3433,6 @@
   },
   {
     "id": 287,
-    "entrezid": 877857,
     "description": "multidrug resistance operon repressor MexR",
     "aliases": "-",
     "obsolete": false,
@@ -3732,7 +3445,6 @@
   },
   {
     "id": 288,
-    "entrezid": 877858,
     "description": "type 4 fimbrial biogenesis protein PilX",
     "aliases": "-",
     "obsolete": false,
@@ -3745,7 +3457,6 @@
   },
   {
     "id": 289,
-    "entrezid": 877859,
     "description": "type 4 fimbrial biogenesis protein PilY1",
     "aliases": "-",
     "obsolete": false,
@@ -3758,7 +3469,6 @@
   },
   {
     "id": 290,
-    "entrezid": 877860,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -3771,7 +3481,6 @@
   },
   {
     "id": 291,
-    "entrezid": 877861,
     "description": "type 4 prepilin peptidase PilD",
     "aliases": "-",
     "obsolete": false,
@@ -3784,7 +3493,6 @@
   },
   {
     "id": 292,
-    "entrezid": 877862,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3797,7 +3505,6 @@
   },
   {
     "id": 293,
-    "entrezid": 877863,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3810,7 +3517,6 @@
   },
   {
     "id": 294,
-    "entrezid": 877864,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -3823,7 +3529,6 @@
   },
   {
     "id": 295,
-    "entrezid": 877865,
     "description": "D-methionine ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -3836,7 +3541,6 @@
   },
   {
     "id": 296,
-    "entrezid": 877866,
     "description": "esterase",
     "aliases": "-",
     "obsolete": false,
@@ -3849,7 +3553,6 @@
   },
   {
     "id": 297,
-    "entrezid": 877867,
     "description": "RNA polymerase sigma factor",
     "aliases": "-",
     "obsolete": false,
@@ -3862,7 +3565,6 @@
   },
   {
     "id": 298,
-    "entrezid": 877868,
     "description": "acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -3875,7 +3577,6 @@
   },
   {
     "id": 299,
-    "entrezid": 877869,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3888,7 +3589,6 @@
   },
   {
     "id": 300,
-    "entrezid": 877870,
     "description": "antioxidant protein",
     "aliases": "-",
     "obsolete": false,
@@ -3901,7 +3601,6 @@
   },
   {
     "id": 301,
-    "entrezid": 877871,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3914,7 +3613,6 @@
   },
   {
     "id": 302,
-    "entrezid": 877872,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3927,7 +3625,6 @@
   },
   {
     "id": 303,
-    "entrezid": 877873,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3940,7 +3637,6 @@
   },
   {
     "id": 304,
-    "entrezid": 877874,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -3953,7 +3649,6 @@
   },
   {
     "id": 305,
-    "entrezid": 877875,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -3966,7 +3661,6 @@
   },
   {
     "id": 306,
-    "entrezid": 877876,
     "description": "pyruvate carboxylase subunit B",
     "aliases": "-",
     "obsolete": false,
@@ -3979,7 +3673,6 @@
   },
   {
     "id": 307,
-    "entrezid": 877877,
     "description": "acetyl-CoA carboxylase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -3992,7 +3685,6 @@
   },
   {
     "id": 308,
-    "entrezid": 877878,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -4005,7 +3697,6 @@
   },
   {
     "id": 309,
-    "entrezid": 877879,
     "description": "vanillate O-demethylase oxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -4018,7 +3709,6 @@
   },
   {
     "id": 310,
-    "entrezid": 877880,
     "description": "vanillate O-demethylase",
     "aliases": "-",
     "obsolete": false,
@@ -4031,7 +3721,6 @@
   },
   {
     "id": 311,
-    "entrezid": 877881,
     "description": "sensor histidine kinase MifS",
     "aliases": "-",
     "obsolete": false,
@@ -4044,7 +3733,6 @@
   },
   {
     "id": 312,
-    "entrezid": 877882,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4057,7 +3745,6 @@
   },
   {
     "id": 313,
-    "entrezid": 877883,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4070,7 +3757,6 @@
   },
   {
     "id": 314,
-    "entrezid": 877884,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -4083,7 +3769,6 @@
   },
   {
     "id": 315,
-    "entrezid": 877885,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4096,7 +3781,6 @@
   },
   {
     "id": 316,
-    "entrezid": 877886,
     "description": "DNA repair protein RadC",
     "aliases": "-",
     "obsolete": false,
@@ -4109,7 +3793,6 @@
   },
   {
     "id": 317,
-    "entrezid": 877887,
     "description": "bifunctional phosphopantothenoylcysteine decarboxylase/phosphopantothenate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -4122,7 +3805,6 @@
   },
   {
     "id": 318,
-    "entrezid": 877888,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4135,7 +3817,6 @@
   },
   {
     "id": 319,
-    "entrezid": 877889,
     "description": "sensor/response regulator hybrid protein",
     "aliases": "-",
     "obsolete": false,
@@ -4148,7 +3829,6 @@
   },
   {
     "id": 320,
-    "entrezid": 877890,
     "description": "GlmR transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -4161,7 +3841,6 @@
   },
   {
     "id": 321,
-    "entrezid": 877891,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4174,7 +3853,6 @@
   },
   {
     "id": 322,
-    "entrezid": 877892,
     "description": "bifunctional glucosamine-1-phosphate acetyltransferase/N-acetylglucosamine-1-phosphate uridyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -4187,7 +3865,6 @@
   },
   {
     "id": 323,
-    "entrezid": 877893,
     "description": "TonB-dependent receptor",
     "aliases": "-",
     "obsolete": false,
@@ -4200,7 +3877,6 @@
   },
   {
     "id": 324,
-    "entrezid": 877894,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4213,7 +3889,6 @@
   },
   {
     "id": 325,
-    "entrezid": 877895,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4226,7 +3901,6 @@
   },
   {
     "id": 326,
-    "entrezid": 877896,
     "description": "pseudouridine synthase",
     "aliases": "-",
     "obsolete": false,
@@ -4239,7 +3913,6 @@
   },
   {
     "id": 327,
-    "entrezid": 877897,
     "description": "competence protein ComL",
     "aliases": "-",
     "obsolete": false,
@@ -4252,7 +3925,6 @@
   },
   {
     "id": 328,
-    "entrezid": 877898,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4265,7 +3937,6 @@
   },
   {
     "id": 329,
-    "entrezid": 877899,
     "description": "molybdopterin biosynthesis protein MoeB",
     "aliases": "-",
     "obsolete": false,
@@ -4278,7 +3949,6 @@
   },
   {
     "id": 330,
-    "entrezid": 877900,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4291,7 +3961,6 @@
   },
   {
     "id": 331,
-    "entrezid": 877901,
     "description": "2-oxoisovalerate dehydrogenase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -4304,7 +3973,6 @@
   },
   {
     "id": 332,
-    "entrezid": 877902,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4317,7 +3985,6 @@
   },
   {
     "id": 333,
-    "entrezid": 877903,
     "description": "chemotaxis transducer",
     "aliases": "-",
     "obsolete": false,
@@ -4330,7 +3997,6 @@
   },
   {
     "id": 334,
-    "entrezid": 877904,
     "description": "chaperone CupA2",
     "aliases": "-",
     "obsolete": false,
@@ -4343,7 +4009,6 @@
   },
   {
     "id": 335,
-    "entrezid": 877905,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4356,7 +4021,6 @@
   },
   {
     "id": 336,
-    "entrezid": 877906,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -4369,7 +4033,6 @@
   },
   {
     "id": 337,
-    "entrezid": 877907,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4382,7 +4045,6 @@
   },
   {
     "id": 338,
-    "entrezid": 877908,
     "description": "taurine ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -4395,7 +4057,6 @@
   },
   {
     "id": 339,
-    "entrezid": 877909,
     "description": "taurine ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -4408,7 +4069,6 @@
   },
   {
     "id": 340,
-    "entrezid": 877910,
     "description": "ribonuclease P",
     "aliases": "-",
     "obsolete": false,
@@ -4421,7 +4081,6 @@
   },
   {
     "id": 341,
-    "entrezid": 877911,
     "description": "50S ribosomal protein L34",
     "aliases": "-",
     "obsolete": false,
@@ -4434,7 +4093,6 @@
   },
   {
     "id": 342,
-    "entrezid": 877912,
     "description": "guanosine-3',5'-bis(diphosphate) 3'-pyrophosphohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -4447,7 +4105,6 @@
   },
   {
     "id": 343,
-    "entrezid": 877913,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4460,7 +4117,6 @@
   },
   {
     "id": 344,
-    "entrezid": 877914,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4473,7 +4129,6 @@
   },
   {
     "id": 345,
-    "entrezid": 877915,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -4486,7 +4141,6 @@
   },
   {
     "id": 346,
-    "entrezid": 877916,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -4499,7 +4153,6 @@
   },
   {
     "id": 347,
-    "entrezid": 877917,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -4512,7 +4165,6 @@
   },
   {
     "id": 348,
-    "entrezid": 877918,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4525,7 +4177,6 @@
   },
   {
     "id": 349,
-    "entrezid": 877919,
     "description": "potassium efflux transporter",
     "aliases": "-",
     "obsolete": false,
@@ -4538,7 +4189,6 @@
   },
   {
     "id": 350,
-    "entrezid": 877920,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4551,7 +4201,6 @@
   },
   {
     "id": 351,
-    "entrezid": 877921,
     "description": "lipid A biosynthesis lauroyl acyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -4564,7 +4213,6 @@
   },
   {
     "id": 352,
-    "entrezid": 877922,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -4577,7 +4225,6 @@
   },
   {
     "id": 353,
-    "entrezid": 877923,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4590,7 +4237,6 @@
   },
   {
     "id": 354,
-    "entrezid": 877924,
     "description": "type III export protein PscD",
     "aliases": "-",
     "obsolete": false,
@@ -4603,7 +4249,6 @@
   },
   {
     "id": 355,
-    "entrezid": 877925,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4616,7 +4261,6 @@
   },
   {
     "id": 356,
-    "entrezid": 877926,
     "description": "Lon protease",
     "aliases": "-",
     "obsolete": false,
@@ -4629,7 +4273,6 @@
   },
   {
     "id": 357,
-    "entrezid": 877927,
     "description": "sodium/proline symporter PutP",
     "aliases": "-",
     "obsolete": false,
@@ -4642,7 +4285,6 @@
   },
   {
     "id": 358,
-    "entrezid": 877928,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4655,7 +4297,6 @@
   },
   {
     "id": 359,
-    "entrezid": 877929,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4668,7 +4309,6 @@
   },
   {
     "id": 360,
-    "entrezid": 877930,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4681,7 +4321,6 @@
   },
   {
     "id": 361,
-    "entrezid": 877931,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4694,7 +4333,6 @@
   },
   {
     "id": 362,
-    "entrezid": 877932,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4707,7 +4345,6 @@
   },
   {
     "id": 363,
-    "entrezid": 877933,
     "description": "flavin-binding monooxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -4720,7 +4357,6 @@
   },
   {
     "id": 364,
-    "entrezid": 877934,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4733,7 +4369,6 @@
   },
   {
     "id": 365,
-    "entrezid": 877935,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4746,7 +4381,6 @@
   },
   {
     "id": 366,
-    "entrezid": 877936,
     "description": "FMN-dependent NADH-azoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -4759,7 +4393,6 @@
   },
   {
     "id": 367,
-    "entrezid": 877937,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -4772,7 +4405,6 @@
   },
   {
     "id": 368,
-    "entrezid": 877938,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -4785,7 +4417,6 @@
   },
   {
     "id": 369,
-    "entrezid": 877939,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4798,7 +4429,6 @@
   },
   {
     "id": 370,
-    "entrezid": 877940,
     "description": "Fanconi-associated nuclease",
     "aliases": "-",
     "obsolete": false,
@@ -4811,7 +4441,6 @@
   },
   {
     "id": 371,
-    "entrezid": 877941,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4824,7 +4453,6 @@
   },
   {
     "id": 372,
-    "entrezid": 877942,
     "description": "amino acid permease",
     "aliases": "-",
     "obsolete": false,
@@ -4837,7 +4465,6 @@
   },
   {
     "id": 373,
-    "entrezid": 877943,
     "description": "nitroreductase",
     "aliases": "-",
     "obsolete": false,
@@ -4850,7 +4477,6 @@
   },
   {
     "id": 374,
-    "entrezid": 877944,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4863,7 +4489,6 @@
   },
   {
     "id": 375,
-    "entrezid": 877945,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -4876,7 +4501,6 @@
   },
   {
     "id": 376,
-    "entrezid": 877946,
     "description": "thioredoxin",
     "aliases": "-",
     "obsolete": false,
@@ -4889,7 +4513,6 @@
   },
   {
     "id": 377,
-    "entrezid": 877947,
     "description": "exopolyphosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -4902,7 +4525,6 @@
   },
   {
     "id": 378,
-    "entrezid": 877948,
     "description": "ClpA/B-type protease",
     "aliases": "-",
     "obsolete": false,
@@ -4915,7 +4537,6 @@
   },
   {
     "id": 379,
-    "entrezid": 877949,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4928,7 +4549,6 @@
   },
   {
     "id": 380,
-    "entrezid": 877950,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4941,7 +4561,6 @@
   },
   {
     "id": 381,
-    "entrezid": 877951,
     "description": "carbamoyl transferase",
     "aliases": "-",
     "obsolete": false,
@@ -4954,7 +4573,6 @@
   },
   {
     "id": 382,
-    "entrezid": 877952,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4967,7 +4585,6 @@
   },
   {
     "id": 383,
-    "entrezid": 877953,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -4980,7 +4597,6 @@
   },
   {
     "id": 384,
-    "entrezid": 877954,
     "description": "positive regulator for alginate biosynthesis MucC",
     "aliases": "-",
     "obsolete": false,
@@ -4993,7 +4609,6 @@
   },
   {
     "id": 385,
-    "entrezid": 877955,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -5006,7 +4621,6 @@
   },
   {
     "id": 386,
-    "entrezid": 877956,
     "description": "glutamine synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -5019,7 +4633,6 @@
   },
   {
     "id": 387,
-    "entrezid": 877957,
     "description": "aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -5032,7 +4645,6 @@
   },
   {
     "id": 388,
-    "entrezid": 877958,
     "description": "asparagine synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -5045,7 +4657,6 @@
   },
   {
     "id": 389,
-    "entrezid": 877959,
     "description": "alginate o-acetylase AlgI",
     "aliases": "-",
     "obsolete": false,
@@ -5058,7 +4669,6 @@
   },
   {
     "id": 390,
-    "entrezid": 877960,
     "description": "RNA polymerase sigma factor",
     "aliases": "-",
     "obsolete": false,
@@ -5071,7 +4681,6 @@
   },
   {
     "id": 391,
-    "entrezid": 877961,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5084,7 +4693,6 @@
   },
   {
     "id": 392,
-    "entrezid": 877962,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5097,7 +4705,6 @@
   },
   {
     "id": 393,
-    "entrezid": 877963,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5110,7 +4717,6 @@
   },
   {
     "id": 394,
-    "entrezid": 877964,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5123,7 +4729,6 @@
   },
   {
     "id": 395,
-    "entrezid": 877965,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5136,7 +4741,6 @@
   },
   {
     "id": 396,
-    "entrezid": 877966,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5149,7 +4753,6 @@
   },
   {
     "id": 397,
-    "entrezid": 877967,
     "description": "glutamate--cysteine ligase",
     "aliases": "-",
     "obsolete": false,
@@ -5162,7 +4765,6 @@
   },
   {
     "id": 398,
-    "entrezid": 877968,
     "description": "adenylyl-sulfate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -5175,7 +4777,6 @@
   },
   {
     "id": 399,
-    "entrezid": 877969,
     "description": "phosphoserine phosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -5188,7 +4789,6 @@
   },
   {
     "id": 400,
-    "entrezid": 877970,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5201,7 +4801,6 @@
   },
   {
     "id": 401,
-    "entrezid": 877971,
     "description": "two-component sensor NtrB",
     "aliases": "-",
     "obsolete": false,
@@ -5214,7 +4813,6 @@
   },
   {
     "id": 402,
-    "entrezid": 877972,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5227,7 +4825,6 @@
   },
   {
     "id": 403,
-    "entrezid": 877973,
     "description": "tRNA-dihydrouridine synthase C",
     "aliases": "-",
     "obsolete": false,
@@ -5240,7 +4837,6 @@
   },
   {
     "id": 404,
-    "entrezid": 877974,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5253,7 +4849,6 @@
   },
   {
     "id": 405,
-    "entrezid": 877975,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5266,7 +4861,6 @@
   },
   {
     "id": 406,
-    "entrezid": 877976,
     "description": "ATP-dependent RNA helicase",
     "aliases": "-",
     "obsolete": false,
@@ -5279,7 +4873,6 @@
   },
   {
     "id": 407,
-    "entrezid": 877977,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -5292,7 +4885,6 @@
   },
   {
     "id": 408,
-    "entrezid": 877978,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -5305,7 +4897,6 @@
   },
   {
     "id": 409,
-    "entrezid": 877979,
     "description": "aldehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -5318,7 +4909,6 @@
   },
   {
     "id": 410,
-    "entrezid": 877980,
     "description": "omega amino acid--pyruvate transaminase",
     "aliases": "-",
     "obsolete": false,
@@ -5331,7 +4921,6 @@
   },
   {
     "id": 411,
-    "entrezid": 877981,
     "description": "ribose operon repressor RbsR",
     "aliases": "-",
     "obsolete": false,
@@ -5344,7 +4933,6 @@
   },
   {
     "id": 412,
-    "entrezid": 877982,
     "description": "cyclic di-GMP phosphodiesterase",
     "aliases": "-",
     "obsolete": false,
@@ -5357,7 +4945,6 @@
   },
   {
     "id": 413,
-    "entrezid": 877983,
     "description": "transcriptional regulator AmpR",
     "aliases": "-",
     "obsolete": false,
@@ -5370,7 +4957,6 @@
   },
   {
     "id": 414,
-    "entrezid": 877984,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -5383,7 +4969,6 @@
   },
   {
     "id": 415,
-    "entrezid": 877985,
     "description": "cysteine synthase",
     "aliases": "-",
     "obsolete": false,
@@ -5396,7 +4981,6 @@
   },
   {
     "id": 416,
-    "entrezid": 877986,
     "description": "amino acid permease",
     "aliases": "-",
     "obsolete": false,
@@ -5409,7 +4993,6 @@
   },
   {
     "id": 417,
-    "entrezid": 877987,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5422,7 +5005,6 @@
   },
   {
     "id": 418,
-    "entrezid": 877988,
     "description": "sensor histidine kinase MifS",
     "aliases": "-",
     "obsolete": false,
@@ -5435,7 +5017,6 @@
   },
   {
     "id": 419,
-    "entrezid": 877989,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5448,7 +5029,6 @@
   },
   {
     "id": 420,
-    "entrezid": 877990,
     "description": "beta-lactamase",
     "aliases": "-",
     "obsolete": false,
@@ -5461,7 +5041,6 @@
   },
   {
     "id": 421,
-    "entrezid": 877991,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5474,7 +5053,6 @@
   },
   {
     "id": 422,
-    "entrezid": 877992,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5487,7 +5065,6 @@
   },
   {
     "id": 423,
-    "entrezid": 877993,
     "description": "bacteriophage protein",
     "aliases": "-",
     "obsolete": false,
@@ -5500,7 +5077,6 @@
   },
   {
     "id": 424,
-    "entrezid": 877994,
     "description": "bacteriophage protein",
     "aliases": "-",
     "obsolete": false,
@@ -5513,7 +5089,6 @@
   },
   {
     "id": 425,
-    "entrezid": 877995,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5526,7 +5101,6 @@
   },
   {
     "id": 426,
-    "entrezid": 877996,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -5539,7 +5113,6 @@
   },
   {
     "id": 427,
-    "entrezid": 877997,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -5552,7 +5125,6 @@
   },
   {
     "id": 428,
-    "entrezid": 877998,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5565,7 +5137,6 @@
   },
   {
     "id": 429,
-    "entrezid": 877999,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5578,7 +5149,6 @@
   },
   {
     "id": 430,
-    "entrezid": 878000,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -5591,7 +5161,6 @@
   },
   {
     "id": 431,
-    "entrezid": 878001,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -5604,7 +5173,6 @@
   },
   {
     "id": 432,
-    "entrezid": 878002,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -5617,7 +5185,6 @@
   },
   {
     "id": 433,
-    "entrezid": 878003,
     "description": "ring-cleaving dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -5630,7 +5197,6 @@
   },
   {
     "id": 434,
-    "entrezid": 878004,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5643,7 +5209,6 @@
   },
   {
     "id": 435,
-    "entrezid": 878005,
     "description": "PhoP/Q and low Mg2+ inducible outer membrane protein H1",
     "aliases": "-",
     "obsolete": false,
@@ -5656,7 +5221,6 @@
   },
   {
     "id": 436,
-    "entrezid": 878006,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5669,7 +5233,6 @@
   },
   {
     "id": 437,
-    "entrezid": 878007,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5682,7 +5245,6 @@
   },
   {
     "id": 438,
-    "entrezid": 878008,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5695,7 +5257,6 @@
   },
   {
     "id": 439,
-    "entrezid": 878009,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -5708,7 +5269,6 @@
   },
   {
     "id": 440,
-    "entrezid": 878010,
     "description": "ClpA/B-type protease",
     "aliases": "-",
     "obsolete": false,
@@ -5721,7 +5281,6 @@
   },
   {
     "id": 441,
-    "entrezid": 878011,
     "description": "coenzyme PQQ synthesis protein F",
     "aliases": "-",
     "obsolete": false,
@@ -5734,7 +5293,6 @@
   },
   {
     "id": 442,
-    "entrezid": 878012,
     "description": "glycosyltransferase WbpZ",
     "aliases": "-",
     "obsolete": false,
@@ -5747,7 +5305,6 @@
   },
   {
     "id": 443,
-    "entrezid": 878013,
     "description": "glycosyltransferase WbpY",
     "aliases": "-",
     "obsolete": false,
@@ -5760,7 +5317,6 @@
   },
   {
     "id": 444,
-    "entrezid": 878014,
     "description": "glycosyltransferase WbpX",
     "aliases": "-",
     "obsolete": false,
@@ -5773,7 +5329,6 @@
   },
   {
     "id": 445,
-    "entrezid": 878015,
     "description": "RNA-binding protein Hfq",
     "aliases": "-",
     "obsolete": false,
@@ -5786,7 +5341,6 @@
   },
   {
     "id": 446,
-    "entrezid": 878016,
     "description": "tRNA delta(2)-isopentenylpyrophosphate transferase",
     "aliases": "-",
     "obsolete": false,
@@ -5799,7 +5353,6 @@
   },
   {
     "id": 447,
-    "entrezid": 878017,
     "description": "adenosylmethionine--8-amino-7-oxononanoate aminotransferase BioA",
     "aliases": "-",
     "obsolete": false,
@@ -5812,7 +5365,6 @@
   },
   {
     "id": 448,
-    "entrezid": 878018,
     "description": "ubiquinone biosynthetic protein UbiB",
     "aliases": "-",
     "obsolete": false,
@@ -5825,7 +5377,6 @@
   },
   {
     "id": 449,
-    "entrezid": 878019,
     "description": "phosphoribosyl-AMP cyclohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -5838,7 +5389,6 @@
   },
   {
     "id": 450,
-    "entrezid": 878020,
     "description": "biofilm formation protein PslF",
     "aliases": "-",
     "obsolete": false,
@@ -5851,7 +5401,6 @@
   },
   {
     "id": 451,
-    "entrezid": 878021,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5864,7 +5413,6 @@
   },
   {
     "id": 452,
-    "entrezid": 878022,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5877,7 +5425,6 @@
   },
   {
     "id": 453,
-    "entrezid": 878023,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5890,7 +5437,6 @@
   },
   {
     "id": 454,
-    "entrezid": 878024,
     "description": "type VI pilus biosynthesis protein",
     "aliases": "-",
     "obsolete": false,
@@ -5903,7 +5449,6 @@
   },
   {
     "id": 455,
-    "entrezid": 878025,
     "description": "coenzyme A transferase",
     "aliases": "-",
     "obsolete": false,
@@ -5916,7 +5461,6 @@
   },
   {
     "id": 456,
-    "entrezid": 878026,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5929,7 +5473,6 @@
   },
   {
     "id": 457,
-    "entrezid": 878027,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5942,7 +5485,6 @@
   },
   {
     "id": 458,
-    "entrezid": 878028,
     "description": "helicase",
     "aliases": "-",
     "obsolete": false,
@@ -5955,7 +5497,6 @@
   },
   {
     "id": 459,
-    "entrezid": 878029,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -5968,7 +5509,6 @@
   },
   {
     "id": 460,
-    "entrezid": 878030,
     "description": "HTH-type transcriptional regulator PtxR",
     "aliases": "-",
     "obsolete": false,
@@ -5981,7 +5521,6 @@
   },
   {
     "id": 461,
-    "entrezid": 878031,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -5994,7 +5533,6 @@
   },
   {
     "id": 462,
-    "entrezid": 878032,
     "description": "16S ribosomal RNA methyltransferase RsmE",
     "aliases": "-",
     "obsolete": false,
@@ -6007,7 +5545,6 @@
   },
   {
     "id": 463,
-    "entrezid": 878033,
     "description": "acyl-CoA lyase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -6020,7 +5557,6 @@
   },
   {
     "id": 464,
-    "entrezid": 878034,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6033,7 +5569,6 @@
   },
   {
     "id": 465,
-    "entrezid": 878035,
     "description": "30S ribosomal protein S18",
     "aliases": "-",
     "obsolete": false,
@@ -6046,7 +5581,6 @@
   },
   {
     "id": 466,
-    "entrezid": 878036,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -6059,7 +5593,6 @@
   },
   {
     "id": 467,
-    "entrezid": 878037,
     "description": "catabolite repression control protein",
     "aliases": "-",
     "obsolete": false,
@@ -6072,7 +5605,6 @@
   },
   {
     "id": 468,
-    "entrezid": 878038,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6085,7 +5617,6 @@
   },
   {
     "id": 469,
-    "entrezid": 878039,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6098,7 +5629,6 @@
   },
   {
     "id": 470,
-    "entrezid": 878040,
     "description": "bacterioferritin comigratory protein",
     "aliases": "-",
     "obsolete": false,
@@ -6111,7 +5641,6 @@
   },
   {
     "id": 471,
-    "entrezid": 878041,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6124,7 +5653,6 @@
   },
   {
     "id": 472,
-    "entrezid": 878042,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6137,7 +5665,6 @@
   },
   {
     "id": 473,
-    "entrezid": 878043,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6150,7 +5677,6 @@
   },
   {
     "id": 474,
-    "entrezid": 878044,
     "description": "fumarate hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -6163,7 +5689,6 @@
   },
   {
     "id": 475,
-    "entrezid": 878045,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6176,7 +5701,6 @@
   },
   {
     "id": 476,
-    "entrezid": 878046,
     "description": "azurin",
     "aliases": "-",
     "obsolete": false,
@@ -6189,7 +5713,6 @@
   },
   {
     "id": 477,
-    "entrezid": 878047,
     "description": "guanylate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -6202,7 +5725,6 @@
   },
   {
     "id": 478,
-    "entrezid": 878048,
     "description": "DNA-directed RNA polymerase subunit omega",
     "aliases": "-",
     "obsolete": false,
@@ -6215,7 +5737,6 @@
   },
   {
     "id": 479,
-    "entrezid": 878049,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6228,7 +5749,6 @@
   },
   {
     "id": 480,
-    "entrezid": 878050,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6241,7 +5761,6 @@
   },
   {
     "id": 481,
-    "entrezid": 878051,
     "description": "biofilm formation protein PslD",
     "aliases": "-",
     "obsolete": false,
@@ -6254,7 +5773,6 @@
   },
   {
     "id": 482,
-    "entrezid": 878052,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6267,7 +5785,6 @@
   },
   {
     "id": 483,
-    "entrezid": 878053,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6280,7 +5797,6 @@
   },
   {
     "id": 484,
-    "entrezid": 878054,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6293,7 +5809,6 @@
   },
   {
     "id": 485,
-    "entrezid": 878055,
     "description": "alanine racemase",
     "aliases": "-",
     "obsolete": false,
@@ -6306,7 +5821,6 @@
   },
   {
     "id": 486,
-    "entrezid": 878056,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6319,7 +5833,6 @@
   },
   {
     "id": 487,
-    "entrezid": 878057,
     "description": "D-amino acid dehydrogenase small subunit",
     "aliases": "-",
     "obsolete": false,
@@ -6332,7 +5845,6 @@
   },
   {
     "id": 488,
-    "entrezid": 878058,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6345,7 +5857,6 @@
   },
   {
     "id": 489,
-    "entrezid": 878060,
     "description": "7-cyano-7-deazaguanine synthase",
     "aliases": "-",
     "obsolete": false,
@@ -6358,7 +5869,6 @@
   },
   {
     "id": 490,
-    "entrezid": 878061,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6371,7 +5881,6 @@
   },
   {
     "id": 491,
-    "entrezid": 878062,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6384,7 +5893,6 @@
   },
   {
     "id": 492,
-    "entrezid": 878063,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -6397,7 +5905,6 @@
   },
   {
     "id": 493,
-    "entrezid": 878064,
     "description": "DNA-binding response regulator MifR",
     "aliases": "-",
     "obsolete": false,
@@ -6410,7 +5917,6 @@
   },
   {
     "id": 494,
-    "entrezid": 878065,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6423,7 +5929,6 @@
   },
   {
     "id": 495,
-    "entrezid": 878066,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6436,7 +5941,6 @@
   },
   {
     "id": 496,
-    "entrezid": 878067,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6449,7 +5953,6 @@
   },
   {
     "id": 497,
-    "entrezid": 878068,
     "description": "paerucumarin biosynthesis protein PvcD",
     "aliases": "-",
     "obsolete": false,
@@ -6462,7 +5965,6 @@
   },
   {
     "id": 498,
-    "entrezid": 878069,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -6475,7 +5977,6 @@
   },
   {
     "id": 499,
-    "entrezid": 878070,
     "description": "osmotically inducible protein OsmC",
     "aliases": "-",
     "obsolete": false,
@@ -6488,7 +5989,6 @@
   },
   {
     "id": 500,
-    "entrezid": 878071,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6501,7 +6001,6 @@
   },
   {
     "id": 501,
-    "entrezid": 878072,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -6514,7 +6013,6 @@
   },
   {
     "id": 502,
-    "entrezid": 878073,
     "description": "protein AmbB",
     "aliases": "-",
     "obsolete": false,
@@ -6527,7 +6025,6 @@
   },
   {
     "id": 503,
-    "entrezid": 878074,
     "description": "carbonic anhydrase",
     "aliases": "-",
     "obsolete": false,
@@ -6540,7 +6037,6 @@
   },
   {
     "id": 504,
-    "entrezid": 878075,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6553,7 +6049,6 @@
   },
   {
     "id": 505,
-    "entrezid": 878076,
     "description": "DNA-3-methyladenine glycosidase I",
     "aliases": "-",
     "obsolete": false,
@@ -6566,7 +6061,6 @@
   },
   {
     "id": 506,
-    "entrezid": 878077,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6579,7 +6073,6 @@
   },
   {
     "id": 507,
-    "entrezid": 878078,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -6592,7 +6085,6 @@
   },
   {
     "id": 508,
-    "entrezid": 878079,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -6605,7 +6097,6 @@
   },
   {
     "id": 509,
-    "entrezid": 878080,
     "description": "pyocin-S2",
     "aliases": "-",
     "obsolete": false,
@@ -6618,7 +6109,6 @@
   },
   {
     "id": 510,
-    "entrezid": 878081,
     "description": "type III secretory apparatus protein PcrD",
     "aliases": "-",
     "obsolete": false,
@@ -6631,7 +6121,6 @@
   },
   {
     "id": 511,
-    "entrezid": 878082,
     "description": "ATP synthase subunit epsilon",
     "aliases": "-",
     "obsolete": false,
@@ -6644,7 +6133,6 @@
   },
   {
     "id": 512,
-    "entrezid": 878083,
     "description": "ATP synthase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -6657,7 +6145,6 @@
   },
   {
     "id": 513,
-    "entrezid": 878084,
     "description": "phosphatidate cytidylyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -6670,7 +6157,6 @@
   },
   {
     "id": 514,
-    "entrezid": 878085,
     "description": "acyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -6683,7 +6169,6 @@
   },
   {
     "id": 515,
-    "entrezid": 878086,
     "description": "CoA transferase subunit A",
     "aliases": "-",
     "obsolete": false,
@@ -6696,7 +6181,6 @@
   },
   {
     "id": 516,
-    "entrezid": 878087,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6709,7 +6193,6 @@
   },
   {
     "id": 517,
-    "entrezid": 878088,
     "description": "RNA 2'-phosphotransferase-like protein",
     "aliases": "-",
     "obsolete": false,
@@ -6722,7 +6205,6 @@
   },
   {
     "id": 518,
-    "entrezid": 878089,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -6735,7 +6217,6 @@
   },
   {
     "id": 519,
-    "entrezid": 878090,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -6748,7 +6229,6 @@
   },
   {
     "id": 520,
-    "entrezid": 878091,
     "description": "translocation protein in type III secretion",
     "aliases": "-",
     "obsolete": false,
@@ -6761,7 +6241,6 @@
   },
   {
     "id": 521,
-    "entrezid": 878092,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6774,7 +6253,6 @@
   },
   {
     "id": 522,
-    "entrezid": 878093,
     "description": "3-dehydroquinate dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -6787,7 +6265,6 @@
   },
   {
     "id": 523,
-    "entrezid": 878094,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6800,7 +6277,6 @@
   },
   {
     "id": 524,
-    "entrezid": 878095,
     "description": "glycine--tRNA ligase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -6813,7 +6289,6 @@
   },
   {
     "id": 525,
-    "entrezid": 878096,
     "description": "50S ribosomal protein L3 glutamine methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -6826,7 +6301,6 @@
   },
   {
     "id": 526,
-    "entrezid": 878097,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6839,7 +6313,6 @@
   },
   {
     "id": 527,
-    "entrezid": 878098,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6852,7 +6325,6 @@
   },
   {
     "id": 528,
-    "entrezid": 878099,
     "description": "paerucumarin biosynthesis protein PvcA",
     "aliases": "-",
     "obsolete": false,
@@ -6865,7 +6337,6 @@
   },
   {
     "id": 529,
-    "entrezid": 878100,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6878,7 +6349,6 @@
   },
   {
     "id": 530,
-    "entrezid": 878101,
     "description": "heat-shock protein",
     "aliases": "-",
     "obsolete": false,
@@ -6891,7 +6361,6 @@
   },
   {
     "id": 531,
-    "entrezid": 878102,
     "description": "membrane protein insertion efficiency factor",
     "aliases": "-",
     "obsolete": false,
@@ -6904,7 +6373,6 @@
   },
   {
     "id": 532,
-    "entrezid": 878103,
     "description": "biofilm formation protein PslC",
     "aliases": "-",
     "obsolete": false,
@@ -6917,7 +6385,6 @@
   },
   {
     "id": 533,
-    "entrezid": 878104,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -6930,7 +6397,6 @@
   },
   {
     "id": 534,
-    "entrezid": 878105,
     "description": "glutamine synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -6943,7 +6409,6 @@
   },
   {
     "id": 535,
-    "entrezid": 878106,
     "description": "siderophore receptor",
     "aliases": "-",
     "obsolete": false,
@@ -6956,7 +6421,6 @@
   },
   {
     "id": 536,
-    "entrezid": 878107,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -6969,7 +6433,6 @@
   },
   {
     "id": 537,
-    "entrezid": 878108,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -6982,7 +6445,6 @@
   },
   {
     "id": 538,
-    "entrezid": 878109,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -6995,7 +6457,6 @@
   },
   {
     "id": 539,
-    "entrezid": 878110,
     "description": "dihydrodipicolinate synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -7008,7 +6469,6 @@
   },
   {
     "id": 540,
-    "entrezid": 878111,
     "description": "enolase-phosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -7021,7 +6481,6 @@
   },
   {
     "id": 541,
-    "entrezid": 878112,
     "description": "DNA-binding transcriptional regulator CynR",
     "aliases": "-",
     "obsolete": false,
@@ -7034,7 +6493,6 @@
   },
   {
     "id": 542,
-    "entrezid": 878113,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7047,7 +6505,6 @@
   },
   {
     "id": 543,
-    "entrezid": 878114,
     "description": "methionine ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -7060,7 +6517,6 @@
   },
   {
     "id": 544,
-    "entrezid": 878115,
     "description": "chemotactic transduction protein ChpE",
     "aliases": "-",
     "obsolete": false,
@@ -7073,7 +6529,6 @@
   },
   {
     "id": 545,
-    "entrezid": 878116,
     "description": "sodium/proton antiporter",
     "aliases": "-",
     "obsolete": false,
@@ -7086,7 +6541,6 @@
   },
   {
     "id": 546,
-    "entrezid": 878117,
     "description": "MFS dicarboxylate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -7099,7 +6553,6 @@
   },
   {
     "id": 547,
-    "entrezid": 878118,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7112,7 +6565,6 @@
   },
   {
     "id": 548,
-    "entrezid": 878119,
     "description": "transporter membrane subunit",
     "aliases": "-",
     "obsolete": false,
@@ -7125,7 +6577,6 @@
   },
   {
     "id": 549,
-    "entrezid": 878120,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7138,7 +6589,6 @@
   },
   {
     "id": 550,
-    "entrezid": 878121,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7151,7 +6601,6 @@
   },
   {
     "id": 551,
-    "entrezid": 878122,
     "description": "dimethylglycine catabolism protein DgcA",
     "aliases": "-",
     "obsolete": false,
@@ -7164,7 +6613,6 @@
   },
   {
     "id": 552,
-    "entrezid": 878123,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -7177,7 +6625,6 @@
   },
   {
     "id": 553,
-    "entrezid": 878124,
     "description": "flagellar basal body rod modification protein",
     "aliases": "-",
     "obsolete": false,
@@ -7190,7 +6637,6 @@
   },
   {
     "id": 554,
-    "entrezid": 878125,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -7203,7 +6649,6 @@
   },
   {
     "id": 555,
-    "entrezid": 878126,
     "description": "tRNA modification GTPase TrmE",
     "aliases": "-",
     "obsolete": false,
@@ -7216,7 +6661,6 @@
   },
   {
     "id": 556,
-    "entrezid": 878127,
     "description": "inner membrane protein translocase subunit YidC",
     "aliases": "-",
     "obsolete": false,
@@ -7229,7 +6673,6 @@
   },
   {
     "id": 557,
-    "entrezid": 878128,
     "description": "ATP synthase subunit I",
     "aliases": "-",
     "obsolete": false,
@@ -7242,7 +6685,6 @@
   },
   {
     "id": 558,
-    "entrezid": 878129,
     "description": "chromosome partitioning protein",
     "aliases": "-",
     "obsolete": false,
@@ -7255,7 +6697,6 @@
   },
   {
     "id": 559,
-    "entrezid": 878130,
     "description": "protocatechuate 3,4-dioxygenase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -7268,7 +6709,6 @@
   },
   {
     "id": 560,
-    "entrezid": 878131,
     "description": "pyridoxine 5'-phosphate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -7281,7 +6721,6 @@
   },
   {
     "id": 561,
-    "entrezid": 878132,
     "description": "sigma factor regulator FemR",
     "aliases": "-",
     "obsolete": false,
@@ -7294,7 +6733,6 @@
   },
   {
     "id": 562,
-    "entrezid": 878133,
     "description": "L-asparaginase I",
     "aliases": "-",
     "obsolete": false,
@@ -7307,7 +6745,6 @@
   },
   {
     "id": 563,
-    "entrezid": 878134,
     "description": "2,3-bisphosphoglycerate-independent phosphoglycerate mutase",
     "aliases": "-",
     "obsolete": false,
@@ -7320,7 +6757,6 @@
   },
   {
     "id": 564,
-    "entrezid": 878135,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7333,7 +6769,6 @@
   },
   {
     "id": 565,
-    "entrezid": 878136,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7346,7 +6781,6 @@
   },
   {
     "id": 566,
-    "entrezid": 878137,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7359,7 +6793,6 @@
   },
   {
     "id": 567,
-    "entrezid": 878138,
     "description": "transporter TonB",
     "aliases": "-",
     "obsolete": false,
@@ -7372,7 +6805,6 @@
   },
   {
     "id": 568,
-    "entrezid": 878139,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -7385,7 +6817,6 @@
   },
   {
     "id": 569,
-    "entrezid": 878140,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7398,7 +6829,6 @@
   },
   {
     "id": 570,
-    "entrezid": 878141,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7411,7 +6841,6 @@
   },
   {
     "id": 571,
-    "entrezid": 878142,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -7424,7 +6853,6 @@
   },
   {
     "id": 572,
-    "entrezid": 878143,
     "description": "phosphonate transporter PhnE",
     "aliases": "-",
     "obsolete": false,
@@ -7437,7 +6865,6 @@
   },
   {
     "id": 573,
-    "entrezid": 878144,
     "description": "phosphoribosylglycinamide formyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -7450,7 +6877,6 @@
   },
   {
     "id": 574,
-    "entrezid": 878145,
     "description": "thiamine pyrophosphate protein",
     "aliases": "-",
     "obsolete": false,
@@ -7463,7 +6889,6 @@
   },
   {
     "id": 575,
-    "entrezid": 878146,
     "description": "pyridine nucleotide transhydrogenase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -7476,7 +6901,6 @@
   },
   {
     "id": 576,
-    "entrezid": 878147,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7489,7 +6913,6 @@
   },
   {
     "id": 577,
-    "entrezid": 878148,
     "description": "chemotaxis protein",
     "aliases": "-",
     "obsolete": false,
@@ -7502,7 +6925,6 @@
   },
   {
     "id": 578,
-    "entrezid": 878149,
     "description": "beta-lactamase",
     "aliases": "-",
     "obsolete": false,
@@ -7515,7 +6937,6 @@
   },
   {
     "id": 579,
-    "entrezid": 878150,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7528,7 +6949,6 @@
   },
   {
     "id": 580,
-    "entrezid": 878151,
     "description": "assimilatory nitrate reductase",
     "aliases": "-",
     "obsolete": false,
@@ -7541,7 +6961,6 @@
   },
   {
     "id": 581,
-    "entrezid": 878152,
     "description": "TonB-dependent receptor",
     "aliases": "-",
     "obsolete": false,
@@ -7554,7 +6973,6 @@
   },
   {
     "id": 582,
-    "entrezid": 878153,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7567,7 +6985,6 @@
   },
   {
     "id": 583,
-    "entrezid": 878154,
     "description": "acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -7580,7 +6997,6 @@
   },
   {
     "id": 584,
-    "entrezid": 878155,
     "description": "dicarboxylic acid transporter PcaT",
     "aliases": "-",
     "obsolete": false,
@@ -7593,7 +7009,6 @@
   },
   {
     "id": 585,
-    "entrezid": 878156,
     "description": "enoyl-CoA hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -7606,7 +7021,6 @@
   },
   {
     "id": 586,
-    "entrezid": 878157,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -7619,7 +7033,6 @@
   },
   {
     "id": 587,
-    "entrezid": 878158,
     "description": "branched-chain amino acid ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -7632,7 +7045,6 @@
   },
   {
     "id": 588,
-    "entrezid": 878159,
     "description": "xanthine phosphoribosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -7645,7 +7057,6 @@
   },
   {
     "id": 589,
-    "entrezid": 878160,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7658,7 +7069,6 @@
   },
   {
     "id": 590,
-    "entrezid": 878161,
     "description": "dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -7671,7 +7081,6 @@
   },
   {
     "id": 591,
-    "entrezid": 878162,
     "description": "ribulose-phosphate 3-epimerase",
     "aliases": "-",
     "obsolete": false,
@@ -7684,7 +7093,6 @@
   },
   {
     "id": 592,
-    "entrezid": 878163,
     "description": "DNA-3-methyladenine glycosidase II",
     "aliases": "-",
     "obsolete": false,
@@ -7697,7 +7105,6 @@
   },
   {
     "id": 593,
-    "entrezid": 878164,
     "description": "3-ketoacyl-ACP reductase",
     "aliases": "-",
     "obsolete": false,
@@ -7710,7 +7117,6 @@
   },
   {
     "id": 594,
-    "entrezid": 878165,
     "description": "succinylglutamate desuccinylase",
     "aliases": "-",
     "obsolete": false,
@@ -7723,7 +7129,6 @@
   },
   {
     "id": 595,
-    "entrezid": 878166,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -7736,7 +7141,6 @@
   },
   {
     "id": 596,
-    "entrezid": 878167,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7749,7 +7153,6 @@
   },
   {
     "id": 597,
-    "entrezid": 878168,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7762,7 +7165,6 @@
   },
   {
     "id": 598,
-    "entrezid": 878169,
     "description": "methylesterase",
     "aliases": "-",
     "obsolete": false,
@@ -7775,7 +7177,6 @@
   },
   {
     "id": 599,
-    "entrezid": 878170,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7788,7 +7189,6 @@
   },
   {
     "id": 600,
-    "entrezid": 878171,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7801,7 +7201,6 @@
   },
   {
     "id": 601,
-    "entrezid": 878172,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7814,7 +7213,6 @@
   },
   {
     "id": 602,
-    "entrezid": 878173,
     "description": "nucleotidyl transferase",
     "aliases": "-",
     "obsolete": false,
@@ -7827,7 +7225,6 @@
   },
   {
     "id": 603,
-    "entrezid": 878174,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7840,7 +7237,6 @@
   },
   {
     "id": 604,
-    "entrezid": 878175,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -7853,7 +7249,6 @@
   },
   {
     "id": 605,
-    "entrezid": 878176,
     "description": "chemotactic signal transduction system protein",
     "aliases": "-",
     "obsolete": false,
@@ -7866,7 +7261,6 @@
   },
   {
     "id": 606,
-    "entrezid": 878177,
     "description": "class II aldolase/adducin domain-containing protein",
     "aliases": "-",
     "obsolete": false,
@@ -7879,7 +7273,6 @@
   },
   {
     "id": 607,
-    "entrezid": 878178,
     "description": "pyoverdine biosynthesis protein PvdJ",
     "aliases": "-",
     "obsolete": false,
@@ -7892,7 +7285,6 @@
   },
   {
     "id": 608,
-    "entrezid": 878179,
     "description": "methyltransferase PilK",
     "aliases": "-",
     "obsolete": false,
@@ -7905,7 +7297,6 @@
   },
   {
     "id": 609,
-    "entrezid": 878180,
     "description": "twitching motility protein PilJ",
     "aliases": "-",
     "obsolete": false,
@@ -7918,7 +7309,6 @@
   },
   {
     "id": 610,
-    "entrezid": 878181,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -7931,7 +7321,6 @@
   },
   {
     "id": 611,
-    "entrezid": 878182,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -7944,7 +7333,6 @@
   },
   {
     "id": 612,
-    "entrezid": 878183,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -7957,7 +7345,6 @@
   },
   {
     "id": 613,
-    "entrezid": 878184,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -7970,7 +7357,6 @@
   },
   {
     "id": 614,
-    "entrezid": 878185,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -7983,7 +7369,6 @@
   },
   {
     "id": 615,
-    "entrezid": 878186,
     "description": "twitching motility protein PilI",
     "aliases": "-",
     "obsolete": false,
@@ -7996,7 +7381,6 @@
   },
   {
     "id": 616,
-    "entrezid": 878187,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8009,7 +7393,6 @@
   },
   {
     "id": 617,
-    "entrezid": 878188,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8022,7 +7405,6 @@
   },
   {
     "id": 618,
-    "entrezid": 878189,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8035,7 +7417,6 @@
   },
   {
     "id": 619,
-    "entrezid": 878190,
     "description": "repressor PtrB",
     "aliases": "-",
     "obsolete": false,
@@ -8048,7 +7429,6 @@
   },
   {
     "id": 620,
-    "entrezid": 878191,
     "description": "flagellar hook-associated protein FlgK",
     "aliases": "-",
     "obsolete": false,
@@ -8061,7 +7441,6 @@
   },
   {
     "id": 621,
-    "entrezid": 878192,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8074,7 +7453,6 @@
   },
   {
     "id": 622,
-    "entrezid": 878193,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8087,7 +7465,6 @@
   },
   {
     "id": 623,
-    "entrezid": 878194,
     "description": "isoleucine--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -8100,7 +7477,6 @@
   },
   {
     "id": 624,
-    "entrezid": 878195,
     "description": "bifunctional riboflavin kinase/FMN adenylyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -8113,7 +7489,6 @@
   },
   {
     "id": 625,
-    "entrezid": 878196,
     "description": "D-amino acid oxidase",
     "aliases": "-",
     "obsolete": false,
@@ -8126,7 +7501,6 @@
   },
   {
     "id": 626,
-    "entrezid": 878197,
     "description": "type 4 fimbrial biogenesis protein FimT",
     "aliases": "-",
     "obsolete": false,
@@ -8139,7 +7513,6 @@
   },
   {
     "id": 627,
-    "entrezid": 878198,
     "description": "twitching motility protein PilH",
     "aliases": "-",
     "obsolete": false,
@@ -8152,7 +7525,6 @@
   },
   {
     "id": 628,
-    "entrezid": 878199,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8165,7 +7537,6 @@
   },
   {
     "id": 629,
-    "entrezid": 878200,
     "description": "citrate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -8178,7 +7549,6 @@
   },
   {
     "id": 630,
-    "entrezid": 878201,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -8191,7 +7561,6 @@
   },
   {
     "id": 631,
-    "entrezid": 878202,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8204,7 +7573,6 @@
   },
   {
     "id": 632,
-    "entrezid": 878203,
     "description": "pilus biosynthesis/twitching motility protein PilG",
     "aliases": "-",
     "obsolete": false,
@@ -8217,7 +7585,6 @@
   },
   {
     "id": 633,
-    "entrezid": 878204,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8230,7 +7597,6 @@
   },
   {
     "id": 634,
-    "entrezid": 878205,
     "description": "oligoribonuclease",
     "aliases": "-",
     "obsolete": false,
@@ -8243,7 +7609,6 @@
   },
   {
     "id": 635,
-    "entrezid": 878206,
     "description": "enoyl-CoA hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -8256,7 +7621,6 @@
   },
   {
     "id": 636,
-    "entrezid": 878207,
     "description": "acetylornithine aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -8269,7 +7633,6 @@
   },
   {
     "id": 637,
-    "entrezid": 878208,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8282,7 +7645,6 @@
   },
   {
     "id": 638,
-    "entrezid": 878209,
     "description": "transmembrane sensor",
     "aliases": "-",
     "obsolete": false,
@@ -8295,7 +7657,6 @@
   },
   {
     "id": 639,
-    "entrezid": 878210,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8308,7 +7669,6 @@
   },
   {
     "id": 640,
-    "entrezid": 878211,
     "description": "phenazine biosynthesis protein PhzB",
     "aliases": "-",
     "obsolete": false,
@@ -8321,7 +7681,6 @@
   },
   {
     "id": 641,
-    "entrezid": 878212,
     "description": "usher CupA3",
     "aliases": "-",
     "obsolete": false,
@@ -8334,7 +7693,6 @@
   },
   {
     "id": 642,
-    "entrezid": 878213,
     "description": "DNA repair protein RecO",
     "aliases": "-",
     "obsolete": false,
@@ -8347,7 +7705,6 @@
   },
   {
     "id": 643,
-    "entrezid": 878214,
     "description": "glycine--tRNA ligase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -8360,7 +7717,6 @@
   },
   {
     "id": 644,
-    "entrezid": 878215,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8373,7 +7729,6 @@
   },
   {
     "id": 645,
-    "entrezid": 878216,
     "description": "ribosome-associated GTPase",
     "aliases": "-",
     "obsolete": false,
@@ -8386,7 +7741,6 @@
   },
   {
     "id": 646,
-    "entrezid": 878217,
     "description": "flagellar motor protein MotB",
     "aliases": "-",
     "obsolete": false,
@@ -8399,7 +7753,6 @@
   },
   {
     "id": 647,
-    "entrezid": 878218,
     "description": "ribonuclease PH",
     "aliases": "-",
     "obsolete": false,
@@ -8412,7 +7765,6 @@
   },
   {
     "id": 648,
-    "entrezid": 878219,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8425,7 +7777,6 @@
   },
   {
     "id": 649,
-    "entrezid": 878220,
     "description": "ATP-dependent dethiobiotin synthetase BioD",
     "aliases": "-",
     "obsolete": false,
@@ -8438,7 +7789,6 @@
   },
   {
     "id": 650,
-    "entrezid": 878221,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8451,7 +7801,6 @@
   },
   {
     "id": 651,
-    "entrezid": 878222,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8464,7 +7813,6 @@
   },
   {
     "id": 652,
-    "entrezid": 878223,
     "description": "glutathione synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -8477,7 +7825,6 @@
   },
   {
     "id": 653,
-    "entrezid": 878224,
     "description": "transporter TonB",
     "aliases": "-",
     "obsolete": false,
@@ -8490,7 +7837,6 @@
   },
   {
     "id": 654,
-    "entrezid": 878225,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8503,7 +7849,6 @@
   },
   {
     "id": 655,
-    "entrezid": 878226,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8516,7 +7861,6 @@
   },
   {
     "id": 656,
-    "entrezid": 878227,
     "description": "orotate phosphoribosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -8529,7 +7873,6 @@
   },
   {
     "id": 657,
-    "entrezid": 878228,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8542,7 +7885,6 @@
   },
   {
     "id": 658,
-    "entrezid": 878229,
     "description": "GTPase Der",
     "aliases": "-",
     "obsolete": false,
@@ -8555,7 +7897,6 @@
   },
   {
     "id": 659,
-    "entrezid": 878230,
     "description": "outer membrane protein assembly factor BamB",
     "aliases": "-",
     "obsolete": false,
@@ -8568,7 +7909,6 @@
   },
   {
     "id": 660,
-    "entrezid": 878231,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -8581,7 +7921,6 @@
   },
   {
     "id": 661,
-    "entrezid": 878232,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8594,7 +7933,6 @@
   },
   {
     "id": 662,
-    "entrezid": 878233,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8607,7 +7945,6 @@
   },
   {
     "id": 663,
-    "entrezid": 878234,
     "description": "chaperone CupC2",
     "aliases": "-",
     "obsolete": false,
@@ -8620,7 +7957,6 @@
   },
   {
     "id": 664,
-    "entrezid": 878235,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8633,7 +7969,6 @@
   },
   {
     "id": 665,
-    "entrezid": 878236,
     "description": "phosphoribosylamine--glycine ligase",
     "aliases": "-",
     "obsolete": false,
@@ -8646,7 +7981,6 @@
   },
   {
     "id": 666,
-    "entrezid": 878237,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8659,7 +7993,6 @@
   },
   {
     "id": 667,
-    "entrezid": 878238,
     "description": "biofilm formation methyltransferase WspC",
     "aliases": "-",
     "obsolete": false,
@@ -8672,7 +8005,6 @@
   },
   {
     "id": 668,
-    "entrezid": 878239,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8685,7 +8017,6 @@
   },
   {
     "id": 669,
-    "entrezid": 878240,
     "description": "urease subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -8698,7 +8029,6 @@
   },
   {
     "id": 670,
-    "entrezid": 878241,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8711,7 +8041,6 @@
   },
   {
     "id": 671,
-    "entrezid": 878242,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8724,7 +8053,6 @@
   },
   {
     "id": 672,
-    "entrezid": 878243,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8737,7 +8065,6 @@
   },
   {
     "id": 673,
-    "entrezid": 878244,
     "description": "methylcrotonyl-CoA carboxylase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -8750,7 +8077,6 @@
   },
   {
     "id": 674,
-    "entrezid": 878245,
     "description": "FruR family transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -8763,7 +8089,6 @@
   },
   {
     "id": 675,
-    "entrezid": 878246,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8776,7 +8101,6 @@
   },
   {
     "id": 676,
-    "entrezid": 878247,
     "description": "Holliday junction resolvase",
     "aliases": "-",
     "obsolete": false,
@@ -8789,7 +8113,6 @@
   },
   {
     "id": 677,
-    "entrezid": 878248,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8802,7 +8125,6 @@
   },
   {
     "id": 678,
-    "entrezid": 878249,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8815,7 +8137,6 @@
   },
   {
     "id": 679,
-    "entrezid": 878250,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -8828,7 +8149,6 @@
   },
   {
     "id": 680,
-    "entrezid": 878251,
     "description": "mono-heme cytochrome C",
     "aliases": "-",
     "obsolete": false,
@@ -8841,7 +8161,6 @@
   },
   {
     "id": 681,
-    "entrezid": 878252,
     "description": "ribonuclease HI",
     "aliases": "-",
     "obsolete": false,
@@ -8854,7 +8173,6 @@
   },
   {
     "id": 682,
-    "entrezid": 878253,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8867,7 +8185,6 @@
   },
   {
     "id": 683,
-    "entrezid": 878254,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -8880,7 +8197,6 @@
   },
   {
     "id": 684,
-    "entrezid": 878255,
     "description": "ECF sigma factor FemI",
     "aliases": "-",
     "obsolete": false,
@@ -8893,7 +8209,6 @@
   },
   {
     "id": 685,
-    "entrezid": 878257,
     "description": "peptide synthase",
     "aliases": "-",
     "obsolete": false,
@@ -8906,7 +8221,6 @@
   },
   {
     "id": 686,
-    "entrezid": 878258,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8919,7 +8233,6 @@
   },
   {
     "id": 687,
-    "entrezid": 878259,
     "description": "bifunctional pyrimidine regulatory protein PyrR/uracil phosphoribosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -8932,7 +8245,6 @@
   },
   {
     "id": 688,
-    "entrezid": 878260,
     "description": "protease LasA",
     "aliases": "-",
     "obsolete": false,
@@ -8945,7 +8257,6 @@
   },
   {
     "id": 689,
-    "entrezid": 878261,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -8958,7 +8269,6 @@
   },
   {
     "id": 690,
-    "entrezid": 878262,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -8971,7 +8281,6 @@
   },
   {
     "id": 691,
-    "entrezid": 878263,
     "description": "paerucumarin biosynthesis protein PvcC",
     "aliases": "-",
     "obsolete": false,
@@ -8984,7 +8293,6 @@
   },
   {
     "id": 692,
-    "entrezid": 878264,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -8997,7 +8305,6 @@
   },
   {
     "id": 693,
-    "entrezid": 878265,
     "description": "polyamine transporter PotI",
     "aliases": "-",
     "obsolete": false,
@@ -9010,7 +8317,6 @@
   },
   {
     "id": 694,
-    "entrezid": 878266,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -9023,7 +8329,6 @@
   },
   {
     "id": 695,
-    "entrezid": 878267,
     "description": "aspartate carbamoyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -9036,7 +8341,6 @@
   },
   {
     "id": 696,
-    "entrezid": 878268,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9049,7 +8353,6 @@
   },
   {
     "id": 697,
-    "entrezid": 878269,
     "description": "hydroxylase molybdopterin-containing subunit",
     "aliases": "-",
     "obsolete": false,
@@ -9062,7 +8365,6 @@
   },
   {
     "id": 698,
-    "entrezid": 878270,
     "description": "L-cysteine ABC transporter protein FliY",
     "aliases": "-",
     "obsolete": false,
@@ -9075,7 +8377,6 @@
   },
   {
     "id": 699,
-    "entrezid": 878271,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9088,7 +8389,6 @@
   },
   {
     "id": 700,
-    "entrezid": 878272,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9101,7 +8401,6 @@
   },
   {
     "id": 701,
-    "entrezid": 878273,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9114,7 +8413,6 @@
   },
   {
     "id": 702,
-    "entrezid": 878274,
     "description": "protein AmbE",
     "aliases": "-",
     "obsolete": false,
@@ -9127,7 +8425,6 @@
   },
   {
     "id": 703,
-    "entrezid": 878275,
     "description": "dihydroorotase",
     "aliases": "-",
     "obsolete": false,
@@ -9140,7 +8437,6 @@
   },
   {
     "id": 704,
-    "entrezid": 878276,
     "description": "ribose ABC transporter substrate-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -9153,7 +8449,6 @@
   },
   {
     "id": 705,
-    "entrezid": 878277,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -9166,7 +8461,6 @@
   },
   {
     "id": 706,
-    "entrezid": 878278,
     "description": "L-cysteine ABC transporter protein YecS",
     "aliases": "-",
     "obsolete": false,
@@ -9179,7 +8473,6 @@
   },
   {
     "id": 707,
-    "entrezid": 878279,
     "description": "preprotein translocase subunit SecD",
     "aliases": "-",
     "obsolete": false,
@@ -9192,7 +8485,6 @@
   },
   {
     "id": 708,
-    "entrezid": 878280,
     "description": "preprotein translocase subunit YajC",
     "aliases": "-",
     "obsolete": false,
@@ -9205,7 +8497,6 @@
   },
   {
     "id": 709,
-    "entrezid": 878281,
     "description": "deoxycytidine triphosphate deaminase",
     "aliases": "-",
     "obsolete": false,
@@ -9218,7 +8509,6 @@
   },
   {
     "id": 710,
-    "entrezid": 878282,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9231,7 +8521,6 @@
   },
   {
     "id": 711,
-    "entrezid": 878283,
     "description": "AGCS sodium/alanine/glycine symporter",
     "aliases": "-",
     "obsolete": false,
@@ -9244,7 +8533,6 @@
   },
   {
     "id": 712,
-    "entrezid": 878284,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9257,7 +8545,6 @@
   },
   {
     "id": 713,
-    "entrezid": 878285,
     "description": "flagellar hook protein FlgE",
     "aliases": "-",
     "obsolete": false,
@@ -9270,7 +8557,6 @@
   },
   {
     "id": 714,
-    "entrezid": 878286,
     "description": "cystathionine gamma-lyase",
     "aliases": "-",
     "obsolete": false,
@@ -9283,7 +8569,6 @@
   },
   {
     "id": 715,
-    "entrezid": 878287,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9296,7 +8581,6 @@
   },
   {
     "id": 716,
-    "entrezid": 878288,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -9309,7 +8593,6 @@
   },
   {
     "id": 717,
-    "entrezid": 878289,
     "description": "assimilatory nitrite reductase small subunit",
     "aliases": "-",
     "obsolete": false,
@@ -9322,7 +8605,6 @@
   },
   {
     "id": 718,
-    "entrezid": 878290,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9335,7 +8617,6 @@
   },
   {
     "id": 719,
-    "entrezid": 878291,
     "description": "cystathionine beta-synthase",
     "aliases": "-",
     "obsolete": false,
@@ -9348,7 +8629,6 @@
   },
   {
     "id": 720,
-    "entrezid": 878292,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9361,7 +8641,6 @@
   },
   {
     "id": 721,
-    "entrezid": 878293,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9374,7 +8653,6 @@
   },
   {
     "id": 722,
-    "entrezid": 878295,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9387,7 +8665,6 @@
   },
   {
     "id": 723,
-    "entrezid": 878296,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9400,7 +8677,6 @@
   },
   {
     "id": 724,
-    "entrezid": 878297,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9413,7 +8689,6 @@
   },
   {
     "id": 725,
-    "entrezid": 878298,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9426,7 +8701,6 @@
   },
   {
     "id": 726,
-    "entrezid": 878299,
     "description": "alanine--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -9439,7 +8713,6 @@
   },
   {
     "id": 727,
-    "entrezid": 878300,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9452,7 +8725,6 @@
   },
   {
     "id": 728,
-    "entrezid": 878301,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9465,7 +8737,6 @@
   },
   {
     "id": 729,
-    "entrezid": 878302,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9478,7 +8749,6 @@
   },
   {
     "id": 730,
-    "entrezid": 878303,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9491,7 +8761,6 @@
   },
   {
     "id": 731,
-    "entrezid": 878304,
     "description": "membrane-bound lytic murein transglycosylase D",
     "aliases": "-",
     "obsolete": false,
@@ -9504,7 +8773,6 @@
   },
   {
     "id": 732,
-    "entrezid": 878305,
     "description": "D-3-phosphoglycerate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -9517,7 +8785,6 @@
   },
   {
     "id": 733,
-    "entrezid": 878306,
     "description": "Mg transporter MgtE",
     "aliases": "-",
     "obsolete": false,
@@ -9530,7 +8797,6 @@
   },
   {
     "id": 734,
-    "entrezid": 878307,
     "description": "ATP-dependent protease ATP-binding subunit ClpX",
     "aliases": "-",
     "obsolete": false,
@@ -9543,7 +8809,6 @@
   },
   {
     "id": 735,
-    "entrezid": 878308,
     "description": "DNA-binding protein HU",
     "aliases": "-",
     "obsolete": false,
@@ -9556,7 +8821,6 @@
   },
   {
     "id": 736,
-    "entrezid": 878309,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9569,7 +8833,6 @@
   },
   {
     "id": 737,
-    "entrezid": 878310,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -9582,7 +8845,6 @@
   },
   {
     "id": 738,
-    "entrezid": 878311,
     "description": "NADH-dependent enoyl-ACP reductase",
     "aliases": "-",
     "obsolete": false,
@@ -9595,7 +8857,6 @@
   },
   {
     "id": 739,
-    "entrezid": 878312,
     "description": "lipopolysaccharide biosynthetic protein LpxO",
     "aliases": "-",
     "obsolete": false,
@@ -9608,7 +8869,6 @@
   },
   {
     "id": 740,
-    "entrezid": 878313,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9621,7 +8881,6 @@
   },
   {
     "id": 741,
-    "entrezid": 878314,
     "description": "cation efflux system protein",
     "aliases": "-",
     "obsolete": false,
@@ -9634,7 +8893,6 @@
   },
   {
     "id": 742,
-    "entrezid": 878315,
     "description": "aspartokinase",
     "aliases": "-",
     "obsolete": false,
@@ -9647,7 +8905,6 @@
   },
   {
     "id": 743,
-    "entrezid": 878316,
     "description": "lipoprotein",
     "aliases": "-",
     "obsolete": false,
@@ -9660,7 +8917,6 @@
   },
   {
     "id": 744,
-    "entrezid": 878317,
     "description": "iron-containing alcohol dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -9673,7 +8929,6 @@
   },
   {
     "id": 745,
-    "entrezid": 878318,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9686,7 +8941,6 @@
   },
   {
     "id": 746,
-    "entrezid": 878319,
     "description": "cytochrome C protein NapB",
     "aliases": "-",
     "obsolete": false,
@@ -9699,7 +8953,6 @@
   },
   {
     "id": 747,
-    "entrezid": 878320,
     "description": "nitrite extrusion protein 1",
     "aliases": "-",
     "obsolete": false,
@@ -9712,7 +8965,6 @@
   },
   {
     "id": 748,
-    "entrezid": 878321,
     "description": "two-component sensor NarX",
     "aliases": "-",
     "obsolete": false,
@@ -9725,7 +8977,6 @@
   },
   {
     "id": 749,
-    "entrezid": 878322,
     "description": "FAD-binding dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -9738,7 +8989,6 @@
   },
   {
     "id": 750,
-    "entrezid": 878323,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9751,7 +9001,6 @@
   },
   {
     "id": 751,
-    "entrezid": 878324,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9764,7 +9013,6 @@
   },
   {
     "id": 752,
-    "entrezid": 878325,
     "description": "50S ribosomal protein L11 methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -9777,7 +9025,6 @@
   },
   {
     "id": 753,
-    "entrezid": 878326,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9790,7 +9037,6 @@
   },
   {
     "id": 754,
-    "entrezid": 878327,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9803,7 +9049,6 @@
   },
   {
     "id": 755,
-    "entrezid": 878328,
     "description": "site-specific tyrosine recombinase XerC",
     "aliases": "-",
     "obsolete": false,
@@ -9816,7 +9061,6 @@
   },
   {
     "id": 756,
-    "entrezid": 878329,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9829,7 +9073,6 @@
   },
   {
     "id": 757,
-    "entrezid": 878330,
     "description": "histidine--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -9842,7 +9085,6 @@
   },
   {
     "id": 758,
-    "entrezid": 878331,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9855,7 +9097,6 @@
   },
   {
     "id": 759,
-    "entrezid": 878332,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9868,7 +9109,6 @@
   },
   {
     "id": 760,
-    "entrezid": 878333,
     "description": "exodeoxyribonuclease VII large subunit",
     "aliases": "-",
     "obsolete": false,
@@ -9881,7 +9121,6 @@
   },
   {
     "id": 761,
-    "entrezid": 878334,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -9894,7 +9133,6 @@
   },
   {
     "id": 762,
-    "entrezid": 878335,
     "description": "two-component sensor ParS",
     "aliases": "-",
     "obsolete": false,
@@ -9907,7 +9145,6 @@
   },
   {
     "id": 763,
-    "entrezid": 878336,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -9920,7 +9157,6 @@
   },
   {
     "id": 764,
-    "entrezid": 878337,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -9933,7 +9169,6 @@
   },
   {
     "id": 765,
-    "entrezid": 878338,
     "description": "chemotaxis-specific methylesterase",
     "aliases": "-",
     "obsolete": false,
@@ -9946,7 +9181,6 @@
   },
   {
     "id": 766,
-    "entrezid": 878339,
     "description": "imidazolonepropionase",
     "aliases": "-",
     "obsolete": false,
@@ -9959,7 +9193,6 @@
   },
   {
     "id": 767,
-    "entrezid": 878340,
     "description": "histidine/phenylalanine ammonia-lyase",
     "aliases": "-",
     "obsolete": false,
@@ -9972,7 +9205,6 @@
   },
   {
     "id": 768,
-    "entrezid": 878341,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -9985,7 +9217,6 @@
   },
   {
     "id": 769,
-    "entrezid": 878342,
     "description": "nitrogen regulatory protein P-II 2",
     "aliases": "-",
     "obsolete": false,
@@ -9998,7 +9229,6 @@
   },
   {
     "id": 770,
-    "entrezid": 878343,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10011,7 +9241,6 @@
   },
   {
     "id": 771,
-    "entrezid": 878344,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10024,7 +9253,6 @@
   },
   {
     "id": 772,
-    "entrezid": 878345,
     "description": "NAD(P) transhydrogenase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -10037,7 +9265,6 @@
   },
   {
     "id": 773,
-    "entrezid": 878346,
     "description": "NAD(P) transhydrogenase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -10050,7 +9277,6 @@
   },
   {
     "id": 774,
-    "entrezid": 878347,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10063,7 +9289,6 @@
   },
   {
     "id": 775,
-    "entrezid": 878348,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10076,7 +9301,6 @@
   },
   {
     "id": 776,
-    "entrezid": 878349,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10089,7 +9313,6 @@
   },
   {
     "id": 777,
-    "entrezid": 878350,
     "description": "exoenzyme T",
     "aliases": "-",
     "obsolete": false,
@@ -10102,7 +9325,6 @@
   },
   {
     "id": 778,
-    "entrezid": 878351,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -10115,7 +9337,6 @@
   },
   {
     "id": 779,
-    "entrezid": 878352,
     "description": "carbon storage regulator",
     "aliases": "-",
     "obsolete": false,
@@ -10128,7 +9349,6 @@
   },
   {
     "id": 780,
-    "entrezid": 878353,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -10141,7 +9361,6 @@
   },
   {
     "id": 781,
-    "entrezid": 878354,
     "description": "two-component response regulator ParR",
     "aliases": "-",
     "obsolete": false,
@@ -10154,7 +9373,6 @@
   },
   {
     "id": 782,
-    "entrezid": 878355,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10167,7 +9385,6 @@
   },
   {
     "id": 783,
-    "entrezid": 878356,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10180,7 +9397,6 @@
   },
   {
     "id": 784,
-    "entrezid": 878357,
     "description": "aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -10193,7 +9409,6 @@
   },
   {
     "id": 785,
-    "entrezid": 878358,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10206,7 +9421,6 @@
   },
   {
     "id": 786,
-    "entrezid": 878359,
     "description": "ATP-dependent Clp protease proteolytic subunit",
     "aliases": "-",
     "obsolete": false,
@@ -10219,7 +9433,6 @@
   },
   {
     "id": 787,
-    "entrezid": 878360,
     "description": "acetylpolyamine aminohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -10232,7 +9445,6 @@
   },
   {
     "id": 788,
-    "entrezid": 878361,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -10245,7 +9457,6 @@
   },
   {
     "id": 789,
-    "entrezid": 878362,
     "description": "twitching motility protein PilU",
     "aliases": "-",
     "obsolete": false,
@@ -10258,7 +9469,6 @@
   },
   {
     "id": 790,
-    "entrezid": 878363,
     "description": "colicin immunity protein",
     "aliases": "-",
     "obsolete": false,
@@ -10271,7 +9481,6 @@
   },
   {
     "id": 791,
-    "entrezid": 878364,
     "description": "C4-dicarboxylate-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -10284,7 +9493,6 @@
   },
   {
     "id": 792,
-    "entrezid": 878365,
     "description": "bacteriophage protein",
     "aliases": "-",
     "obsolete": false,
@@ -10297,7 +9505,6 @@
   },
   {
     "id": 793,
-    "entrezid": 878366,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10310,7 +9517,6 @@
   },
   {
     "id": 794,
-    "entrezid": 878367,
     "description": "amino acid permease",
     "aliases": "-",
     "obsolete": false,
@@ -10323,7 +9529,6 @@
   },
   {
     "id": 795,
-    "entrezid": 878368,
     "description": "histidine ammonia-lyase",
     "aliases": "-",
     "obsolete": false,
@@ -10336,7 +9541,6 @@
   },
   {
     "id": 796,
-    "entrezid": 878369,
     "description": "peptidyl-prolyl cis-trans isomerase D",
     "aliases": "-",
     "obsolete": false,
@@ -10349,7 +9553,6 @@
   },
   {
     "id": 797,
-    "entrezid": 878370,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -10362,7 +9565,6 @@
   },
   {
     "id": 798,
-    "entrezid": 878371,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10375,7 +9577,6 @@
   },
   {
     "id": 799,
-    "entrezid": 878372,
     "description": "membrane-bound lytic murein transglycosylase A",
     "aliases": "-",
     "obsolete": false,
@@ -10388,7 +9589,6 @@
   },
   {
     "id": 800,
-    "entrezid": 878373,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10401,7 +9601,6 @@
   },
   {
     "id": 801,
-    "entrezid": 878374,
     "description": "chloramphenicol acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -10414,7 +9613,6 @@
   },
   {
     "id": 802,
-    "entrezid": 878375,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10427,7 +9625,6 @@
   },
   {
     "id": 803,
-    "entrezid": 878376,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -10440,7 +9637,6 @@
   },
   {
     "id": 804,
-    "entrezid": 878377,
     "description": "hydroxyacylglutathione hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -10453,7 +9649,6 @@
   },
   {
     "id": 805,
-    "entrezid": 878378,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10466,7 +9661,6 @@
   },
   {
     "id": 806,
-    "entrezid": 878379,
     "description": "S-adenosylmethionine synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -10479,7 +9673,6 @@
   },
   {
     "id": 807,
-    "entrezid": 878380,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -10492,7 +9685,6 @@
   },
   {
     "id": 808,
-    "entrezid": 878381,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10505,7 +9697,6 @@
   },
   {
     "id": 809,
-    "entrezid": 878382,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10518,7 +9709,6 @@
   },
   {
     "id": 810,
-    "entrezid": 878383,
     "description": "beta-alanine degradation protein BauB",
     "aliases": "-",
     "obsolete": false,
@@ -10531,7 +9721,6 @@
   },
   {
     "id": 811,
-    "entrezid": 878384,
     "description": "ornithine utilization transcriptional regulator OruR",
     "aliases": "-",
     "obsolete": false,
@@ -10544,7 +9733,6 @@
   },
   {
     "id": 812,
-    "entrezid": 878385,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10557,7 +9745,6 @@
   },
   {
     "id": 813,
-    "entrezid": 878386,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10570,7 +9757,6 @@
   },
   {
     "id": 814,
-    "entrezid": 878387,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10583,7 +9769,6 @@
   },
   {
     "id": 815,
-    "entrezid": 878388,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10596,7 +9781,6 @@
   },
   {
     "id": 816,
-    "entrezid": 878389,
     "description": "twitching motility protein PilT",
     "aliases": "-",
     "obsolete": false,
@@ -10609,7 +9793,6 @@
   },
   {
     "id": 817,
-    "entrezid": 878390,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10622,7 +9805,6 @@
   },
   {
     "id": 818,
-    "entrezid": 878391,
     "description": "sensor protein",
     "aliases": "-",
     "obsolete": false,
@@ -10635,7 +9817,6 @@
   },
   {
     "id": 819,
-    "entrezid": 878392,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10648,7 +9829,6 @@
   },
   {
     "id": 820,
-    "entrezid": 878393,
     "description": "carbon-phosphorus lyase complex subunit",
     "aliases": "-",
     "obsolete": false,
@@ -10661,7 +9841,6 @@
   },
   {
     "id": 821,
-    "entrezid": 878394,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10674,7 +9853,6 @@
   },
   {
     "id": 822,
-    "entrezid": 878395,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10687,7 +9865,6 @@
   },
   {
     "id": 823,
-    "entrezid": 878396,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -10700,7 +9877,6 @@
   },
   {
     "id": 824,
-    "entrezid": 878397,
     "description": "ATPase",
     "aliases": "-",
     "obsolete": false,
@@ -10713,7 +9889,6 @@
   },
   {
     "id": 825,
-    "entrezid": 878398,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -10726,7 +9901,6 @@
   },
   {
     "id": 826,
-    "entrezid": 878399,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10739,7 +9913,6 @@
   },
   {
     "id": 827,
-    "entrezid": 878400,
     "description": "anthranilate synthase component II",
     "aliases": "-",
     "obsolete": false,
@@ -10752,7 +9925,6 @@
   },
   {
     "id": 828,
-    "entrezid": 878401,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10765,7 +9937,6 @@
   },
   {
     "id": 829,
-    "entrezid": 878402,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10778,7 +9949,6 @@
   },
   {
     "id": 830,
-    "entrezid": 878403,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10791,7 +9961,6 @@
   },
   {
     "id": 831,
-    "entrezid": 878404,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10804,7 +9973,6 @@
   },
   {
     "id": 832,
-    "entrezid": 878405,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10817,7 +9985,6 @@
   },
   {
     "id": 833,
-    "entrezid": 878406,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10830,7 +9997,6 @@
   },
   {
     "id": 834,
-    "entrezid": 878407,
     "description": "solute-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -10843,7 +10009,6 @@
   },
   {
     "id": 835,
-    "entrezid": 878408,
     "description": "transcriptional regulator PhhR",
     "aliases": "-",
     "obsolete": false,
@@ -10856,7 +10021,6 @@
   },
   {
     "id": 836,
-    "entrezid": 878409,
     "description": "nitrate reductase catalytic subunit",
     "aliases": "-",
     "obsolete": false,
@@ -10869,7 +10033,6 @@
   },
   {
     "id": 837,
-    "entrezid": 878410,
     "description": "ECF sigma factor VreI",
     "aliases": "-",
     "obsolete": false,
@@ -10882,7 +10045,6 @@
   },
   {
     "id": 838,
-    "entrezid": 878411,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -10895,7 +10057,6 @@
   },
   {
     "id": 839,
-    "entrezid": 878412,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10908,7 +10069,6 @@
   },
   {
     "id": 840,
-    "entrezid": 878413,
     "description": "pyrroline-5-carboxylate reductase",
     "aliases": "-",
     "obsolete": false,
@@ -10921,7 +10081,6 @@
   },
   {
     "id": 841,
-    "entrezid": 878414,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10934,7 +10093,6 @@
   },
   {
     "id": 842,
-    "entrezid": 878415,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10947,7 +10105,6 @@
   },
   {
     "id": 843,
-    "entrezid": 878416,
     "description": "protein FimX",
     "aliases": "-",
     "obsolete": false,
@@ -10960,7 +10117,6 @@
   },
   {
     "id": 844,
-    "entrezid": 878417,
     "description": "chromosome replication initiator DnaA",
     "aliases": "-",
     "obsolete": false,
@@ -10973,7 +10129,6 @@
   },
   {
     "id": 845,
-    "entrezid": 878418,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -10986,7 +10141,6 @@
   },
   {
     "id": 846,
-    "entrezid": 878419,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -10999,7 +10153,6 @@
   },
   {
     "id": 847,
-    "entrezid": 878420,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -11012,7 +10165,6 @@
   },
   {
     "id": 848,
-    "entrezid": 878421,
     "description": "anthranilate synthase component I",
     "aliases": "-",
     "obsolete": false,
@@ -11025,7 +10177,6 @@
   },
   {
     "id": 849,
-    "entrezid": 878422,
     "description": "nicotinate-nucleotide pyrophosphorylase",
     "aliases": "-",
     "obsolete": false,
@@ -11038,7 +10189,6 @@
   },
   {
     "id": 850,
-    "entrezid": 878423,
     "description": "type 4 fimbrial protein PilA",
     "aliases": "-",
     "obsolete": false,
@@ -11051,7 +10201,6 @@
   },
   {
     "id": 851,
-    "entrezid": 878424,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11064,7 +10213,6 @@
   },
   {
     "id": 852,
-    "entrezid": 878425,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11077,7 +10225,6 @@
   },
   {
     "id": 853,
-    "entrezid": 878426,
     "description": "glutathione S-transferase",
     "aliases": "-",
     "obsolete": false,
@@ -11090,7 +10237,6 @@
   },
   {
     "id": 854,
-    "entrezid": 878427,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -11103,7 +10249,6 @@
   },
   {
     "id": 855,
-    "entrezid": 878428,
     "description": "cytochrome C",
     "aliases": "-",
     "obsolete": false,
@@ -11116,7 +10261,6 @@
   },
   {
     "id": 856,
-    "entrezid": 878429,
     "description": "serine/threonine transporter SstT",
     "aliases": "-",
     "obsolete": false,
@@ -11129,7 +10273,6 @@
   },
   {
     "id": 857,
-    "entrezid": 878430,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11142,7 +10285,6 @@
   },
   {
     "id": 858,
-    "entrezid": 878431,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -11155,7 +10297,6 @@
   },
   {
     "id": 859,
-    "entrezid": 878432,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11168,7 +10309,6 @@
   },
   {
     "id": 860,
-    "entrezid": 878433,
     "description": "4'-phosphopantetheinyl transferase",
     "aliases": "-",
     "obsolete": false,
@@ -11181,7 +10321,6 @@
   },
   {
     "id": 861,
-    "entrezid": 878434,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11194,7 +10333,6 @@
   },
   {
     "id": 862,
-    "entrezid": 878435,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11207,7 +10345,6 @@
   },
   {
     "id": 863,
-    "entrezid": 878436,
     "description": "leucine-responsive regulatory protein",
     "aliases": "-",
     "obsolete": false,
@@ -11220,7 +10357,6 @@
   },
   {
     "id": 864,
-    "entrezid": 878437,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11233,7 +10369,6 @@
   },
   {
     "id": 865,
-    "entrezid": 878438,
     "description": "two-component response regulator PhoB",
     "aliases": "-",
     "obsolete": false,
@@ -11246,7 +10381,6 @@
   },
   {
     "id": 866,
-    "entrezid": 878439,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11259,7 +10393,6 @@
   },
   {
     "id": 867,
-    "entrezid": 878440,
     "description": "5-(carboxyamino)imidazole ribonucleotide synthase",
     "aliases": "-",
     "obsolete": false,
@@ -11272,7 +10405,6 @@
   },
   {
     "id": 868,
-    "entrezid": 878441,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11285,7 +10417,6 @@
   },
   {
     "id": 869,
-    "entrezid": 878442,
     "description": "outer membrane porin F",
     "aliases": "-",
     "obsolete": false,
@@ -11298,7 +10429,6 @@
   },
   {
     "id": 870,
-    "entrezid": 878443,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -11311,7 +10441,6 @@
   },
   {
     "id": 871,
-    "entrezid": 878444,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11324,7 +10453,6 @@
   },
   {
     "id": 872,
-    "entrezid": 878445,
     "description": "L-serine dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -11337,7 +10465,6 @@
   },
   {
     "id": 873,
-    "entrezid": 878446,
     "description": "S-adenosylmethionine decarboxylase",
     "aliases": "-",
     "obsolete": false,
@@ -11350,7 +10477,6 @@
   },
   {
     "id": 874,
-    "entrezid": 878447,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -11363,7 +10489,6 @@
   },
   {
     "id": 875,
-    "entrezid": 878448,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11376,7 +10501,6 @@
   },
   {
     "id": 876,
-    "entrezid": 878449,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11389,7 +10513,6 @@
   },
   {
     "id": 877,
-    "entrezid": 878450,
     "description": "type 4 fimbrial biogenesis protein PilY2",
     "aliases": "-",
     "obsolete": false,
@@ -11402,7 +10525,6 @@
   },
   {
     "id": 878,
-    "entrezid": 878451,
     "description": "type 4 fimbrial biogenesis protein PilE",
     "aliases": "-",
     "obsolete": false,
@@ -11415,7 +10537,6 @@
   },
   {
     "id": 879,
-    "entrezid": 878452,
     "description": "exoenzyme S synthesis protein ExsC",
     "aliases": "-",
     "obsolete": false,
@@ -11428,7 +10549,6 @@
   },
   {
     "id": 880,
-    "entrezid": 878453,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11441,7 +10561,6 @@
   },
   {
     "id": 881,
-    "entrezid": 878454,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -11454,7 +10573,6 @@
   },
   {
     "id": 882,
-    "entrezid": 878455,
     "description": "amino acid permease",
     "aliases": "-",
     "obsolete": false,
@@ -11467,7 +10585,6 @@
   },
   {
     "id": 883,
-    "entrezid": 878456,
     "description": "sigma factor regulator VreR",
     "aliases": "-",
     "obsolete": false,
@@ -11480,7 +10597,6 @@
   },
   {
     "id": 884,
-    "entrezid": 878457,
     "description": "paerucumarin biosynthesis protein PvcB",
     "aliases": "-",
     "obsolete": false,
@@ -11493,7 +10609,6 @@
   },
   {
     "id": 885,
-    "entrezid": 878458,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11506,7 +10621,6 @@
   },
   {
     "id": 886,
-    "entrezid": 878459,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11519,7 +10633,6 @@
   },
   {
     "id": 887,
-    "entrezid": 878460,
     "description": "NADH dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -11532,7 +10645,6 @@
   },
   {
     "id": 888,
-    "entrezid": 878461,
     "description": "protein AmbA",
     "aliases": "-",
     "obsolete": false,
@@ -11545,7 +10657,6 @@
   },
   {
     "id": 889,
-    "entrezid": 878462,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11558,7 +10669,6 @@
   },
   {
     "id": 890,
-    "entrezid": 878463,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11571,7 +10681,6 @@
   },
   {
     "id": 891,
-    "entrezid": 878464,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11584,7 +10693,6 @@
   },
   {
     "id": 892,
-    "entrezid": 878465,
     "description": "dihydroorotase",
     "aliases": "-",
     "obsolete": false,
@@ -11597,7 +10705,6 @@
   },
   {
     "id": 893,
-    "entrezid": 878466,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11610,7 +10717,6 @@
   },
   {
     "id": 894,
-    "entrezid": 878467,
     "description": "amino acid permease",
     "aliases": "-",
     "obsolete": false,
@@ -11623,7 +10729,6 @@
   },
   {
     "id": 895,
-    "entrezid": 878468,
     "description": "DNA mismatch repair protein",
     "aliases": "-",
     "obsolete": false,
@@ -11636,7 +10741,6 @@
   },
   {
     "id": 896,
-    "entrezid": 878469,
     "description": "N-acetylmuramoyl-L-alanine amidase",
     "aliases": "-",
     "obsolete": false,
@@ -11649,7 +10753,6 @@
   },
   {
     "id": 897,
-    "entrezid": 878470,
     "description": "branched-chain alpha-keto acid dehydrogenase complex dihydrolipoyl dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -11662,7 +10765,6 @@
   },
   {
     "id": 898,
-    "entrezid": 878471,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -11675,7 +10777,6 @@
   },
   {
     "id": 899,
-    "entrezid": 878472,
     "description": "undecaprenyl-phosphate 4-deoxy-4-formamido-L-arabinose transferase",
     "aliases": "-",
     "obsolete": false,
@@ -11688,7 +10789,6 @@
   },
   {
     "id": 900,
-    "entrezid": 878473,
     "description": "bifunctional UDP-glucuronic acid decarboxylase/UDP-4-amino-4-deoxy-L-arabinose formyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -11701,7 +10801,6 @@
   },
   {
     "id": 901,
-    "entrezid": 878474,
     "description": "porin",
     "aliases": "-",
     "obsolete": false,
@@ -11714,7 +10813,6 @@
   },
   {
     "id": 902,
-    "entrezid": 878475,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11727,7 +10825,6 @@
   },
   {
     "id": 903,
-    "entrezid": 878476,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -11740,7 +10837,6 @@
   },
   {
     "id": 904,
-    "entrezid": 878477,
     "description": "phenazine biosynthesis protein PhzA",
     "aliases": "-",
     "obsolete": false,
@@ -11753,7 +10849,6 @@
   },
   {
     "id": 905,
-    "entrezid": 878478,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11766,7 +10861,6 @@
   },
   {
     "id": 906,
-    "entrezid": 878479,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11779,7 +10873,6 @@
   },
   {
     "id": 907,
-    "entrezid": 878480,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11792,7 +10885,6 @@
   },
   {
     "id": 908,
-    "entrezid": 878481,
     "description": "peptidyl-prolyl cis-trans isomerase C1",
     "aliases": "-",
     "obsolete": false,
@@ -11805,7 +10897,6 @@
   },
   {
     "id": 909,
-    "entrezid": 878482,
     "description": "oligopeptidase A",
     "aliases": "-",
     "obsolete": false,
@@ -11818,7 +10909,6 @@
   },
   {
     "id": 910,
-    "entrezid": 878483,
     "description": "cytochrome C5",
     "aliases": "-",
     "obsolete": false,
@@ -11831,7 +10921,6 @@
   },
   {
     "id": 911,
-    "entrezid": 878484,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -11844,7 +10933,6 @@
   },
   {
     "id": 912,
-    "entrezid": 878485,
     "description": "bacteriophage protein",
     "aliases": "-",
     "obsolete": false,
@@ -11857,7 +10945,6 @@
   },
   {
     "id": 913,
-    "entrezid": 878486,
     "description": "phosphoribosyl-ATP pyrophosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -11870,7 +10957,6 @@
   },
   {
     "id": 914,
-    "entrezid": 878487,
     "description": "twin-arginine translocation protein TatA",
     "aliases": "-",
     "obsolete": false,
@@ -11883,7 +10969,6 @@
   },
   {
     "id": 915,
-    "entrezid": 878488,
     "description": "biotin synthesis protein BioC",
     "aliases": "-",
     "obsolete": false,
@@ -11896,7 +10981,6 @@
   },
   {
     "id": 916,
-    "entrezid": 878489,
     "description": "ring-hydroxylating dioxygenase small subunit",
     "aliases": "-",
     "obsolete": false,
@@ -11909,7 +10993,6 @@
   },
   {
     "id": 917,
-    "entrezid": 878490,
     "description": "biofilm formation protein PslE",
     "aliases": "-",
     "obsolete": false,
@@ -11922,7 +11005,6 @@
   },
   {
     "id": 918,
-    "entrezid": 878491,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11935,7 +11017,6 @@
   },
   {
     "id": 919,
-    "entrezid": 878492,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11948,7 +11029,6 @@
   },
   {
     "id": 920,
-    "entrezid": 878493,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11961,7 +11041,6 @@
   },
   {
     "id": 921,
-    "entrezid": 878494,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -11974,7 +11053,6 @@
   },
   {
     "id": 922,
-    "entrezid": 878495,
     "description": "5'-nucleotidase",
     "aliases": "-",
     "obsolete": false,
@@ -11987,7 +11065,6 @@
   },
   {
     "id": 923,
-    "entrezid": 878496,
     "description": "UDP-glucose 4-epimerase",
     "aliases": "-",
     "obsolete": false,
@@ -12000,7 +11077,6 @@
   },
   {
     "id": 924,
-    "entrezid": 878497,
     "description": "glutamine amidotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -12013,7 +11089,6 @@
   },
   {
     "id": 925,
-    "entrezid": 878498,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12026,7 +11101,6 @@
   },
   {
     "id": 926,
-    "entrezid": 878499,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12039,7 +11113,6 @@
   },
   {
     "id": 927,
-    "entrezid": 878500,
     "description": "disulfide bond formation protein",
     "aliases": "-",
     "obsolete": false,
@@ -12052,7 +11125,6 @@
   },
   {
     "id": 928,
-    "entrezid": 878501,
     "description": "branched-chain amino acid ABC transporter substrate-binding protein BraC",
     "aliases": "-",
     "obsolete": false,
@@ -12065,7 +11137,6 @@
   },
   {
     "id": 929,
-    "entrezid": 878502,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12078,7 +11149,6 @@
   },
   {
     "id": 930,
-    "entrezid": 878503,
     "description": "bifunctional proline dehydrogenase/pyrroline-5-carboxylate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -12091,7 +11161,6 @@
   },
   {
     "id": 931,
-    "entrezid": 878504,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12104,7 +11173,6 @@
   },
   {
     "id": 932,
-    "entrezid": 878505,
     "description": "ferredoxin protein NapF",
     "aliases": "-",
     "obsolete": false,
@@ -12117,7 +11185,6 @@
   },
   {
     "id": 933,
-    "entrezid": 878507,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12130,7 +11197,6 @@
   },
   {
     "id": 934,
-    "entrezid": 878508,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12143,7 +11209,6 @@
   },
   {
     "id": 935,
-    "entrezid": 878509,
     "description": "ATP synthase subunit delta",
     "aliases": "-",
     "obsolete": false,
@@ -12156,7 +11221,6 @@
   },
   {
     "id": 936,
-    "entrezid": 878510,
     "description": "ATP synthase subunit B",
     "aliases": "-",
     "obsolete": false,
@@ -12169,7 +11233,6 @@
   },
   {
     "id": 937,
-    "entrezid": 878511,
     "description": "two-component sensor PhoR",
     "aliases": "-",
     "obsolete": false,
@@ -12182,7 +11245,6 @@
   },
   {
     "id": 938,
-    "entrezid": 878512,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12195,7 +11257,6 @@
   },
   {
     "id": 939,
-    "entrezid": 878513,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -12208,7 +11269,6 @@
   },
   {
     "id": 940,
-    "entrezid": 878514,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12221,7 +11281,6 @@
   },
   {
     "id": 941,
-    "entrezid": 878515,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -12234,7 +11293,6 @@
   },
   {
     "id": 942,
-    "entrezid": 878516,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12247,7 +11305,6 @@
   },
   {
     "id": 943,
-    "entrezid": 878517,
     "description": "esterase",
     "aliases": "-",
     "obsolete": false,
@@ -12260,7 +11317,6 @@
   },
   {
     "id": 944,
-    "entrezid": 878518,
     "description": "transcriptional regulator PcaQ",
     "aliases": "-",
     "obsolete": false,
@@ -12273,7 +11329,6 @@
   },
   {
     "id": 945,
-    "entrezid": 878519,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12286,7 +11341,6 @@
   },
   {
     "id": 946,
-    "entrezid": 878520,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -12299,7 +11353,6 @@
   },
   {
     "id": 947,
-    "entrezid": 878521,
     "description": "branched-chain amino acid ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -12312,7 +11365,6 @@
   },
   {
     "id": 948,
-    "entrezid": 878522,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -12325,7 +11377,6 @@
   },
   {
     "id": 949,
-    "entrezid": 878523,
     "description": "transketolase",
     "aliases": "-",
     "obsolete": false,
@@ -12338,7 +11389,6 @@
   },
   {
     "id": 950,
-    "entrezid": 878524,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -12351,7 +11401,6 @@
   },
   {
     "id": 951,
-    "entrezid": 878525,
     "description": "glucose-6-phosphate 1-dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -12364,7 +11413,6 @@
   },
   {
     "id": 952,
-    "entrezid": 878526,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -12377,7 +11425,6 @@
   },
   {
     "id": 953,
-    "entrezid": 878527,
     "description": "RNA polymerase sigma factor SigX",
     "aliases": "-",
     "obsolete": false,
@@ -12390,7 +11437,6 @@
   },
   {
     "id": 954,
-    "entrezid": 878528,
     "description": "translocation protein in type III secretion",
     "aliases": "-",
     "obsolete": false,
@@ -12403,7 +11449,6 @@
   },
   {
     "id": 955,
-    "entrezid": 878530,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12416,7 +11461,6 @@
   },
   {
     "id": 956,
-    "entrezid": 878531,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -12429,7 +11473,6 @@
   },
   {
     "id": 957,
-    "entrezid": 878532,
     "description": "acyl-CoA thiolase",
     "aliases": "-",
     "obsolete": false,
@@ -12442,7 +11485,6 @@
   },
   {
     "id": 958,
-    "entrezid": 878533,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12455,7 +11497,6 @@
   },
   {
     "id": 959,
-    "entrezid": 878534,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12468,7 +11509,6 @@
   },
   {
     "id": 960,
-    "entrezid": 878535,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12481,7 +11521,6 @@
   },
   {
     "id": 961,
-    "entrezid": 878536,
     "description": "flagellar basal body P-ring protein",
     "aliases": "-",
     "obsolete": false,
@@ -12494,7 +11533,6 @@
   },
   {
     "id": 962,
-    "entrezid": 878537,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12507,7 +11545,6 @@
   },
   {
     "id": 963,
-    "entrezid": 878538,
     "description": "C4-dicarboxylate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -12520,7 +11557,6 @@
   },
   {
     "id": 964,
-    "entrezid": 878539,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12533,7 +11569,6 @@
   },
   {
     "id": 965,
-    "entrezid": 878540,
     "description": "transmembrane sensor",
     "aliases": "-",
     "obsolete": false,
@@ -12546,7 +11581,6 @@
   },
   {
     "id": 966,
-    "entrezid": 878541,
     "description": "imidazole glycerol phosphate synthase subunit HisF",
     "aliases": "-",
     "obsolete": false,
@@ -12559,7 +11593,6 @@
   },
   {
     "id": 967,
-    "entrezid": 878542,
     "description": "1-(5-phosphoribosyl)-5-[(5-phosphoribosylamino)methylideneamino] imidazole-4-carboxamide isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -12572,7 +11605,6 @@
   },
   {
     "id": 968,
-    "entrezid": 878543,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12585,7 +11617,6 @@
   },
   {
     "id": 969,
-    "entrezid": 878544,
     "description": "fimbrial subunit CupA4",
     "aliases": "-",
     "obsolete": false,
@@ -12598,7 +11629,6 @@
   },
   {
     "id": 970,
-    "entrezid": 878545,
     "description": "alpha-1,6-rhamnosyltransferase MigA",
     "aliases": "-",
     "obsolete": false,
@@ -12611,7 +11641,6 @@
   },
   {
     "id": 971,
-    "entrezid": 878546,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12624,7 +11653,6 @@
   },
   {
     "id": 972,
-    "entrezid": 878547,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12637,7 +11665,6 @@
   },
   {
     "id": 973,
-    "entrezid": 878548,
     "description": "tRNA 2-selenouridine synthase",
     "aliases": "-",
     "obsolete": false,
@@ -12650,7 +11677,6 @@
   },
   {
     "id": 974,
-    "entrezid": 878549,
     "description": "homoserine O-acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -12663,7 +11689,6 @@
   },
   {
     "id": 975,
-    "entrezid": 878550,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12676,7 +11701,6 @@
   },
   {
     "id": 976,
-    "entrezid": 878551,
     "description": "alginate biosynthesis protein AlgX",
     "aliases": "-",
     "obsolete": false,
@@ -12689,7 +11713,6 @@
   },
   {
     "id": 977,
-    "entrezid": 878552,
     "description": "alginate lyase",
     "aliases": "-",
     "obsolete": false,
@@ -12702,7 +11725,6 @@
   },
   {
     "id": 978,
-    "entrezid": 878553,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12715,7 +11737,6 @@
   },
   {
     "id": 979,
-    "entrezid": 878554,
     "description": "esterase TesA",
     "aliases": "-",
     "obsolete": false,
@@ -12728,7 +11749,6 @@
   },
   {
     "id": 980,
-    "entrezid": 878555,
     "description": "dehydrocarnitine CoA transferase subunit B",
     "aliases": "-",
     "obsolete": false,
@@ -12741,7 +11761,6 @@
   },
   {
     "id": 981,
-    "entrezid": 878556,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12754,7 +11773,6 @@
   },
   {
     "id": 982,
-    "entrezid": 878557,
     "description": "exoenzyme S synthesis protein ExsB",
     "aliases": "-",
     "obsolete": false,
@@ -12767,7 +11785,6 @@
   },
   {
     "id": 983,
-    "entrezid": 878558,
     "description": "phosphoserine phosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -12780,7 +11797,6 @@
   },
   {
     "id": 984,
-    "entrezid": 878559,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12793,7 +11809,6 @@
   },
   {
     "id": 985,
-    "entrezid": 878560,
     "description": "phosphoadenosine phosphosulfate reductase",
     "aliases": "-",
     "obsolete": false,
@@ -12806,7 +11821,6 @@
   },
   {
     "id": 986,
-    "entrezid": 878561,
     "description": "peptidyl-tRNA hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -12819,7 +11833,6 @@
   },
   {
     "id": 987,
-    "entrezid": 878562,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -12832,7 +11845,6 @@
   },
   {
     "id": 988,
-    "entrezid": 878563,
     "description": "transmembrane sensor",
     "aliases": "-",
     "obsolete": false,
@@ -12845,7 +11857,6 @@
   },
   {
     "id": 989,
-    "entrezid": 878564,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -12858,7 +11869,6 @@
   },
   {
     "id": 990,
-    "entrezid": 878565,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12871,7 +11881,6 @@
   },
   {
     "id": 991,
-    "entrezid": 878566,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12884,7 +11893,6 @@
   },
   {
     "id": 992,
-    "entrezid": 878567,
     "description": "tRNA (mo5U34)-methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -12897,7 +11905,6 @@
   },
   {
     "id": 993,
-    "entrezid": 878568,
     "description": "rRNA methylase",
     "aliases": "-",
     "obsolete": false,
@@ -12910,7 +11917,6 @@
   },
   {
     "id": 994,
-    "entrezid": 878569,
     "description": "preprotein translocase subunit SecB",
     "aliases": "-",
     "obsolete": false,
@@ -12923,7 +11929,6 @@
   },
   {
     "id": 995,
-    "entrezid": 878570,
     "description": "glutathione reductase",
     "aliases": "-",
     "obsolete": false,
@@ -12936,7 +11941,6 @@
   },
   {
     "id": 996,
-    "entrezid": 878571,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -12949,7 +11953,6 @@
   },
   {
     "id": 997,
-    "entrezid": 878572,
     "description": "dephospho-CoA kinase",
     "aliases": "-",
     "obsolete": false,
@@ -12962,7 +11965,6 @@
   },
   {
     "id": 998,
-    "entrezid": 878573,
     "description": "zinc-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -12975,7 +11977,6 @@
   },
   {
     "id": 999,
-    "entrezid": 878574,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -12988,7 +11989,6 @@
   },
   {
     "id": 1000,
-    "entrezid": 878575,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13001,7 +12001,6 @@
   },
   {
     "id": 1001,
-    "entrezid": 878576,
     "description": "flagellar basal body rod protein FlgF",
     "aliases": "-",
     "obsolete": false,
@@ -13014,7 +12013,6 @@
   },
   {
     "id": 1002,
-    "entrezid": 878577,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13027,7 +12025,6 @@
   },
   {
     "id": 1003,
-    "entrezid": 878578,
     "description": "peptidoglycan hydrolase FlgJ",
     "aliases": "-",
     "obsolete": false,
@@ -13040,7 +12037,6 @@
   },
   {
     "id": 1004,
-    "entrezid": 878579,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -13053,7 +12049,6 @@
   },
   {
     "id": 1005,
-    "entrezid": 878580,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13066,7 +12061,6 @@
   },
   {
     "id": 1006,
-    "entrezid": 878581,
     "description": "sulfite reductase",
     "aliases": "-",
     "obsolete": false,
@@ -13079,7 +12073,6 @@
   },
   {
     "id": 1007,
-    "entrezid": 878582,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13092,7 +12085,6 @@
   },
   {
     "id": 1008,
-    "entrezid": 878583,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13105,7 +12097,6 @@
   },
   {
     "id": 1009,
-    "entrezid": 878584,
     "description": "nitrate reductase protein NapE",
     "aliases": "-",
     "obsolete": false,
@@ -13118,7 +12109,6 @@
   },
   {
     "id": 1010,
-    "entrezid": 878585,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13131,7 +12121,6 @@
   },
   {
     "id": 1011,
-    "entrezid": 878586,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -13144,7 +12133,6 @@
   },
   {
     "id": 1012,
-    "entrezid": 878587,
     "description": "chitinase",
     "aliases": "-",
     "obsolete": false,
@@ -13157,7 +12145,6 @@
   },
   {
     "id": 1013,
-    "entrezid": 878588,
     "description": "N-succinylarginine dihydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -13170,7 +12157,6 @@
   },
   {
     "id": 1014,
-    "entrezid": 878589,
     "description": "taurine dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -13183,7 +12169,6 @@
   },
   {
     "id": 1015,
-    "entrezid": 878590,
     "description": "aldehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -13196,7 +12181,6 @@
   },
   {
     "id": 1016,
-    "entrezid": 878591,
     "description": "kynurenine formamidase KynB",
     "aliases": "-",
     "obsolete": false,
@@ -13209,7 +12193,6 @@
   },
   {
     "id": 1017,
-    "entrezid": 878592,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13222,7 +12205,6 @@
   },
   {
     "id": 1018,
-    "entrezid": 878593,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13235,7 +12217,6 @@
   },
   {
     "id": 1019,
-    "entrezid": 878594,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -13248,7 +12229,6 @@
   },
   {
     "id": 1020,
-    "entrezid": 878595,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -13261,7 +12241,6 @@
   },
   {
     "id": 1021,
-    "entrezid": 878596,
     "description": "lysine-specific pyridoxal 5'-phosphate-dependent carboxylase LdcA",
     "aliases": "-",
     "obsolete": false,
@@ -13274,7 +12253,6 @@
   },
   {
     "id": 1022,
-    "entrezid": 878597,
     "description": "phosphoenolpyruvate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -13287,7 +12265,6 @@
   },
   {
     "id": 1023,
-    "entrezid": 878598,
     "description": "secretion protein XqhA",
     "aliases": "-",
     "obsolete": false,
@@ -13300,7 +12277,6 @@
   },
   {
     "id": 1024,
-    "entrezid": 878599,
     "description": "transcriptional regulator OpdE",
     "aliases": "-",
     "obsolete": false,
@@ -13313,7 +12289,6 @@
   },
   {
     "id": 1025,
-    "entrezid": 878600,
     "description": "3-hydroxyacyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -13326,7 +12301,6 @@
   },
   {
     "id": 1026,
-    "entrezid": 878601,
     "description": "hemagglutinin",
     "aliases": "-",
     "obsolete": false,
@@ -13339,7 +12313,6 @@
   },
   {
     "id": 1027,
-    "entrezid": 878602,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -13352,7 +12325,6 @@
   },
   {
     "id": 1028,
-    "entrezid": 878603,
     "description": "aspartate ammonia-lyase",
     "aliases": "-",
     "obsolete": false,
@@ -13365,7 +12337,6 @@
   },
   {
     "id": 1029,
-    "entrezid": 878604,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13378,7 +12349,6 @@
   },
   {
     "id": 1030,
-    "entrezid": 878605,
     "description": "ferripyoverdine receptor",
     "aliases": "-",
     "obsolete": false,
@@ -13391,7 +12361,6 @@
   },
   {
     "id": 1031,
-    "entrezid": 878606,
     "description": "serine/threonine-protein kinase",
     "aliases": "-",
     "obsolete": false,
@@ -13404,7 +12373,6 @@
   },
   {
     "id": 1032,
-    "entrezid": 878607,
     "description": "threonine dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -13417,7 +12385,6 @@
   },
   {
     "id": 1033,
-    "entrezid": 878608,
     "description": "aldehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -13430,7 +12397,6 @@
   },
   {
     "id": 1034,
-    "entrezid": 878609,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13443,7 +12409,6 @@
   },
   {
     "id": 1035,
-    "entrezid": 878610,
     "description": "carboxyl-terminal protease",
     "aliases": "-",
     "obsolete": false,
@@ -13456,7 +12421,6 @@
   },
   {
     "id": 1036,
-    "entrezid": 878611,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13469,7 +12433,6 @@
   },
   {
     "id": 1037,
-    "entrezid": 878612,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13482,7 +12445,6 @@
   },
   {
     "id": 1038,
-    "entrezid": 878613,
     "description": "N-acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -13495,7 +12457,6 @@
   },
   {
     "id": 1039,
-    "entrezid": 878614,
     "description": "fructokinase",
     "aliases": "-",
     "obsolete": false,
@@ -13508,7 +12469,6 @@
   },
   {
     "id": 1040,
-    "entrezid": 878615,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13521,7 +12481,6 @@
   },
   {
     "id": 1041,
-    "entrezid": 878616,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13534,7 +12493,6 @@
   },
   {
     "id": 1042,
-    "entrezid": 878617,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13547,7 +12505,6 @@
   },
   {
     "id": 1043,
-    "entrezid": 878618,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13560,7 +12517,6 @@
   },
   {
     "id": 1044,
-    "entrezid": 878619,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13573,7 +12529,6 @@
   },
   {
     "id": 1045,
-    "entrezid": 878620,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13586,7 +12541,6 @@
   },
   {
     "id": 1046,
-    "entrezid": 878621,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -13599,7 +12553,6 @@
   },
   {
     "id": 1047,
-    "entrezid": 878622,
     "description": "maltose ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -13612,7 +12565,6 @@
   },
   {
     "id": 1048,
-    "entrezid": 878623,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13625,7 +12577,6 @@
   },
   {
     "id": 1049,
-    "entrezid": 878624,
     "description": "pyoverdine synthetase F",
     "aliases": "-",
     "obsolete": false,
@@ -13638,7 +12589,6 @@
   },
   {
     "id": 1050,
-    "entrezid": 878625,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13651,7 +12601,6 @@
   },
   {
     "id": 1051,
-    "entrezid": 878626,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13664,7 +12613,6 @@
   },
   {
     "id": 1052,
-    "entrezid": 878627,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13677,7 +12625,6 @@
   },
   {
     "id": 1053,
-    "entrezid": 878628,
     "description": "pyridoxamine kinase",
     "aliases": "-",
     "obsolete": false,
@@ -13690,7 +12637,6 @@
   },
   {
     "id": 1054,
-    "entrezid": 878629,
     "description": "ArsR family transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -13703,7 +12649,6 @@
   },
   {
     "id": 1055,
-    "entrezid": 878630,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13716,7 +12661,6 @@
   },
   {
     "id": 1056,
-    "entrezid": 878631,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13729,7 +12673,6 @@
   },
   {
     "id": 1057,
-    "entrezid": 878632,
     "description": "urease accessory protein UreG",
     "aliases": "-",
     "obsolete": false,
@@ -13742,7 +12685,6 @@
   },
   {
     "id": 1058,
-    "entrezid": 878633,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13755,7 +12697,6 @@
   },
   {
     "id": 1059,
-    "entrezid": 878634,
     "description": "arsenite-antimonite efflux pump ArsB",
     "aliases": "-",
     "obsolete": false,
@@ -13768,7 +12709,6 @@
   },
   {
     "id": 1060,
-    "entrezid": 878635,
     "description": "transmembrane sensor",
     "aliases": "-",
     "obsolete": false,
@@ -13781,7 +12721,6 @@
   },
   {
     "id": 1061,
-    "entrezid": 878636,
     "description": "RNA polymerase sigma factor",
     "aliases": "-",
     "obsolete": false,
@@ -13794,7 +12733,6 @@
   },
   {
     "id": 1062,
-    "entrezid": 878637,
     "description": "phenazine-modifying protein",
     "aliases": "-",
     "obsolete": false,
@@ -13807,7 +12745,6 @@
   },
   {
     "id": 1063,
-    "entrezid": 878638,
     "description": "molybdenum transport regulator",
     "aliases": "-",
     "obsolete": false,
@@ -13820,7 +12757,6 @@
   },
   {
     "id": 1064,
-    "entrezid": 878639,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13833,7 +12769,6 @@
   },
   {
     "id": 1065,
-    "entrezid": 878640,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13846,7 +12781,6 @@
   },
   {
     "id": 1066,
-    "entrezid": 878641,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13859,7 +12793,6 @@
   },
   {
     "id": 1067,
-    "entrezid": 878642,
     "description": "thiamine monophosphate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -13872,7 +12805,6 @@
   },
   {
     "id": 1068,
-    "entrezid": 878643,
     "description": "transcription antitermination protein NusB",
     "aliases": "-",
     "obsolete": false,
@@ -13885,7 +12817,6 @@
   },
   {
     "id": 1069,
-    "entrezid": 878644,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13898,7 +12829,6 @@
   },
   {
     "id": 1070,
-    "entrezid": 878645,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13911,7 +12841,6 @@
   },
   {
     "id": 1071,
-    "entrezid": 878646,
     "description": "biosynthetic alanine racemase",
     "aliases": "-",
     "obsolete": false,
@@ -13924,7 +12853,6 @@
   },
   {
     "id": 1072,
-    "entrezid": 878647,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -13937,7 +12865,6 @@
   },
   {
     "id": 1073,
-    "entrezid": 878648,
     "description": "acetyl-CoA carboxylase biotin carboxyl carrier protein subunit",
     "aliases": "-",
     "obsolete": false,
@@ -13950,7 +12877,6 @@
   },
   {
     "id": 1074,
-    "entrezid": 878649,
     "description": "5-carboxymethyl-2-hydroxymuconate isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -13963,7 +12889,6 @@
   },
   {
     "id": 1075,
-    "entrezid": 878650,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -13976,7 +12901,6 @@
   },
   {
     "id": 1076,
-    "entrezid": 878651,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -13989,7 +12913,6 @@
   },
   {
     "id": 1077,
-    "entrezid": 878652,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14002,7 +12925,6 @@
   },
   {
     "id": 1078,
-    "entrezid": 878653,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14015,7 +12937,6 @@
   },
   {
     "id": 1079,
-    "entrezid": 878654,
     "description": "biotin biosynthesis protein BioH",
     "aliases": "-",
     "obsolete": false,
@@ -14028,7 +12949,6 @@
   },
   {
     "id": 1080,
-    "entrezid": 878655,
     "description": "magnesium/cobalt transporter",
     "aliases": "-",
     "obsolete": false,
@@ -14041,7 +12961,6 @@
   },
   {
     "id": 1081,
-    "entrezid": 878656,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14054,7 +12973,6 @@
   },
   {
     "id": 1082,
-    "entrezid": 878657,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14067,7 +12985,6 @@
   },
   {
     "id": 1083,
-    "entrezid": 878658,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14080,7 +12997,6 @@
   },
   {
     "id": 1084,
-    "entrezid": 878659,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14093,7 +13009,6 @@
   },
   {
     "id": 1085,
-    "entrezid": 878660,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14106,7 +13021,6 @@
   },
   {
     "id": 1086,
-    "entrezid": 878661,
     "description": "glutamine synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -14119,7 +13033,6 @@
   },
   {
     "id": 1087,
-    "entrezid": 878662,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14132,7 +13045,6 @@
   },
   {
     "id": 1088,
-    "entrezid": 878663,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -14145,7 +13057,6 @@
   },
   {
     "id": 1089,
-    "entrezid": 878664,
     "description": "NAD-specific glutamate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -14158,7 +13069,6 @@
   },
   {
     "id": 1090,
-    "entrezid": 878665,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14171,7 +13081,6 @@
   },
   {
     "id": 1091,
-    "entrezid": 878666,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14184,7 +13093,6 @@
   },
   {
     "id": 1092,
-    "entrezid": 878667,
     "description": "response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -14197,7 +13105,6 @@
   },
   {
     "id": 1093,
-    "entrezid": 878668,
     "description": "fimbrial subunit CupB6",
     "aliases": "-",
     "obsolete": false,
@@ -14210,7 +13117,6 @@
   },
   {
     "id": 1094,
-    "entrezid": 878669,
     "description": "DNA polymerase II",
     "aliases": "-",
     "obsolete": false,
@@ -14223,7 +13129,6 @@
   },
   {
     "id": 1095,
-    "entrezid": 878670,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14236,7 +13141,6 @@
   },
   {
     "id": 1096,
-    "entrezid": 878671,
     "description": "repressor PtrA",
     "aliases": "-",
     "obsolete": false,
@@ -14249,7 +13153,6 @@
   },
   {
     "id": 1097,
-    "entrezid": 878672,
     "description": "two-component response regulator CopR",
     "aliases": "-",
     "obsolete": false,
@@ -14262,7 +13165,6 @@
   },
   {
     "id": 1098,
-    "entrezid": 878673,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -14275,7 +13177,6 @@
   },
   {
     "id": 1099,
-    "entrezid": 878674,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14288,7 +13189,6 @@
   },
   {
     "id": 1100,
-    "entrezid": 878675,
     "description": "non-canonical purine NTP pyrophosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -14301,7 +13201,6 @@
   },
   {
     "id": 1101,
-    "entrezid": 878676,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14314,7 +13213,6 @@
   },
   {
     "id": 1102,
-    "entrezid": 878677,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14327,7 +13225,6 @@
   },
   {
     "id": 1103,
-    "entrezid": 878678,
     "description": "phosphodiesterase",
     "aliases": "-",
     "obsolete": false,
@@ -14340,7 +13237,6 @@
   },
   {
     "id": 1104,
-    "entrezid": 878679,
     "description": "soluble pyridine nucleotide transhydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -14353,7 +13249,6 @@
   },
   {
     "id": 1105,
-    "entrezid": 878680,
     "description": "fatty acid oxidation complex subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -14366,7 +13261,6 @@
   },
   {
     "id": 1106,
-    "entrezid": 878681,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14379,7 +13273,6 @@
   },
   {
     "id": 1107,
-    "entrezid": 878682,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14392,7 +13285,6 @@
   },
   {
     "id": 1108,
-    "entrezid": 878683,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14405,7 +13297,6 @@
   },
   {
     "id": 1109,
-    "entrezid": 878684,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -14418,7 +13309,6 @@
   },
   {
     "id": 1110,
-    "entrezid": 878685,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14431,7 +13321,6 @@
   },
   {
     "id": 1111,
-    "entrezid": 878686,
     "description": "amino acid permease",
     "aliases": "-",
     "obsolete": false,
@@ -14444,7 +13333,6 @@
   },
   {
     "id": 1112,
-    "entrezid": 878687,
     "description": "aldehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -14457,7 +13345,6 @@
   },
   {
     "id": 1113,
-    "entrezid": 878688,
     "description": "coproporphyrinogen III oxidase",
     "aliases": "-",
     "obsolete": false,
@@ -14470,7 +13357,6 @@
   },
   {
     "id": 1114,
-    "entrezid": 878689,
     "description": "nonribosomal peptide synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -14483,7 +13369,6 @@
   },
   {
     "id": 1115,
-    "entrezid": 878690,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -14496,7 +13381,6 @@
   },
   {
     "id": 1116,
-    "entrezid": 878691,
     "description": "branched-chain alpha-keto acid dehydrogenase subunit E2",
     "aliases": "-",
     "obsolete": false,
@@ -14509,7 +13393,6 @@
   },
   {
     "id": 1117,
-    "entrezid": 878692,
     "description": "pyruvate dehydrogenase E1 component subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -14522,7 +13405,6 @@
   },
   {
     "id": 1118,
-    "entrezid": 878693,
     "description": "FeaR family transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -14535,7 +13417,6 @@
   },
   {
     "id": 1119,
-    "entrezid": 878694,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14548,7 +13429,6 @@
   },
   {
     "id": 1120,
-    "entrezid": 878695,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -14561,7 +13441,6 @@
   },
   {
     "id": 1121,
-    "entrezid": 878696,
     "description": "propionyl-CoA synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -14574,7 +13453,6 @@
   },
   {
     "id": 1122,
-    "entrezid": 878697,
     "description": "transmembrane sensor",
     "aliases": "-",
     "obsolete": false,
@@ -14587,7 +13465,6 @@
   },
   {
     "id": 1123,
-    "entrezid": 878698,
     "description": "ECF subfamily sigma-70 factor",
     "aliases": "-",
     "obsolete": false,
@@ -14600,7 +13477,6 @@
   },
   {
     "id": 1124,
-    "entrezid": 878699,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -14613,7 +13489,6 @@
   },
   {
     "id": 1125,
-    "entrezid": 878700,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14626,7 +13501,6 @@
   },
   {
     "id": 1126,
-    "entrezid": 878701,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14639,7 +13513,6 @@
   },
   {
     "id": 1127,
-    "entrezid": 878702,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -14652,7 +13525,6 @@
   },
   {
     "id": 1128,
-    "entrezid": 878703,
     "description": "alcohol dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -14665,7 +13537,6 @@
   },
   {
     "id": 1129,
-    "entrezid": 878704,
     "description": "chemotaxis transducer",
     "aliases": "-",
     "obsolete": false,
@@ -14678,7 +13549,6 @@
   },
   {
     "id": 1130,
-    "entrezid": 878705,
     "description": "alkane-1 monooxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -14691,7 +13561,6 @@
   },
   {
     "id": 1131,
-    "entrezid": 878706,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14704,7 +13573,6 @@
   },
   {
     "id": 1132,
-    "entrezid": 878707,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -14717,7 +13585,6 @@
   },
   {
     "id": 1133,
-    "entrezid": 878708,
     "description": "adhesive protein CupB5",
     "aliases": "-",
     "obsolete": false,
@@ -14730,7 +13597,6 @@
   },
   {
     "id": 1134,
-    "entrezid": 878709,
     "description": "chaperone CupB4",
     "aliases": "-",
     "obsolete": false,
@@ -14743,7 +13609,6 @@
   },
   {
     "id": 1135,
-    "entrezid": 878710,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14756,7 +13621,6 @@
   },
   {
     "id": 1136,
-    "entrezid": 878711,
     "description": "translocation protein TolQ",
     "aliases": "-",
     "obsolete": false,
@@ -14769,7 +13633,6 @@
   },
   {
     "id": 1137,
-    "entrezid": 878712,
     "description": "epimerase",
     "aliases": "-",
     "obsolete": false,
@@ -14782,7 +13645,6 @@
   },
   {
     "id": 1138,
-    "entrezid": 878713,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14795,7 +13657,6 @@
   },
   {
     "id": 1139,
-    "entrezid": 878714,
     "description": "alginate and motility regulator Z",
     "aliases": "-",
     "obsolete": false,
@@ -14808,7 +13669,6 @@
   },
   {
     "id": 1140,
-    "entrezid": 878715,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14821,7 +13681,6 @@
   },
   {
     "id": 1141,
-    "entrezid": 878716,
     "description": "alginate o-acetylase AlgJ",
     "aliases": "-",
     "obsolete": false,
@@ -14834,7 +13693,6 @@
   },
   {
     "id": 1142,
-    "entrezid": 878717,
     "description": "alginate o-acetyltransferase AlgF",
     "aliases": "-",
     "obsolete": false,
@@ -14847,7 +13705,6 @@
   },
   {
     "id": 1143,
-    "entrezid": 878718,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -14860,7 +13717,6 @@
   },
   {
     "id": 1144,
-    "entrezid": 878719,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14873,7 +13729,6 @@
   },
   {
     "id": 1145,
-    "entrezid": 878720,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14886,7 +13741,6 @@
   },
   {
     "id": 1146,
-    "entrezid": 878721,
     "description": "protease subunit HflC",
     "aliases": "-",
     "obsolete": false,
@@ -14899,7 +13753,6 @@
   },
   {
     "id": 1147,
-    "entrezid": 878722,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14912,7 +13765,6 @@
   },
   {
     "id": 1148,
-    "entrezid": 878723,
     "description": "liu genes regulator",
     "aliases": "-",
     "obsolete": false,
@@ -14925,7 +13777,6 @@
   },
   {
     "id": 1149,
-    "entrezid": 878724,
     "description": "usher CupB3",
     "aliases": "-",
     "obsolete": false,
@@ -14938,7 +13789,6 @@
   },
   {
     "id": 1150,
-    "entrezid": 878725,
     "description": "chaperone CupB2",
     "aliases": "-",
     "obsolete": false,
@@ -14951,7 +13801,6 @@
   },
   {
     "id": 1151,
-    "entrezid": 878726,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -14964,7 +13813,6 @@
   },
   {
     "id": 1152,
-    "entrezid": 878727,
     "description": "4-hydroxyphenylacetate 3-monooxygenase large subunit",
     "aliases": "-",
     "obsolete": false,
@@ -14977,7 +13825,6 @@
   },
   {
     "id": 1153,
-    "entrezid": 878728,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -14990,7 +13837,6 @@
   },
   {
     "id": 1154,
-    "entrezid": 878729,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15003,7 +13849,6 @@
   },
   {
     "id": 1155,
-    "entrezid": 878730,
     "description": "thymidylate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -15016,7 +13861,6 @@
   },
   {
     "id": 1156,
-    "entrezid": 878731,
     "description": "type II secretion system protein G",
     "aliases": "-",
     "obsolete": false,
@@ -15029,7 +13873,6 @@
   },
   {
     "id": 1157,
-    "entrezid": 878732,
     "description": "type II secretion system protein F",
     "aliases": "-",
     "obsolete": false,
@@ -15042,7 +13885,6 @@
   },
   {
     "id": 1158,
-    "entrezid": 878733,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15055,7 +13897,6 @@
   },
   {
     "id": 1159,
-    "entrezid": 878734,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15068,7 +13909,6 @@
   },
   {
     "id": 1160,
-    "entrezid": 878735,
     "description": "4-hydroxyphenylacetate 3-monooxygenase small subunit",
     "aliases": "-",
     "obsolete": false,
@@ -15081,7 +13921,6 @@
   },
   {
     "id": 1161,
-    "entrezid": 878736,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15094,7 +13933,6 @@
   },
   {
     "id": 1162,
-    "entrezid": 878737,
     "description": "iron-containing alcohol dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -15107,7 +13945,6 @@
   },
   {
     "id": 1163,
-    "entrezid": 878738,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15120,7 +13957,6 @@
   },
   {
     "id": 1164,
-    "entrezid": 878739,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15133,7 +13969,6 @@
   },
   {
     "id": 1165,
-    "entrezid": 878740,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -15146,7 +13981,6 @@
   },
   {
     "id": 1166,
-    "entrezid": 878741,
     "description": "spermidine/putrescine-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -15159,7 +13993,6 @@
   },
   {
     "id": 1167,
-    "entrezid": 878742,
     "description": "aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -15172,7 +14005,6 @@
   },
   {
     "id": 1168,
-    "entrezid": 878743,
     "description": "3-ketoacyl-ACP reductase",
     "aliases": "-",
     "obsolete": false,
@@ -15185,7 +14017,6 @@
   },
   {
     "id": 1169,
-    "entrezid": 878744,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15198,7 +14029,6 @@
   },
   {
     "id": 1170,
-    "entrezid": 878745,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -15211,7 +14041,6 @@
   },
   {
     "id": 1171,
-    "entrezid": 878746,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15224,7 +14053,6 @@
   },
   {
     "id": 1172,
-    "entrezid": 878747,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15237,7 +14065,6 @@
   },
   {
     "id": 1173,
-    "entrezid": 878748,
     "description": "fumarylacetoacetase",
     "aliases": "-",
     "obsolete": false,
@@ -15250,7 +14077,6 @@
   },
   {
     "id": 1174,
-    "entrezid": 878749,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15263,7 +14089,6 @@
   },
   {
     "id": 1175,
-    "entrezid": 878750,
     "description": "aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -15276,7 +14101,6 @@
   },
   {
     "id": 1176,
-    "entrezid": 878751,
     "description": "dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -15289,7 +14113,6 @@
   },
   {
     "id": 1177,
-    "entrezid": 878752,
     "description": "protein BfmR",
     "aliases": "-",
     "obsolete": false,
@@ -15302,7 +14125,6 @@
   },
   {
     "id": 1178,
-    "entrezid": 878753,
     "description": "A/G-specific adenine glycosylase",
     "aliases": "-",
     "obsolete": false,
@@ -15315,7 +14137,6 @@
   },
   {
     "id": 1179,
-    "entrezid": 878754,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15328,7 +14149,6 @@
   },
   {
     "id": 1180,
-    "entrezid": 878755,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15341,7 +14161,6 @@
   },
   {
     "id": 1181,
-    "entrezid": 878756,
     "description": "protein BfmS",
     "aliases": "-",
     "obsolete": false,
@@ -15354,7 +14173,6 @@
   },
   {
     "id": 1182,
-    "entrezid": 878757,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15367,7 +14185,6 @@
   },
   {
     "id": 1183,
-    "entrezid": 878758,
     "description": "fimbrial subunit CupB1",
     "aliases": "-",
     "obsolete": false,
@@ -15380,7 +14197,6 @@
   },
   {
     "id": 1184,
-    "entrezid": 878759,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15393,7 +14209,6 @@
   },
   {
     "id": 1185,
-    "entrezid": 878760,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15406,7 +14221,6 @@
   },
   {
     "id": 1186,
-    "entrezid": 878761,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15419,7 +14233,6 @@
   },
   {
     "id": 1187,
-    "entrezid": 878762,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15432,7 +14245,6 @@
   },
   {
     "id": 1188,
-    "entrezid": 878763,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -15445,7 +14257,6 @@
   },
   {
     "id": 1189,
-    "entrezid": 878764,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -15458,7 +14269,6 @@
   },
   {
     "id": 1190,
-    "entrezid": 878765,
     "description": "GTP cyclohydrolase I",
     "aliases": "-",
     "obsolete": false,
@@ -15471,7 +14281,6 @@
   },
   {
     "id": 1191,
-    "entrezid": 878766,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15484,7 +14293,6 @@
   },
   {
     "id": 1192,
-    "entrezid": 878767,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15497,7 +14305,6 @@
   },
   {
     "id": 1193,
-    "entrezid": 878768,
     "description": "lytic transglycosylase",
     "aliases": "-",
     "obsolete": false,
@@ -15510,7 +14317,6 @@
   },
   {
     "id": 1194,
-    "entrezid": 878769,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15523,7 +14329,6 @@
   },
   {
     "id": 1195,
-    "entrezid": 878770,
     "description": "alginate biosynthesis protein Alg44",
     "aliases": "-",
     "obsolete": false,
@@ -15536,7 +14341,6 @@
   },
   {
     "id": 1196,
-    "entrezid": 878771,
     "description": "alginate biosynthesis protein AlgK",
     "aliases": "-",
     "obsolete": false,
@@ -15549,7 +14353,6 @@
   },
   {
     "id": 1197,
-    "entrezid": 878772,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15562,7 +14365,6 @@
   },
   {
     "id": 1198,
-    "entrezid": 878773,
     "description": "Na+/H+ antiporter NhaP",
     "aliases": "-",
     "obsolete": false,
@@ -15575,7 +14377,6 @@
   },
   {
     "id": 1199,
-    "entrezid": 878774,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15588,7 +14389,6 @@
   },
   {
     "id": 1200,
-    "entrezid": 878775,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15601,7 +14401,6 @@
   },
   {
     "id": 1201,
-    "entrezid": 878776,
     "description": "protein tyrosine phosphatase TpbA",
     "aliases": "-",
     "obsolete": false,
@@ -15614,7 +14413,6 @@
   },
   {
     "id": 1202,
-    "entrezid": 878777,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15627,7 +14425,6 @@
   },
   {
     "id": 1203,
-    "entrezid": 878778,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15640,7 +14437,6 @@
   },
   {
     "id": 1204,
-    "entrezid": 878779,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15653,7 +14449,6 @@
   },
   {
     "id": 1205,
-    "entrezid": 878780,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15666,7 +14461,6 @@
   },
   {
     "id": 1206,
-    "entrezid": 878781,
     "description": "isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -15679,7 +14473,6 @@
   },
   {
     "id": 1207,
-    "entrezid": 878782,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15692,7 +14485,6 @@
   },
   {
     "id": 1208,
-    "entrezid": 878783,
     "description": "thioredoxin",
     "aliases": "-",
     "obsolete": false,
@@ -15705,7 +14497,6 @@
   },
   {
     "id": 1209,
-    "entrezid": 878784,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15718,7 +14509,6 @@
   },
   {
     "id": 1210,
-    "entrezid": 878785,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15731,7 +14521,6 @@
   },
   {
     "id": 1211,
-    "entrezid": 878786,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15744,7 +14533,6 @@
   },
   {
     "id": 1212,
-    "entrezid": 878787,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15757,7 +14545,6 @@
   },
   {
     "id": 1213,
-    "entrezid": 878788,
     "description": "imidazole glycerol phosphate synthase subunit HisH",
     "aliases": "-",
     "obsolete": false,
@@ -15770,7 +14557,6 @@
   },
   {
     "id": 1214,
-    "entrezid": 878789,
     "description": "imidazoleglycerol-phosphate dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -15783,7 +14569,6 @@
   },
   {
     "id": 1215,
-    "entrezid": 878790,
     "description": "UDP-2,3-diacylglucosamine hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -15796,7 +14581,6 @@
   },
   {
     "id": 1216,
-    "entrezid": 878791,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15809,7 +14593,6 @@
   },
   {
     "id": 1217,
-    "entrezid": 878792,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -15822,7 +14605,6 @@
   },
   {
     "id": 1218,
-    "entrezid": 878793,
     "description": "ornithine carbamoyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -15835,7 +14617,6 @@
   },
   {
     "id": 1219,
-    "entrezid": 878794,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15848,7 +14629,6 @@
   },
   {
     "id": 1220,
-    "entrezid": 878795,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15861,7 +14641,6 @@
   },
   {
     "id": 1221,
-    "entrezid": 878796,
     "description": "lactoylglutathione lyase",
     "aliases": "-",
     "obsolete": false,
@@ -15874,7 +14653,6 @@
   },
   {
     "id": 1222,
-    "entrezid": 878797,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15887,7 +14665,6 @@
   },
   {
     "id": 1223,
-    "entrezid": 878798,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -15900,7 +14677,6 @@
   },
   {
     "id": 1224,
-    "entrezid": 878799,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15913,7 +14689,6 @@
   },
   {
     "id": 1225,
-    "entrezid": 878800,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15926,7 +14701,6 @@
   },
   {
     "id": 1226,
-    "entrezid": 878801,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15939,7 +14713,6 @@
   },
   {
     "id": 1227,
-    "entrezid": 878802,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -15952,7 +14725,6 @@
   },
   {
     "id": 1228,
-    "entrezid": 878803,
     "description": "cytochrome b561",
     "aliases": "-",
     "obsolete": false,
@@ -15965,7 +14737,6 @@
   },
   {
     "id": 1229,
-    "entrezid": 878804,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -15978,7 +14749,6 @@
   },
   {
     "id": 1230,
-    "entrezid": 878805,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -15991,7 +14761,6 @@
   },
   {
     "id": 1231,
-    "entrezid": 878806,
     "description": "taurine-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -16004,7 +14773,6 @@
   },
   {
     "id": 1232,
-    "entrezid": 878807,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16017,7 +14785,6 @@
   },
   {
     "id": 1233,
-    "entrezid": 878808,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16030,7 +14797,6 @@
   },
   {
     "id": 1234,
-    "entrezid": 878809,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16043,7 +14809,6 @@
   },
   {
     "id": 1235,
-    "entrezid": 878810,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16056,7 +14821,6 @@
   },
   {
     "id": 1236,
-    "entrezid": 878811,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16069,7 +14833,6 @@
   },
   {
     "id": 1237,
-    "entrezid": 878812,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -16082,7 +14845,6 @@
   },
   {
     "id": 1238,
-    "entrezid": 878813,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -16095,7 +14857,6 @@
   },
   {
     "id": 1239,
-    "entrezid": 878814,
     "description": "methylmalonate-semialdehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -16108,7 +14869,6 @@
   },
   {
     "id": 1240,
-    "entrezid": 878815,
     "description": "transcriptional regulator MmsR",
     "aliases": "-",
     "obsolete": false,
@@ -16121,7 +14881,6 @@
   },
   {
     "id": 1241,
-    "entrezid": 878816,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16134,7 +14893,6 @@
   },
   {
     "id": 1242,
-    "entrezid": 878817,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -16147,7 +14905,6 @@
   },
   {
     "id": 1243,
-    "entrezid": 878818,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16160,7 +14917,6 @@
   },
   {
     "id": 1244,
-    "entrezid": 878819,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -16173,7 +14929,6 @@
   },
   {
     "id": 1245,
-    "entrezid": 878820,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16186,7 +14941,6 @@
   },
   {
     "id": 1246,
-    "entrezid": 878821,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16199,7 +14953,6 @@
   },
   {
     "id": 1247,
-    "entrezid": 878822,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -16212,7 +14965,6 @@
   },
   {
     "id": 1248,
-    "entrezid": 878823,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16225,7 +14977,6 @@
   },
   {
     "id": 1249,
-    "entrezid": 878824,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16238,7 +14989,6 @@
   },
   {
     "id": 1250,
-    "entrezid": 878826,
     "description": "esterase",
     "aliases": "-",
     "obsolete": false,
@@ -16251,7 +15001,6 @@
   },
   {
     "id": 1251,
-    "entrezid": 878827,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16264,7 +15013,6 @@
   },
   {
     "id": 1252,
-    "entrezid": 878828,
     "description": "glutamine--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -16277,7 +15025,6 @@
   },
   {
     "id": 1253,
-    "entrezid": 878829,
     "description": "DNA binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -16290,7 +15037,6 @@
   },
   {
     "id": 1254,
-    "entrezid": 878830,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16303,7 +15049,6 @@
   },
   {
     "id": 1255,
-    "entrezid": 878831,
     "description": "methionine--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -16316,7 +15061,6 @@
   },
   {
     "id": 1256,
-    "entrezid": 878832,
     "description": "pellicle/biofilm biosynthesis protein PelB",
     "aliases": "-",
     "obsolete": false,
@@ -16329,7 +15073,6 @@
   },
   {
     "id": 1257,
-    "entrezid": 878833,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16342,7 +15085,6 @@
   },
   {
     "id": 1258,
-    "entrezid": 878834,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16355,7 +15097,6 @@
   },
   {
     "id": 1259,
-    "entrezid": 878835,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -16368,7 +15109,6 @@
   },
   {
     "id": 1260,
-    "entrezid": 878836,
     "description": "acyl-CoA thioesterase II",
     "aliases": "-",
     "obsolete": false,
@@ -16381,7 +15121,6 @@
   },
   {
     "id": 1261,
-    "entrezid": 878837,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16394,7 +15133,6 @@
   },
   {
     "id": 1262,
-    "entrezid": 878838,
     "description": "transcriptional regulator NarL",
     "aliases": "-",
     "obsolete": false,
@@ -16407,7 +15145,6 @@
   },
   {
     "id": 1263,
-    "entrezid": 878839,
     "description": "multidrug efflux lipoprotein",
     "aliases": "-",
     "obsolete": false,
@@ -16420,7 +15157,6 @@
   },
   {
     "id": 1264,
-    "entrezid": 878840,
     "description": "Na(+)-translocating NADH-quinone reductase subunit F",
     "aliases": "-",
     "obsolete": false,
@@ -16433,7 +15169,6 @@
   },
   {
     "id": 1265,
-    "entrezid": 878841,
     "description": "glutathione peroxidase",
     "aliases": "-",
     "obsolete": false,
@@ -16446,7 +15181,6 @@
   },
   {
     "id": 1266,
-    "entrezid": 878842,
     "description": "methionine sulfoxide reductase B",
     "aliases": "-",
     "obsolete": false,
@@ -16459,7 +15193,6 @@
   },
   {
     "id": 1267,
-    "entrezid": 878843,
     "description": "two-component response regulator RocA1",
     "aliases": "-",
     "obsolete": false,
@@ -16472,7 +15205,6 @@
   },
   {
     "id": 1268,
-    "entrezid": 878844,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16485,7 +15217,6 @@
   },
   {
     "id": 1269,
-    "entrezid": 878845,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16498,7 +15229,6 @@
   },
   {
     "id": 1270,
-    "entrezid": 878846,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16511,7 +15241,6 @@
   },
   {
     "id": 1271,
-    "entrezid": 878847,
     "description": "ATP-dependent RNA helicase",
     "aliases": "-",
     "obsolete": false,
@@ -16524,7 +15253,6 @@
   },
   {
     "id": 1272,
-    "entrezid": 878848,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16537,7 +15265,6 @@
   },
   {
     "id": 1273,
-    "entrezid": 878849,
     "description": "transporter HasD",
     "aliases": "-",
     "obsolete": false,
@@ -16550,7 +15277,6 @@
   },
   {
     "id": 1274,
-    "entrezid": 878850,
     "description": "aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -16563,7 +15289,6 @@
   },
   {
     "id": 1275,
-    "entrezid": 878851,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16576,7 +15301,6 @@
   },
   {
     "id": 1276,
-    "entrezid": 878852,
     "description": "acyl-CoA thiolase",
     "aliases": "-",
     "obsolete": false,
@@ -16589,7 +15313,6 @@
   },
   {
     "id": 1277,
-    "entrezid": 878853,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16602,7 +15325,6 @@
   },
   {
     "id": 1278,
-    "entrezid": 878854,
     "description": "acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -16615,7 +15337,6 @@
   },
   {
     "id": 1279,
-    "entrezid": 878855,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16628,7 +15349,6 @@
   },
   {
     "id": 1280,
-    "entrezid": 878856,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16641,7 +15361,6 @@
   },
   {
     "id": 1281,
-    "entrezid": 878857,
     "description": "3-hydroxy-3-isohexenylglutaryl-CoA/hydroxy-methylglutaryl-CoA lyase",
     "aliases": "-",
     "obsolete": false,
@@ -16654,7 +15373,6 @@
   },
   {
     "id": 1282,
-    "entrezid": 878858,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16667,7 +15385,6 @@
   },
   {
     "id": 1283,
-    "entrezid": 878859,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -16680,7 +15397,6 @@
   },
   {
     "id": 1284,
-    "entrezid": 878860,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16693,7 +15409,6 @@
   },
   {
     "id": 1285,
-    "entrezid": 878861,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -16706,7 +15421,6 @@
   },
   {
     "id": 1286,
-    "entrezid": 878862,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -16719,7 +15433,6 @@
   },
   {
     "id": 1287,
-    "entrezid": 878863,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16732,7 +15445,6 @@
   },
   {
     "id": 1288,
-    "entrezid": 878864,
     "description": "pseudouridine synthase",
     "aliases": "-",
     "obsolete": false,
@@ -16745,7 +15457,6 @@
   },
   {
     "id": 1289,
-    "entrezid": 878865,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16758,7 +15469,6 @@
   },
   {
     "id": 1290,
-    "entrezid": 878866,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16771,7 +15481,6 @@
   },
   {
     "id": 1291,
-    "entrezid": 878867,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16784,7 +15493,6 @@
   },
   {
     "id": 1292,
-    "entrezid": 878868,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16797,7 +15505,6 @@
   },
   {
     "id": 1293,
-    "entrezid": 878869,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16810,7 +15517,6 @@
   },
   {
     "id": 1294,
-    "entrezid": 878870,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -16823,7 +15529,6 @@
   },
   {
     "id": 1295,
-    "entrezid": 878871,
     "description": "DNA-binding response regulator RocR",
     "aliases": "-",
     "obsolete": false,
@@ -16836,7 +15541,6 @@
   },
   {
     "id": 1296,
-    "entrezid": 878872,
     "description": "argininosuccinate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -16849,7 +15553,6 @@
   },
   {
     "id": 1297,
-    "entrezid": 878873,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16862,7 +15565,6 @@
   },
   {
     "id": 1298,
-    "entrezid": 878874,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16875,7 +15577,6 @@
   },
   {
     "id": 1299,
-    "entrezid": 878875,
     "description": "ATP-dependent helicase",
     "aliases": "-",
     "obsolete": false,
@@ -16888,7 +15589,6 @@
   },
   {
     "id": 1300,
-    "entrezid": 878876,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16901,7 +15601,6 @@
   },
   {
     "id": 1301,
-    "entrezid": 878877,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16914,7 +15613,6 @@
   },
   {
     "id": 1302,
-    "entrezid": 878878,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16927,7 +15625,6 @@
   },
   {
     "id": 1303,
-    "entrezid": 878879,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16940,7 +15637,6 @@
   },
   {
     "id": 1304,
-    "entrezid": 878880,
     "description": "AMP nucleosidase",
     "aliases": "-",
     "obsolete": false,
@@ -16953,7 +15649,6 @@
   },
   {
     "id": 1305,
-    "entrezid": 878881,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -16966,7 +15661,6 @@
   },
   {
     "id": 1306,
-    "entrezid": 878882,
     "description": "multidrug efflux protein",
     "aliases": "-",
     "obsolete": false,
@@ -16979,7 +15673,6 @@
   },
   {
     "id": 1307,
-    "entrezid": 878883,
     "description": "PpiC-type peptidyl-prolyl cis-trans isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -16992,7 +15685,6 @@
   },
   {
     "id": 1308,
-    "entrezid": 878884,
     "description": "respiratory nitrate reductase subunit gamma",
     "aliases": "-",
     "obsolete": false,
@@ -17005,7 +15697,6 @@
   },
   {
     "id": 1309,
-    "entrezid": 878885,
     "description": "sensor/response regulator hybrid protein",
     "aliases": "-",
     "obsolete": false,
@@ -17018,7 +15709,6 @@
   },
   {
     "id": 1310,
-    "entrezid": 878886,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -17031,7 +15721,6 @@
   },
   {
     "id": 1311,
-    "entrezid": 878888,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -17044,7 +15733,6 @@
   },
   {
     "id": 1312,
-    "entrezid": 878889,
     "description": "dehydrocarnitine CoA transferase subunit A",
     "aliases": "-",
     "obsolete": false,
@@ -17057,7 +15745,6 @@
   },
   {
     "id": 1313,
-    "entrezid": 878890,
     "description": "lost adherence sensor LadS",
     "aliases": "-",
     "obsolete": false,
@@ -17070,7 +15757,6 @@
   },
   {
     "id": 1314,
-    "entrezid": 878891,
     "description": "phosphomethylpyrimidine kinase",
     "aliases": "-",
     "obsolete": false,
@@ -17083,7 +15769,6 @@
   },
   {
     "id": 1315,
-    "entrezid": 878892,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17096,7 +15781,6 @@
   },
   {
     "id": 1316,
-    "entrezid": 878893,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17109,7 +15793,6 @@
   },
   {
     "id": 1317,
-    "entrezid": 878894,
     "description": "exonuclease III",
     "aliases": "-",
     "obsolete": false,
@@ -17122,7 +15805,6 @@
   },
   {
     "id": 1318,
-    "entrezid": 878895,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -17135,7 +15817,6 @@
   },
   {
     "id": 1319,
-    "entrezid": 878896,
     "description": "RNA polymerase sigma factor",
     "aliases": "-",
     "obsolete": false,
@@ -17148,7 +15829,6 @@
   },
   {
     "id": 1320,
-    "entrezid": 878897,
     "description": "metalloprotease",
     "aliases": "-",
     "obsolete": false,
@@ -17161,7 +15841,6 @@
   },
   {
     "id": 1321,
-    "entrezid": 878898,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17174,7 +15853,6 @@
   },
   {
     "id": 1322,
-    "entrezid": 878899,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -17187,7 +15865,6 @@
   },
   {
     "id": 1323,
-    "entrezid": 878900,
     "description": "transposase",
     "aliases": "-",
     "obsolete": false,
@@ -17200,7 +15877,6 @@
   },
   {
     "id": 1324,
-    "entrezid": 878901,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17213,7 +15889,6 @@
   },
   {
     "id": 1325,
-    "entrezid": 878902,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17226,7 +15901,6 @@
   },
   {
     "id": 1326,
-    "entrezid": 878903,
     "description": "(dimethylallyl)adenosine tRNA methylthiotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -17239,7 +15913,6 @@
   },
   {
     "id": 1327,
-    "entrezid": 878904,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17252,7 +15925,6 @@
   },
   {
     "id": 1328,
-    "entrezid": 878905,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17265,7 +15937,6 @@
   },
   {
     "id": 1329,
-    "entrezid": 878906,
     "description": "resistance-nodulation-cell division (RND) efflux transporter",
     "aliases": "-",
     "obsolete": false,
@@ -17278,7 +15949,6 @@
   },
   {
     "id": 1330,
-    "entrezid": 878907,
     "description": "apolipoprotein N-acyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -17291,7 +15961,6 @@
   },
   {
     "id": 1331,
-    "entrezid": 878908,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17304,7 +15973,6 @@
   },
   {
     "id": 1332,
-    "entrezid": 878909,
     "description": "aminoglycoside response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -17317,7 +15985,6 @@
   },
   {
     "id": 1333,
-    "entrezid": 878911,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17330,7 +15997,6 @@
   },
   {
     "id": 1334,
-    "entrezid": 878912,
     "description": "adhesin",
     "aliases": "-",
     "obsolete": false,
@@ -17343,7 +16009,6 @@
   },
   {
     "id": 1335,
-    "entrezid": 878913,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -17356,7 +16021,6 @@
   },
   {
     "id": 1336,
-    "entrezid": 878914,
     "description": "3,4-dihydroxy-2-butanone-4-phosphate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -17369,7 +16033,6 @@
   },
   {
     "id": 1337,
-    "entrezid": 878915,
     "description": "riboflavin synthase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -17382,7 +16045,6 @@
   },
   {
     "id": 1338,
-    "entrezid": 878916,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17395,7 +16057,6 @@
   },
   {
     "id": 1339,
-    "entrezid": 878917,
     "description": "transmembrane sensor",
     "aliases": "-",
     "obsolete": false,
@@ -17408,7 +16069,6 @@
   },
   {
     "id": 1340,
-    "entrezid": 878918,
     "description": "Fe(III) dicitrate transporter FecA",
     "aliases": "-",
     "obsolete": false,
@@ -17421,7 +16081,6 @@
   },
   {
     "id": 1341,
-    "entrezid": 878919,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -17434,7 +16093,6 @@
   },
   {
     "id": 1342,
-    "entrezid": 878920,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -17447,7 +16105,6 @@
   },
   {
     "id": 1343,
-    "entrezid": 878922,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -17460,7 +16117,6 @@
   },
   {
     "id": 1344,
-    "entrezid": 878923,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17473,7 +16129,6 @@
   },
   {
     "id": 1345,
-    "entrezid": 878924,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17486,7 +16141,6 @@
   },
   {
     "id": 1346,
-    "entrezid": 878925,
     "description": "leucine--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -17499,7 +16153,6 @@
   },
   {
     "id": 1347,
-    "entrezid": 878926,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -17512,7 +16165,6 @@
   },
   {
     "id": 1348,
-    "entrezid": 878927,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17525,7 +16177,6 @@
   },
   {
     "id": 1349,
-    "entrezid": 878928,
     "description": "peptide chain release factor 3",
     "aliases": "-",
     "obsolete": false,
@@ -17538,7 +16189,6 @@
   },
   {
     "id": 1350,
-    "entrezid": 878929,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17551,7 +16201,6 @@
   },
   {
     "id": 1351,
-    "entrezid": 878930,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -17564,7 +16213,6 @@
   },
   {
     "id": 1352,
-    "entrezid": 878931,
     "description": "lipoyl synthase",
     "aliases": "-",
     "obsolete": false,
@@ -17577,7 +16225,6 @@
   },
   {
     "id": 1353,
-    "entrezid": 878932,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17590,7 +16237,6 @@
   },
   {
     "id": 1354,
-    "entrezid": 878933,
     "description": "spermidine/putrescine-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -17603,7 +16249,6 @@
   },
   {
     "id": 1355,
-    "entrezid": 878935,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17616,7 +16261,6 @@
   },
   {
     "id": 1356,
-    "entrezid": 878936,
     "description": "DNA polymerase III subunit delta",
     "aliases": "-",
     "obsolete": false,
@@ -17629,7 +16273,6 @@
   },
   {
     "id": 1357,
-    "entrezid": 878937,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17642,7 +16285,6 @@
   },
   {
     "id": 1358,
-    "entrezid": 878938,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17655,7 +16297,6 @@
   },
   {
     "id": 1359,
-    "entrezid": 878939,
     "description": "chloramphenicol-sensitive protein RarD",
     "aliases": "-",
     "obsolete": false,
@@ -17668,7 +16309,6 @@
   },
   {
     "id": 1360,
-    "entrezid": 878940,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17681,7 +16321,6 @@
   },
   {
     "id": 1361,
-    "entrezid": 878941,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17694,7 +16333,6 @@
   },
   {
     "id": 1362,
-    "entrezid": 878942,
     "description": "transposase",
     "aliases": "-",
     "obsolete": false,
@@ -17707,7 +16345,6 @@
   },
   {
     "id": 1363,
-    "entrezid": 878943,
     "description": "epoxide hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -17720,7 +16357,6 @@
   },
   {
     "id": 1364,
-    "entrezid": 878944,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17733,7 +16369,6 @@
   },
   {
     "id": 1365,
-    "entrezid": 878945,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17746,7 +16381,6 @@
   },
   {
     "id": 1366,
-    "entrezid": 878946,
     "description": "soluble lytic transglycosylase B",
     "aliases": "-",
     "obsolete": false,
@@ -17759,7 +16393,6 @@
   },
   {
     "id": 1367,
-    "entrezid": 878947,
     "description": "rod shape-determining protein",
     "aliases": "-",
     "obsolete": false,
@@ -17772,7 +16405,6 @@
   },
   {
     "id": 1368,
-    "entrezid": 878948,
     "description": "epoxide hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -17785,7 +16417,6 @@
   },
   {
     "id": 1369,
-    "entrezid": 878949,
     "description": "aldolase",
     "aliases": "-",
     "obsolete": false,
@@ -17798,7 +16429,6 @@
   },
   {
     "id": 1370,
-    "entrezid": 878950,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17811,7 +16441,6 @@
   },
   {
     "id": 1371,
-    "entrezid": 878951,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17824,7 +16453,6 @@
   },
   {
     "id": 1372,
-    "entrezid": 878952,
     "description": "lipoate-protein ligase B",
     "aliases": "-",
     "obsolete": false,
@@ -17837,7 +16465,6 @@
   },
   {
     "id": 1373,
-    "entrezid": 878953,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17850,7 +16477,6 @@
   },
   {
     "id": 1374,
-    "entrezid": 878954,
     "description": "rhamnosyltransferase subunit B",
     "aliases": "-",
     "obsolete": false,
@@ -17863,7 +16489,6 @@
   },
   {
     "id": 1375,
-    "entrezid": 878955,
     "description": "rhamnosyltransferase subunit A",
     "aliases": "-",
     "obsolete": false,
@@ -17876,7 +16501,6 @@
   },
   {
     "id": 1376,
-    "entrezid": 878956,
     "description": "D-ala-D-ala-carboxypeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -17889,7 +16513,6 @@
   },
   {
     "id": 1377,
-    "entrezid": 878957,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17902,7 +16525,6 @@
   },
   {
     "id": 1378,
-    "entrezid": 878958,
     "description": "cytidylate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -17915,7 +16537,6 @@
   },
   {
     "id": 1379,
-    "entrezid": 878959,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -17928,7 +16549,6 @@
   },
   {
     "id": 1380,
-    "entrezid": 878960,
     "description": "3-methyladenine DNA glycosylase",
     "aliases": "-",
     "obsolete": false,
@@ -17941,7 +16561,6 @@
   },
   {
     "id": 1381,
-    "entrezid": 878961,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17954,7 +16573,6 @@
   },
   {
     "id": 1382,
-    "entrezid": 878962,
     "description": "penicillin-binding protein 2",
     "aliases": "-",
     "obsolete": false,
@@ -17967,7 +16585,6 @@
   },
   {
     "id": 1383,
-    "entrezid": 878963,
     "description": "extracelullar DNA degradation protein EddA",
     "aliases": "-",
     "obsolete": false,
@@ -17980,7 +16597,6 @@
   },
   {
     "id": 1384,
-    "entrezid": 878964,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -17993,7 +16609,6 @@
   },
   {
     "id": 1385,
-    "entrezid": 878965,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18006,7 +16621,6 @@
   },
   {
     "id": 1386,
-    "entrezid": 878966,
     "description": "extracelullar DNA degradation protein EddB",
     "aliases": "-",
     "obsolete": false,
@@ -18019,7 +16633,6 @@
   },
   {
     "id": 1387,
-    "entrezid": 878967,
     "description": "acyl-homoserine-lactone synthase",
     "aliases": "-",
     "obsolete": false,
@@ -18032,7 +16645,6 @@
   },
   {
     "id": 1388,
-    "entrezid": 878968,
     "description": "transcriptional regulator RhlR",
     "aliases": "-",
     "obsolete": false,
@@ -18045,7 +16657,6 @@
   },
   {
     "id": 1389,
-    "entrezid": 878969,
     "description": "nicotinic acid mononucleotide adenylyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -18058,7 +16669,6 @@
   },
   {
     "id": 1390,
-    "entrezid": 878970,
     "description": "gamma-glutamyl phosphate reductase",
     "aliases": "-",
     "obsolete": false,
@@ -18071,7 +16681,6 @@
   },
   {
     "id": 1391,
-    "entrezid": 878971,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18084,7 +16693,6 @@
   },
   {
     "id": 1392,
-    "entrezid": 878972,
     "description": "protease",
     "aliases": "-",
     "obsolete": false,
@@ -18097,7 +16705,6 @@
   },
   {
     "id": 1393,
-    "entrezid": 878973,
     "description": "23S rRNA (pseudouridine(1915)-N(3))-methyltransferase RlmH",
     "aliases": "-",
     "obsolete": false,
@@ -18110,7 +16717,6 @@
   },
   {
     "id": 1394,
-    "entrezid": 878974,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18123,7 +16729,6 @@
   },
   {
     "id": 1395,
-    "entrezid": 878975,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18136,7 +16741,6 @@
   },
   {
     "id": 1396,
-    "entrezid": 878976,
     "description": "cyclohexadienyl dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -18149,7 +16753,6 @@
   },
   {
     "id": 1397,
-    "entrezid": 878977,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -18162,7 +16765,6 @@
   },
   {
     "id": 1398,
-    "entrezid": 878978,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18175,7 +16777,6 @@
   },
   {
     "id": 1399,
-    "entrezid": 878979,
     "description": "serine protease",
     "aliases": "-",
     "obsolete": false,
@@ -18188,7 +16789,6 @@
   },
   {
     "id": 1400,
-    "entrezid": 878980,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18201,7 +16801,6 @@
   },
   {
     "id": 1401,
-    "entrezid": 878981,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -18214,7 +16813,6 @@
   },
   {
     "id": 1402,
-    "entrezid": 878982,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18227,7 +16825,6 @@
   },
   {
     "id": 1403,
-    "entrezid": 878983,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18240,7 +16837,6 @@
   },
   {
     "id": 1404,
-    "entrezid": 878984,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18253,7 +16849,6 @@
   },
   {
     "id": 1405,
-    "entrezid": 878985,
     "description": "molybdopterin converting factor large subunit",
     "aliases": "-",
     "obsolete": false,
@@ -18266,7 +16861,6 @@
   },
   {
     "id": 1406,
-    "entrezid": 878986,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18279,7 +16873,6 @@
   },
   {
     "id": 1407,
-    "entrezid": 878987,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18292,7 +16885,6 @@
   },
   {
     "id": 1408,
-    "entrezid": 878988,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18305,7 +16897,6 @@
   },
   {
     "id": 1409,
-    "entrezid": 878989,
     "description": "molybdenum cofactor biosynthesis protein A",
     "aliases": "-",
     "obsolete": false,
@@ -18318,7 +16909,6 @@
   },
   {
     "id": 1410,
-    "entrezid": 878990,
     "description": "molybdopterin biosynthesis protein B",
     "aliases": "-",
     "obsolete": false,
@@ -18331,7 +16921,6 @@
   },
   {
     "id": 1411,
-    "entrezid": 878991,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18344,7 +16933,6 @@
   },
   {
     "id": 1412,
-    "entrezid": 878992,
     "description": "aromatic acid decarboxylase",
     "aliases": "-",
     "obsolete": false,
@@ -18357,7 +16945,6 @@
   },
   {
     "id": 1413,
-    "entrezid": 878993,
     "description": "cytochrome C Snr1",
     "aliases": "-",
     "obsolete": false,
@@ -18370,7 +16957,6 @@
   },
   {
     "id": 1414,
-    "entrezid": 878994,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18383,7 +16969,6 @@
   },
   {
     "id": 1415,
-    "entrezid": 878995,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18396,7 +16981,6 @@
   },
   {
     "id": 1416,
-    "entrezid": 878996,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18409,7 +16993,6 @@
   },
   {
     "id": 1417,
-    "entrezid": 878997,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18422,7 +17005,6 @@
   },
   {
     "id": 1418,
-    "entrezid": 878998,
     "description": "CifR protein",
     "aliases": "-",
     "obsolete": false,
@@ -18435,7 +17017,6 @@
   },
   {
     "id": 1419,
-    "entrezid": 878999,
     "description": "morphinone reductase",
     "aliases": "-",
     "obsolete": false,
@@ -18448,7 +17029,6 @@
   },
   {
     "id": 1420,
-    "entrezid": 879000,
     "description": "UDP-N-acetylmuramate:L-alanyl-gamma-D-glutamyl-meso-diaminopimelate ligase",
     "aliases": "-",
     "obsolete": false,
@@ -18461,7 +17041,6 @@
   },
   {
     "id": 1421,
-    "entrezid": 879001,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -18474,7 +17053,6 @@
   },
   {
     "id": 1422,
-    "entrezid": 879002,
     "description": "ethanolamine ammonia-lyase large subunit",
     "aliases": "-",
     "obsolete": false,
@@ -18487,7 +17065,6 @@
   },
   {
     "id": 1423,
-    "entrezid": 879003,
     "description": "ethanolamine ammonia-lyase small subunit",
     "aliases": "-",
     "obsolete": false,
@@ -18500,7 +17077,6 @@
   },
   {
     "id": 1424,
-    "entrezid": 879004,
     "description": "GDP-mannose 6-dehydrogenase AlgD",
     "aliases": "-",
     "obsolete": false,
@@ -18513,7 +17089,6 @@
   },
   {
     "id": 1425,
-    "entrezid": 879005,
     "description": "glycosyltransferase alg8",
     "aliases": "-",
     "obsolete": false,
@@ -18526,7 +17101,6 @@
   },
   {
     "id": 1426,
-    "entrezid": 879006,
     "description": "acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -18539,7 +17113,6 @@
   },
   {
     "id": 1427,
-    "entrezid": 879007,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18552,7 +17125,6 @@
   },
   {
     "id": 1428,
-    "entrezid": 879008,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -18565,7 +17137,6 @@
   },
   {
     "id": 1429,
-    "entrezid": 879009,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18578,7 +17149,6 @@
   },
   {
     "id": 1430,
-    "entrezid": 879010,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -18591,7 +17161,6 @@
   },
   {
     "id": 1431,
-    "entrezid": 879011,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18604,7 +17173,6 @@
   },
   {
     "id": 1432,
-    "entrezid": 879012,
     "description": "methylcrotonyl-CoA carboxylase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -18617,7 +17185,6 @@
   },
   {
     "id": 1433,
-    "entrezid": 879013,
     "description": "molybdopterin converting factor small subunit",
     "aliases": "-",
     "obsolete": false,
@@ -18630,7 +17197,6 @@
   },
   {
     "id": 1434,
-    "entrezid": 879014,
     "description": "molybdenum cofactor biosynthesis protein MoaC",
     "aliases": "-",
     "obsolete": false,
@@ -18643,7 +17209,6 @@
   },
   {
     "id": 1435,
-    "entrezid": 879015,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -18656,7 +17221,6 @@
   },
   {
     "id": 1436,
-    "entrezid": 879016,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -18669,7 +17233,6 @@
   },
   {
     "id": 1437,
-    "entrezid": 879017,
     "description": "aldehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -18682,7 +17245,6 @@
   },
   {
     "id": 1438,
-    "entrezid": 879018,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -18695,7 +17257,6 @@
   },
   {
     "id": 1439,
-    "entrezid": 879019,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18708,7 +17269,6 @@
   },
   {
     "id": 1440,
-    "entrezid": 879020,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -18721,7 +17281,6 @@
   },
   {
     "id": 1441,
-    "entrezid": 879021,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18734,7 +17293,6 @@
   },
   {
     "id": 1442,
-    "entrezid": 879022,
     "description": "metal transporting P-type ATPase",
     "aliases": "-",
     "obsolete": false,
@@ -18747,7 +17305,6 @@
   },
   {
     "id": 1443,
-    "entrezid": 879023,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -18760,7 +17317,6 @@
   },
   {
     "id": 1444,
-    "entrezid": 879024,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18773,7 +17329,6 @@
   },
   {
     "id": 1445,
-    "entrezid": 879025,
     "description": "inorganic pyrophosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -18786,7 +17341,6 @@
   },
   {
     "id": 1446,
-    "entrezid": 879026,
     "description": "bacterioferritin",
     "aliases": "-",
     "obsolete": false,
@@ -18799,7 +17353,6 @@
   },
   {
     "id": 1447,
-    "entrezid": 879027,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18812,7 +17365,6 @@
   },
   {
     "id": 1448,
-    "entrezid": 879028,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -18825,7 +17377,6 @@
   },
   {
     "id": 1449,
-    "entrezid": 879029,
     "description": "malate:quinone oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -18838,7 +17389,6 @@
   },
   {
     "id": 1450,
-    "entrezid": 879030,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18851,7 +17401,6 @@
   },
   {
     "id": 1451,
-    "entrezid": 879031,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -18864,7 +17413,6 @@
   },
   {
     "id": 1452,
-    "entrezid": 879032,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -18877,7 +17425,6 @@
   },
   {
     "id": 1453,
-    "entrezid": 879033,
     "description": "D-alanine--D-alanine ligase",
     "aliases": "-",
     "obsolete": false,
@@ -18890,7 +17437,6 @@
   },
   {
     "id": 1454,
-    "entrezid": 879034,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18903,7 +17449,6 @@
   },
   {
     "id": 1455,
-    "entrezid": 879035,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -18916,7 +17461,6 @@
   },
   {
     "id": 1456,
-    "entrezid": 879036,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18929,7 +17473,6 @@
   },
   {
     "id": 1457,
-    "entrezid": 879037,
     "description": "1-deoxy-D-xylulose-5-phosphate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -18942,7 +17485,6 @@
   },
   {
     "id": 1458,
-    "entrezid": 879039,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18955,7 +17497,6 @@
   },
   {
     "id": 1459,
-    "entrezid": 879040,
     "description": "flavodoxin",
     "aliases": "-",
     "obsolete": false,
@@ -18968,7 +17509,6 @@
   },
   {
     "id": 1460,
-    "entrezid": 879041,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18981,7 +17521,6 @@
   },
   {
     "id": 1461,
-    "entrezid": 879042,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -18994,7 +17533,6 @@
   },
   {
     "id": 1462,
-    "entrezid": 879043,
     "description": "long-chain-fatty-acid--CoA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -19007,7 +17545,6 @@
   },
   {
     "id": 1463,
-    "entrezid": 879044,
     "description": "cyanide insensitive terminal oxidase",
     "aliases": "-",
     "obsolete": false,
@@ -19020,7 +17557,6 @@
   },
   {
     "id": 1464,
-    "entrezid": 879045,
     "description": "cyanide insensitive terminal oxidase",
     "aliases": "-",
     "obsolete": false,
@@ -19033,7 +17569,6 @@
   },
   {
     "id": 1465,
-    "entrezid": 879046,
     "description": "acetyl-CoA acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -19046,7 +17581,6 @@
   },
   {
     "id": 1466,
-    "entrezid": 879047,
     "description": "acyl-CoA thiolase",
     "aliases": "-",
     "obsolete": false,
@@ -19059,7 +17593,6 @@
   },
   {
     "id": 1467,
-    "entrezid": 879048,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -19072,7 +17605,6 @@
   },
   {
     "id": 1468,
-    "entrezid": 879049,
     "description": "aquaporin Z",
     "aliases": "-",
     "obsolete": false,
@@ -19085,7 +17617,6 @@
   },
   {
     "id": 1469,
-    "entrezid": 879050,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19098,7 +17629,6 @@
   },
   {
     "id": 1470,
-    "entrezid": 879051,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19111,7 +17641,6 @@
   },
   {
     "id": 1471,
-    "entrezid": 879052,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19124,7 +17653,6 @@
   },
   {
     "id": 1472,
-    "entrezid": 879053,
     "description": "4-hydroxy-3-methylbut-2-en-1-yl diphosphate synthase (flavodoxin)",
     "aliases": "-",
     "obsolete": false,
@@ -19137,7 +17665,6 @@
   },
   {
     "id": 1473,
-    "entrezid": 879054,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19150,7 +17677,6 @@
   },
   {
     "id": 1474,
-    "entrezid": 879055,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19163,7 +17689,6 @@
   },
   {
     "id": 1475,
-    "entrezid": 879056,
     "description": "folylpolyglutamate synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -19176,7 +17701,6 @@
   },
   {
     "id": 1476,
-    "entrezid": 879057,
     "description": "exodeoxyribonuclease VII small subunit",
     "aliases": "-",
     "obsolete": false,
@@ -19189,7 +17713,6 @@
   },
   {
     "id": 1477,
-    "entrezid": 879058,
     "description": "geranyltranstransferase",
     "aliases": "-",
     "obsolete": false,
@@ -19202,7 +17725,6 @@
   },
   {
     "id": 1478,
-    "entrezid": 879059,
     "description": "GTP cyclohydrolase II",
     "aliases": "-",
     "obsolete": false,
@@ -19215,7 +17737,6 @@
   },
   {
     "id": 1479,
-    "entrezid": 879060,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19228,7 +17749,6 @@
   },
   {
     "id": 1480,
-    "entrezid": 879061,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19241,7 +17761,6 @@
   },
   {
     "id": 1481,
-    "entrezid": 879062,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19254,7 +17773,6 @@
   },
   {
     "id": 1482,
-    "entrezid": 879063,
     "description": "adenylosuccinate lyase",
     "aliases": "-",
     "obsolete": false,
@@ -19267,7 +17785,6 @@
   },
   {
     "id": 1483,
-    "entrezid": 879064,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19280,7 +17797,6 @@
   },
   {
     "id": 1484,
-    "entrezid": 879065,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -19293,7 +17809,6 @@
   },
   {
     "id": 1485,
-    "entrezid": 879066,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19306,7 +17821,6 @@
   },
   {
     "id": 1486,
-    "entrezid": 879067,
     "description": "choline transporter",
     "aliases": "-",
     "obsolete": false,
@@ -19319,7 +17833,6 @@
   },
   {
     "id": 1487,
-    "entrezid": 879068,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19332,7 +17845,6 @@
   },
   {
     "id": 1488,
-    "entrezid": 879069,
     "description": "endonuclease III",
     "aliases": "-",
     "obsolete": false,
@@ -19345,7 +17857,6 @@
   },
   {
     "id": 1489,
-    "entrezid": 879070,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19358,7 +17869,6 @@
   },
   {
     "id": 1490,
-    "entrezid": 879071,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19371,7 +17881,6 @@
   },
   {
     "id": 1491,
-    "entrezid": 879072,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -19384,7 +17893,6 @@
   },
   {
     "id": 1492,
-    "entrezid": 879073,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19397,7 +17905,6 @@
   },
   {
     "id": 1493,
-    "entrezid": 879074,
     "description": "phosphatidylglycerophosphatase A",
     "aliases": "-",
     "obsolete": false,
@@ -19410,7 +17917,6 @@
   },
   {
     "id": 1494,
-    "entrezid": 879075,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19423,7 +17929,6 @@
   },
   {
     "id": 1495,
-    "entrezid": 879076,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19436,7 +17941,6 @@
   },
   {
     "id": 1496,
-    "entrezid": 879077,
     "description": "OpdB proline porin",
     "aliases": "-",
     "obsolete": false,
@@ -19449,7 +17953,6 @@
   },
   {
     "id": 1497,
-    "entrezid": 879078,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -19462,7 +17965,6 @@
   },
   {
     "id": 1498,
-    "entrezid": 879079,
     "description": "riboflavin-specific deaminase/reductase",
     "aliases": "-",
     "obsolete": false,
@@ -19475,7 +17977,6 @@
   },
   {
     "id": 1499,
-    "entrezid": 879080,
     "description": "transcriptional regulator NrdR",
     "aliases": "-",
     "obsolete": false,
@@ -19488,7 +17989,6 @@
   },
   {
     "id": 1500,
-    "entrezid": 879081,
     "description": "6,7-dimethyl-8-ribityllumazine synthase",
     "aliases": "-",
     "obsolete": false,
@@ -19501,7 +18001,6 @@
   },
   {
     "id": 1501,
-    "entrezid": 879082,
     "description": "adenylate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -19514,7 +18013,6 @@
   },
   {
     "id": 1502,
-    "entrezid": 879083,
     "description": "phosphoenolpyruvate carboxylase",
     "aliases": "-",
     "obsolete": false,
@@ -19527,7 +18025,6 @@
   },
   {
     "id": 1503,
-    "entrezid": 879084,
     "description": "transcriptional regulator DhcR",
     "aliases": "-",
     "obsolete": false,
@@ -19540,7 +18037,6 @@
   },
   {
     "id": 1504,
-    "entrezid": 879085,
     "description": "coenzyme PQQ synthesis protein D",
     "aliases": "-",
     "obsolete": false,
@@ -19553,7 +18049,6 @@
   },
   {
     "id": 1505,
-    "entrezid": 879086,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19566,7 +18061,6 @@
   },
   {
     "id": 1506,
-    "entrezid": 879087,
     "description": "enoyl-CoA hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -19579,7 +18073,6 @@
   },
   {
     "id": 1507,
-    "entrezid": 879088,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19592,7 +18085,6 @@
   },
   {
     "id": 1508,
-    "entrezid": 879089,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19605,7 +18097,6 @@
   },
   {
     "id": 1509,
-    "entrezid": 879090,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19618,7 +18109,6 @@
   },
   {
     "id": 1510,
-    "entrezid": 879091,
     "description": "copper transport outer membrane porin OprC",
     "aliases": "-",
     "obsolete": false,
@@ -19631,7 +18121,6 @@
   },
   {
     "id": 1511,
-    "entrezid": 879092,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19644,7 +18133,6 @@
   },
   {
     "id": 1512,
-    "entrezid": 879093,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19657,7 +18145,6 @@
   },
   {
     "id": 1513,
-    "entrezid": 879094,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19670,7 +18157,6 @@
   },
   {
     "id": 1514,
-    "entrezid": 879095,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -19683,7 +18169,6 @@
   },
   {
     "id": 1515,
-    "entrezid": 879096,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19696,7 +18181,6 @@
   },
   {
     "id": 1516,
-    "entrezid": 879097,
     "description": "3-hydroxyisobutyrate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -19709,7 +18193,6 @@
   },
   {
     "id": 1517,
-    "entrezid": 879098,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19722,7 +18205,6 @@
   },
   {
     "id": 1518,
-    "entrezid": 879099,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19735,7 +18217,6 @@
   },
   {
     "id": 1519,
-    "entrezid": 879100,
     "description": "aliphatic sulfonates ABC transporter ATP-binding subunit",
     "aliases": "-",
     "obsolete": false,
@@ -19748,7 +18229,6 @@
   },
   {
     "id": 1520,
-    "entrezid": 879101,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -19761,7 +18241,6 @@
   },
   {
     "id": 1521,
-    "entrezid": 879102,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19774,7 +18253,6 @@
   },
   {
     "id": 1522,
-    "entrezid": 879103,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19787,7 +18265,6 @@
   },
   {
     "id": 1523,
-    "entrezid": 879104,
     "description": "outer membrane porin F",
     "aliases": "-",
     "obsolete": false,
@@ -19800,7 +18277,6 @@
   },
   {
     "id": 1524,
-    "entrezid": 879105,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19813,7 +18289,6 @@
   },
   {
     "id": 1525,
-    "entrezid": 879106,
     "description": "peptidase",
     "aliases": "-",
     "obsolete": false,
@@ -19826,7 +18301,6 @@
   },
   {
     "id": 1526,
-    "entrezid": 879107,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -19839,7 +18313,6 @@
   },
   {
     "id": 1527,
-    "entrezid": 879108,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19852,7 +18325,6 @@
   },
   {
     "id": 1528,
-    "entrezid": 879109,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19865,7 +18337,6 @@
   },
   {
     "id": 1529,
-    "entrezid": 879110,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19878,7 +18349,6 @@
   },
   {
     "id": 1530,
-    "entrezid": 879111,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -19891,7 +18361,6 @@
   },
   {
     "id": 1531,
-    "entrezid": 879112,
     "description": "pyrroloquinoline-quinone synthase",
     "aliases": "-",
     "obsolete": false,
@@ -19904,7 +18373,6 @@
   },
   {
     "id": 1532,
-    "entrezid": 879113,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -19917,7 +18385,6 @@
   },
   {
     "id": 1533,
-    "entrezid": 879114,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19930,7 +18397,6 @@
   },
   {
     "id": 1534,
-    "entrezid": 879115,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19943,7 +18409,6 @@
   },
   {
     "id": 1535,
-    "entrezid": 879116,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19956,7 +18421,6 @@
   },
   {
     "id": 1536,
-    "entrezid": 879117,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19969,7 +18433,6 @@
   },
   {
     "id": 1537,
-    "entrezid": 879118,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -19982,7 +18445,6 @@
   },
   {
     "id": 1538,
-    "entrezid": 879119,
     "description": "GMC-type oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -19995,7 +18457,6 @@
   },
   {
     "id": 1539,
-    "entrezid": 879120,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -20008,7 +18469,6 @@
   },
   {
     "id": 1540,
-    "entrezid": 879121,
     "description": "4-deoxy-4-formamido-L-arabinose-phosphoundecaprenol deformylase ArnD",
     "aliases": "-",
     "obsolete": false,
@@ -20021,7 +18481,6 @@
   },
   {
     "id": 1541,
-    "entrezid": 879122,
     "description": "4-amino-4-deoxy-L-arabinose lipid A transferase",
     "aliases": "-",
     "obsolete": false,
@@ -20034,7 +18493,6 @@
   },
   {
     "id": 1542,
-    "entrezid": 879123,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20047,7 +18505,6 @@
   },
   {
     "id": 1543,
-    "entrezid": 879124,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20060,7 +18517,6 @@
   },
   {
     "id": 1544,
-    "entrezid": 879125,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20073,7 +18529,6 @@
   },
   {
     "id": 1545,
-    "entrezid": 879126,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -20086,7 +18541,6 @@
   },
   {
     "id": 1546,
-    "entrezid": 879127,
     "description": "acetoacetyl-CoA synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -20099,7 +18553,6 @@
   },
   {
     "id": 1547,
-    "entrezid": 879128,
     "description": "gamma-carboxygeranoyl-CoA hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -20112,7 +18565,6 @@
   },
   {
     "id": 1548,
-    "entrezid": 879129,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20125,7 +18577,6 @@
   },
   {
     "id": 1549,
-    "entrezid": 879130,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20138,7 +18589,6 @@
   },
   {
     "id": 1550,
-    "entrezid": 879131,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20151,7 +18601,6 @@
   },
   {
     "id": 1551,
-    "entrezid": 879132,
     "description": "4-amino-4-deoxy-L-arabinose-phosphoundecaprenol flippase subunit ArnE",
     "aliases": "-",
     "obsolete": false,
@@ -20164,7 +18613,6 @@
   },
   {
     "id": 1552,
-    "entrezid": 879133,
     "description": "4-amino-4-deoxy-L-arabinose-phosphoundecaprenol flippase subunit ArnF",
     "aliases": "-",
     "obsolete": false,
@@ -20177,7 +18625,6 @@
   },
   {
     "id": 1553,
-    "entrezid": 879134,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20190,7 +18637,6 @@
   },
   {
     "id": 1554,
-    "entrezid": 879135,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -20203,7 +18649,6 @@
   },
   {
     "id": 1555,
-    "entrezid": 879136,
     "description": "metal-transporting P-type ATPase",
     "aliases": "-",
     "obsolete": false,
@@ -20216,7 +18661,6 @@
   },
   {
     "id": 1556,
-    "entrezid": 879137,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20229,7 +18673,6 @@
   },
   {
     "id": 1557,
-    "entrezid": 879138,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20242,7 +18685,6 @@
   },
   {
     "id": 1558,
-    "entrezid": 879139,
     "description": "molybdopterin-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -20255,7 +18697,6 @@
   },
   {
     "id": 1559,
-    "entrezid": 879140,
     "description": "tryptophan 2,3-dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -20268,7 +18709,6 @@
   },
   {
     "id": 1560,
-    "entrezid": 879141,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20281,7 +18721,6 @@
   },
   {
     "id": 1561,
-    "entrezid": 879142,
     "description": "bifunctional mannose-1-phosphate guanylyltransferase/mannose-6-phosphate isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -20294,7 +18733,6 @@
   },
   {
     "id": 1562,
-    "entrezid": 879143,
     "description": "UDP-4-amino-4-deoxy-L-arabinose--oxoglutarate aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -20307,7 +18745,6 @@
   },
   {
     "id": 1563,
-    "entrezid": 879144,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20320,7 +18757,6 @@
   },
   {
     "id": 1564,
-    "entrezid": 879145,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20333,7 +18769,6 @@
   },
   {
     "id": 1565,
-    "entrezid": 879146,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20346,7 +18781,6 @@
   },
   {
     "id": 1566,
-    "entrezid": 879147,
     "description": "catechol 1,2-dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -20359,7 +18793,6 @@
   },
   {
     "id": 1567,
-    "entrezid": 879148,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20372,7 +18805,6 @@
   },
   {
     "id": 1568,
-    "entrezid": 879149,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20385,7 +18817,6 @@
   },
   {
     "id": 1569,
-    "entrezid": 879150,
     "description": "ribosomal RNA small subunit methyltransferase J",
     "aliases": "-",
     "obsolete": false,
@@ -20398,7 +18829,6 @@
   },
   {
     "id": 1570,
-    "entrezid": 879151,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20411,7 +18841,6 @@
   },
   {
     "id": 1571,
-    "entrezid": 879152,
     "description": "pellicle/biofilm biosynthesis glycosyltransferase PelF",
     "aliases": "-",
     "obsolete": false,
@@ -20424,7 +18853,6 @@
   },
   {
     "id": 1572,
-    "entrezid": 879153,
     "description": "pellicle/biofilm biosynthesis protein PelE",
     "aliases": "-",
     "obsolete": false,
@@ -20437,7 +18865,6 @@
   },
   {
     "id": 1573,
-    "entrezid": 879154,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20450,7 +18877,6 @@
   },
   {
     "id": 1574,
-    "entrezid": 879155,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20463,7 +18889,6 @@
   },
   {
     "id": 1575,
-    "entrezid": 879156,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20476,7 +18901,6 @@
   },
   {
     "id": 1576,
-    "entrezid": 879157,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20489,7 +18913,6 @@
   },
   {
     "id": 1577,
-    "entrezid": 879158,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -20502,7 +18925,6 @@
   },
   {
     "id": 1578,
-    "entrezid": 879159,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -20515,7 +18937,6 @@
   },
   {
     "id": 1579,
-    "entrezid": 879160,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -20528,7 +18949,6 @@
   },
   {
     "id": 1580,
-    "entrezid": 879161,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -20541,7 +18961,6 @@
   },
   {
     "id": 1581,
-    "entrezid": 879162,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -20554,7 +18973,6 @@
   },
   {
     "id": 1582,
-    "entrezid": 879163,
     "description": "alkanesulfonate monooxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -20567,7 +18985,6 @@
   },
   {
     "id": 1583,
-    "entrezid": 879164,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20580,7 +18997,6 @@
   },
   {
     "id": 1584,
-    "entrezid": 879165,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -20593,7 +19009,6 @@
   },
   {
     "id": 1585,
-    "entrezid": 879166,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -20606,7 +19021,6 @@
   },
   {
     "id": 1586,
-    "entrezid": 879167,
     "description": "isovaleryl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -20619,7 +19033,6 @@
   },
   {
     "id": 1587,
-    "entrezid": 879168,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -20632,7 +19045,6 @@
   },
   {
     "id": 1588,
-    "entrezid": 879169,
     "description": "aldehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -20645,7 +19057,6 @@
   },
   {
     "id": 1589,
-    "entrezid": 879170,
     "description": "type 4 fimbrial biogenesis protein PilF",
     "aliases": "-",
     "obsolete": false,
@@ -20658,7 +19069,6 @@
   },
   {
     "id": 1590,
-    "entrezid": 879171,
     "description": "23S rRNA (adenine(2503)-C(2))-methyltransferase RlmN",
     "aliases": "-",
     "obsolete": false,
@@ -20671,7 +19081,6 @@
   },
   {
     "id": 1591,
-    "entrezid": 879172,
     "description": "thiosulfate:cyanide sulfurtransferase",
     "aliases": "-",
     "obsolete": false,
@@ -20684,7 +19093,6 @@
   },
   {
     "id": 1592,
-    "entrezid": 879173,
     "description": "phosphatidylserine decarboxylase",
     "aliases": "-",
     "obsolete": false,
@@ -20697,7 +19105,6 @@
   },
   {
     "id": 1593,
-    "entrezid": 879174,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20710,7 +19117,6 @@
   },
   {
     "id": 1594,
-    "entrezid": 879175,
     "description": "L-aspartate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -20723,7 +19129,6 @@
   },
   {
     "id": 1595,
-    "entrezid": 879176,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20736,7 +19141,6 @@
   },
   {
     "id": 1596,
-    "entrezid": 879177,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20749,7 +19153,6 @@
   },
   {
     "id": 1597,
-    "entrezid": 879178,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -20762,7 +19165,6 @@
   },
   {
     "id": 1598,
-    "entrezid": 879179,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20775,7 +19177,6 @@
   },
   {
     "id": 1599,
-    "entrezid": 879180,
     "description": "5-formyltetrahydrofolate cyclo-ligase",
     "aliases": "-",
     "obsolete": false,
@@ -20788,7 +19189,6 @@
   },
   {
     "id": 1600,
-    "entrezid": 879181,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20801,7 +19201,6 @@
   },
   {
     "id": 1601,
-    "entrezid": 879182,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20814,7 +19213,6 @@
   },
   {
     "id": 1602,
-    "entrezid": 879183,
     "description": "trans-2,3-dihydro-3-hydroxyanthranilate isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -20827,7 +19225,6 @@
   },
   {
     "id": 1603,
-    "entrezid": 879184,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20840,7 +19237,6 @@
   },
   {
     "id": 1604,
-    "entrezid": 879185,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20853,7 +19249,6 @@
   },
   {
     "id": 1605,
-    "entrezid": 879186,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20866,7 +19261,6 @@
   },
   {
     "id": 1606,
-    "entrezid": 879187,
     "description": "two-component sensor PhoQ",
     "aliases": "-",
     "obsolete": false,
@@ -20879,7 +19273,6 @@
   },
   {
     "id": 1607,
-    "entrezid": 879188,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20892,7 +19285,6 @@
   },
   {
     "id": 1608,
-    "entrezid": 879189,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20905,7 +19297,6 @@
   },
   {
     "id": 1609,
-    "entrezid": 879190,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20918,7 +19309,6 @@
   },
   {
     "id": 1610,
-    "entrezid": 879191,
     "description": "anthranilate synthase component I",
     "aliases": "-",
     "obsolete": false,
@@ -20931,7 +19321,6 @@
   },
   {
     "id": 1611,
-    "entrezid": 879192,
     "description": "ferredoxin",
     "aliases": "-",
     "obsolete": false,
@@ -20944,7 +19333,6 @@
   },
   {
     "id": 1612,
-    "entrezid": 879193,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20957,7 +19345,6 @@
   },
   {
     "id": 1613,
-    "entrezid": 879194,
     "description": "two-component response regulator PhoP",
     "aliases": "-",
     "obsolete": false,
@@ -20970,7 +19357,6 @@
   },
   {
     "id": 1614,
-    "entrezid": 879195,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20983,7 +19369,6 @@
   },
   {
     "id": 1615,
-    "entrezid": 879196,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -20996,7 +19381,6 @@
   },
   {
     "id": 1616,
-    "entrezid": 879197,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21009,7 +19393,6 @@
   },
   {
     "id": 1617,
-    "entrezid": 879198,
     "description": "phosphoglycerate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -21022,7 +19405,6 @@
   },
   {
     "id": 1618,
-    "entrezid": 879199,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -21035,7 +19417,6 @@
   },
   {
     "id": 1619,
-    "entrezid": 879200,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21048,7 +19429,6 @@
   },
   {
     "id": 1620,
-    "entrezid": 879201,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21061,7 +19441,6 @@
   },
   {
     "id": 1621,
-    "entrezid": 879202,
     "description": "amino acid permease",
     "aliases": "-",
     "obsolete": false,
@@ -21074,7 +19453,6 @@
   },
   {
     "id": 1622,
-    "entrezid": 879203,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21087,7 +19465,6 @@
   },
   {
     "id": 1623,
-    "entrezid": 879204,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21100,7 +19477,6 @@
   },
   {
     "id": 1624,
-    "entrezid": 879205,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21113,7 +19489,6 @@
   },
   {
     "id": 1625,
-    "entrezid": 879206,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -21126,7 +19501,6 @@
   },
   {
     "id": 1626,
-    "entrezid": 879207,
     "description": "serine protease MucD",
     "aliases": "-",
     "obsolete": false,
@@ -21139,7 +19513,6 @@
   },
   {
     "id": 1627,
-    "entrezid": 879208,
     "description": "FMNH2-dependent monooxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -21152,7 +19525,6 @@
   },
   {
     "id": 1628,
-    "entrezid": 879209,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21165,7 +19537,6 @@
   },
   {
     "id": 1629,
-    "entrezid": 879210,
     "description": "arginine/ornithine ABC transporter substrate-binding protein AotJ",
     "aliases": "-",
     "obsolete": false,
@@ -21178,7 +19549,6 @@
   },
   {
     "id": 1630,
-    "entrezid": 879211,
     "description": "nitrate reductase biosynthesis protein NapD",
     "aliases": "-",
     "obsolete": false,
@@ -21191,7 +19561,6 @@
   },
   {
     "id": 1631,
-    "entrezid": 879212,
     "description": "tryptophan synthase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -21204,7 +19573,6 @@
   },
   {
     "id": 1632,
-    "entrezid": 879213,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21217,7 +19585,6 @@
   },
   {
     "id": 1633,
-    "entrezid": 879214,
     "description": "ring-cleaving dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -21230,7 +19597,6 @@
   },
   {
     "id": 1634,
-    "entrezid": 879216,
     "description": "branched-chain amino acid transport system 3 carrier protein",
     "aliases": "-",
     "obsolete": false,
@@ -21243,7 +19609,6 @@
   },
   {
     "id": 1635,
-    "entrezid": 879217,
     "description": "tRNA (cmo5U34)-methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -21256,7 +19621,6 @@
   },
   {
     "id": 1636,
-    "entrezid": 879219,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21269,7 +19633,6 @@
   },
   {
     "id": 1637,
-    "entrezid": 879220,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21282,7 +19645,6 @@
   },
   {
     "id": 1638,
-    "entrezid": 879221,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21295,7 +19657,6 @@
   },
   {
     "id": 1639,
-    "entrezid": 879222,
     "description": "bacteriophage protein",
     "aliases": "-",
     "obsolete": false,
@@ -21308,7 +19669,6 @@
   },
   {
     "id": 1640,
-    "entrezid": 879223,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -21321,7 +19681,6 @@
   },
   {
     "id": 1641,
-    "entrezid": 879224,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -21334,7 +19693,6 @@
   },
   {
     "id": 1642,
-    "entrezid": 879225,
     "description": "bacteriophage protein",
     "aliases": "-",
     "obsolete": false,
@@ -21347,7 +19705,6 @@
   },
   {
     "id": 1643,
-    "entrezid": 879226,
     "description": "2-oxoisovalerate dehydrogenase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -21360,7 +19717,6 @@
   },
   {
     "id": 1644,
-    "entrezid": 879227,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21373,7 +19729,6 @@
   },
   {
     "id": 1645,
-    "entrezid": 879228,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21386,7 +19741,6 @@
   },
   {
     "id": 1646,
-    "entrezid": 879229,
     "description": "DNA replication and repair protein RecF",
     "aliases": "-",
     "obsolete": false,
@@ -21399,7 +19753,6 @@
   },
   {
     "id": 1647,
-    "entrezid": 879230,
     "description": "DNA gyrase subunit B",
     "aliases": "-",
     "obsolete": false,
@@ -21412,7 +19765,6 @@
   },
   {
     "id": 1648,
-    "entrezid": 879231,
     "description": "2-octaprenyl-3-methyl-6-methoxy-1,4-benzoquinol hydroxylase",
     "aliases": "-",
     "obsolete": false,
@@ -21425,7 +19777,6 @@
   },
   {
     "id": 1649,
-    "entrezid": 879232,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21438,7 +19789,6 @@
   },
   {
     "id": 1650,
-    "entrezid": 879233,
     "description": "dihydrofolate reductase",
     "aliases": "-",
     "obsolete": false,
@@ -21451,7 +19801,6 @@
   },
   {
     "id": 1651,
-    "entrezid": 879234,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21464,7 +19813,6 @@
   },
   {
     "id": 1652,
-    "entrezid": 879235,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21477,7 +19825,6 @@
   },
   {
     "id": 1653,
-    "entrezid": 879236,
     "description": "amino acid ABC transporter ATP binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -21490,7 +19837,6 @@
   },
   {
     "id": 1654,
-    "entrezid": 879237,
     "description": "aldehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -21503,7 +19849,6 @@
   },
   {
     "id": 1655,
-    "entrezid": 879238,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -21516,7 +19861,6 @@
   },
   {
     "id": 1656,
-    "entrezid": 879239,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21529,7 +19873,6 @@
   },
   {
     "id": 1657,
-    "entrezid": 879240,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21542,7 +19885,6 @@
   },
   {
     "id": 1658,
-    "entrezid": 879241,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21555,7 +19897,6 @@
   },
   {
     "id": 1659,
-    "entrezid": 879242,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21568,7 +19909,6 @@
   },
   {
     "id": 1660,
-    "entrezid": 879243,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21581,7 +19921,6 @@
   },
   {
     "id": 1661,
-    "entrezid": 879244,
     "description": "DNA polymerase III subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -21594,7 +19933,6 @@
   },
   {
     "id": 1662,
-    "entrezid": 879245,
     "description": "D-glycero-beta-D-manno-heptose-1,7-bisphosphate 7-phosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -21607,7 +19945,6 @@
   },
   {
     "id": 1663,
-    "entrezid": 879246,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -21620,7 +19957,6 @@
   },
   {
     "id": 1664,
-    "entrezid": 879247,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21633,7 +19969,6 @@
   },
   {
     "id": 1665,
-    "entrezid": 879248,
     "description": "2-(5''-triphosphoribosyl)-3'-dephosphocoenzyme-A synthase",
     "aliases": "-",
     "obsolete": false,
@@ -21646,7 +19981,6 @@
   },
   {
     "id": 1666,
-    "entrezid": 879249,
     "description": "adenosine deaminase",
     "aliases": "-",
     "obsolete": false,
@@ -21659,7 +19993,6 @@
   },
   {
     "id": 1667,
-    "entrezid": 879250,
     "description": "xanthine dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -21672,7 +20005,6 @@
   },
   {
     "id": 1668,
-    "entrezid": 879251,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21685,7 +20017,6 @@
   },
   {
     "id": 1669,
-    "entrezid": 879252,
     "description": "inhibitor of cysteine peptidase",
     "aliases": "-",
     "obsolete": false,
@@ -21698,7 +20029,6 @@
   },
   {
     "id": 1670,
-    "entrezid": 879253,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21711,7 +20041,6 @@
   },
   {
     "id": 1671,
-    "entrezid": 879254,
     "description": "phosphoribosyl-dephospho-CoA transferase",
     "aliases": "-",
     "obsolete": false,
@@ -21724,7 +20053,6 @@
   },
   {
     "id": 1672,
-    "entrezid": 879255,
     "description": "potassium transporter inner membrane associated protein",
     "aliases": "-",
     "obsolete": false,
@@ -21737,7 +20065,6 @@
   },
   {
     "id": 1673,
-    "entrezid": 879256,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -21750,7 +20077,6 @@
   },
   {
     "id": 1674,
-    "entrezid": 879257,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21763,7 +20089,6 @@
   },
   {
     "id": 1675,
-    "entrezid": 879258,
     "description": "methionyl-tRNA formyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -21776,7 +20101,6 @@
   },
   {
     "id": 1676,
-    "entrezid": 879259,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -21789,7 +20113,6 @@
   },
   {
     "id": 1677,
-    "entrezid": 879260,
     "description": "transcriptional regulator PcrR",
     "aliases": "-",
     "obsolete": false,
@@ -21802,7 +20125,6 @@
   },
   {
     "id": 1678,
-    "entrezid": 879261,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21815,7 +20137,6 @@
   },
   {
     "id": 1679,
-    "entrezid": 879262,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21828,7 +20149,6 @@
   },
   {
     "id": 1680,
-    "entrezid": 879263,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -21841,7 +20161,6 @@
   },
   {
     "id": 1681,
-    "entrezid": 879264,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21854,7 +20173,6 @@
   },
   {
     "id": 1682,
-    "entrezid": 879265,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21867,7 +20185,6 @@
   },
   {
     "id": 1683,
-    "entrezid": 879266,
     "description": "type III secretion outer membrane protein PopN",
     "aliases": "-",
     "obsolete": false,
@@ -21880,7 +20197,6 @@
   },
   {
     "id": 1684,
-    "entrezid": 879267,
     "description": "regulatory protein PcrH",
     "aliases": "-",
     "obsolete": false,
@@ -21893,7 +20209,6 @@
   },
   {
     "id": 1685,
-    "entrezid": 879268,
     "description": "xanthine dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -21906,7 +20221,6 @@
   },
   {
     "id": 1686,
-    "entrezid": 879269,
     "description": "NAD-dependent DNA ligase LigA",
     "aliases": "-",
     "obsolete": false,
@@ -21919,7 +20233,6 @@
   },
   {
     "id": 1687,
-    "entrezid": 879270,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21932,7 +20245,6 @@
   },
   {
     "id": 1688,
-    "entrezid": 879271,
     "description": "aerotaxis receptor Aer",
     "aliases": "-",
     "obsolete": false,
@@ -21945,7 +20257,6 @@
   },
   {
     "id": 1689,
-    "entrezid": 879272,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -21958,7 +20269,6 @@
   },
   {
     "id": 1690,
-    "entrezid": 879273,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21971,7 +20281,6 @@
   },
   {
     "id": 1691,
-    "entrezid": 879274,
     "description": "dihydroxy-acid dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -21984,7 +20293,6 @@
   },
   {
     "id": 1692,
-    "entrezid": 879275,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -21997,7 +20305,6 @@
   },
   {
     "id": 1693,
-    "entrezid": 879276,
     "description": "glycosyl transferase family protein",
     "aliases": "-",
     "obsolete": false,
@@ -22010,7 +20317,6 @@
   },
   {
     "id": 1694,
-    "entrezid": 879277,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22023,7 +20329,6 @@
   },
   {
     "id": 1695,
-    "entrezid": 879278,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -22036,7 +20341,6 @@
   },
   {
     "id": 1696,
-    "entrezid": 879279,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -22049,7 +20353,6 @@
   },
   {
     "id": 1697,
-    "entrezid": 879280,
     "description": "bacteriohemerythrin",
     "aliases": "-",
     "obsolete": false,
@@ -22062,7 +20365,6 @@
   },
   {
     "id": 1698,
-    "entrezid": 879281,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22075,7 +20377,6 @@
   },
   {
     "id": 1699,
-    "entrezid": 879282,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22088,7 +20389,6 @@
   },
   {
     "id": 1700,
-    "entrezid": 879283,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22101,7 +20401,6 @@
   },
   {
     "id": 1701,
-    "entrezid": 879284,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22114,7 +20413,6 @@
   },
   {
     "id": 1702,
-    "entrezid": 879285,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22127,7 +20425,6 @@
   },
   {
     "id": 1703,
-    "entrezid": 879286,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -22140,7 +20437,6 @@
   },
   {
     "id": 1704,
-    "entrezid": 879287,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22153,7 +20449,6 @@
   },
   {
     "id": 1705,
-    "entrezid": 879288,
     "description": "arylsulfatase",
     "aliases": "-",
     "obsolete": false,
@@ -22166,7 +20461,6 @@
   },
   {
     "id": 1706,
-    "entrezid": 879289,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22179,7 +20473,6 @@
   },
   {
     "id": 1707,
-    "entrezid": 879290,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22192,7 +20485,6 @@
   },
   {
     "id": 1708,
-    "entrezid": 879291,
     "description": "enoyl-CoA hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -22205,7 +20497,6 @@
   },
   {
     "id": 1709,
-    "entrezid": 879292,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22218,7 +20509,6 @@
   },
   {
     "id": 1710,
-    "entrezid": 879293,
     "description": "5-hydroxyisourate hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -22231,7 +20521,6 @@
   },
   {
     "id": 1711,
-    "entrezid": 879294,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22244,7 +20533,6 @@
   },
   {
     "id": 1712,
-    "entrezid": 879295,
     "description": "acetylpolyamine aminohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -22257,7 +20545,6 @@
   },
   {
     "id": 1713,
-    "entrezid": 879296,
     "description": "hemolytic phospholipase C",
     "aliases": "-",
     "obsolete": false,
@@ -22270,7 +20557,6 @@
   },
   {
     "id": 1714,
-    "entrezid": 879297,
     "description": "Ribosomal RNA small subunit methyltransferase B",
     "aliases": "-",
     "obsolete": false,
@@ -22283,7 +20569,6 @@
   },
   {
     "id": 1715,
-    "entrezid": 879298,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22296,7 +20581,6 @@
   },
   {
     "id": 1716,
-    "entrezid": 879299,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22309,7 +20593,6 @@
   },
   {
     "id": 1717,
-    "entrezid": 879300,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22322,7 +20605,6 @@
   },
   {
     "id": 1718,
-    "entrezid": 879301,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22335,7 +20617,6 @@
   },
   {
     "id": 1719,
-    "entrezid": 879302,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -22348,7 +20629,6 @@
   },
   {
     "id": 1720,
-    "entrezid": 879303,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -22361,7 +20641,6 @@
   },
   {
     "id": 1721,
-    "entrezid": 879304,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -22374,7 +20653,6 @@
   },
   {
     "id": 1722,
-    "entrezid": 879305,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -22387,7 +20665,6 @@
   },
   {
     "id": 1723,
-    "entrezid": 879306,
     "description": "peptide deformylase",
     "aliases": "-",
     "obsolete": false,
@@ -22400,7 +20677,6 @@
   },
   {
     "id": 1724,
-    "entrezid": 879307,
     "description": "formamidopyrimidine-DNA glycosylase",
     "aliases": "-",
     "obsolete": false,
@@ -22413,7 +20689,6 @@
   },
   {
     "id": 1725,
-    "entrezid": 879308,
     "description": "GTP cyclohydrolase I",
     "aliases": "-",
     "obsolete": false,
@@ -22426,7 +20701,6 @@
   },
   {
     "id": 1726,
-    "entrezid": 879309,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22439,7 +20713,6 @@
   },
   {
     "id": 1727,
-    "entrezid": 879310,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22452,7 +20725,6 @@
   },
   {
     "id": 1728,
-    "entrezid": 879311,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22465,7 +20737,6 @@
   },
   {
     "id": 1729,
-    "entrezid": 879312,
     "description": "phosphoenolpyruvate carboxykinase",
     "aliases": "-",
     "obsolete": false,
@@ -22478,7 +20749,6 @@
   },
   {
     "id": 1730,
-    "entrezid": 879313,
     "description": "heat shock protein 33",
     "aliases": "-",
     "obsolete": false,
@@ -22491,7 +20761,6 @@
   },
   {
     "id": 1731,
-    "entrezid": 879314,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -22504,7 +20773,6 @@
   },
   {
     "id": 1732,
-    "entrezid": 879315,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22517,7 +20785,6 @@
   },
   {
     "id": 1733,
-    "entrezid": 879316,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -22530,7 +20797,6 @@
   },
   {
     "id": 1734,
-    "entrezid": 879317,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22543,7 +20809,6 @@
   },
   {
     "id": 1735,
-    "entrezid": 879318,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22556,7 +20821,6 @@
   },
   {
     "id": 1736,
-    "entrezid": 879319,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22569,7 +20833,6 @@
   },
   {
     "id": 1737,
-    "entrezid": 879320,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22582,7 +20845,6 @@
   },
   {
     "id": 1738,
-    "entrezid": 879321,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -22595,7 +20857,6 @@
   },
   {
     "id": 1739,
-    "entrezid": 879322,
     "description": "malonate decarboxylase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -22608,7 +20869,6 @@
   },
   {
     "id": 1740,
-    "entrezid": 879323,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22621,7 +20881,6 @@
   },
   {
     "id": 1741,
-    "entrezid": 879324,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -22634,7 +20893,6 @@
   },
   {
     "id": 1742,
-    "entrezid": 879325,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -22647,7 +20905,6 @@
   },
   {
     "id": 1743,
-    "entrezid": 879326,
     "description": "alkyl hydroperoxide reductase",
     "aliases": "-",
     "obsolete": false,
@@ -22660,7 +20917,6 @@
   },
   {
     "id": 1744,
-    "entrezid": 879327,
     "description": "amino acid permease",
     "aliases": "-",
     "obsolete": false,
@@ -22673,7 +20929,6 @@
   },
   {
     "id": 1745,
-    "entrezid": 879328,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22686,7 +20941,6 @@
   },
   {
     "id": 1746,
-    "entrezid": 879329,
     "description": "glycerophosphoryl diester phosphodiesterase",
     "aliases": "-",
     "obsolete": false,
@@ -22699,7 +20953,6 @@
   },
   {
     "id": 1747,
-    "entrezid": 879330,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -22712,7 +20965,6 @@
   },
   {
     "id": 1748,
-    "entrezid": 879331,
     "description": "guanine deaminase",
     "aliases": "-",
     "obsolete": false,
@@ -22725,7 +20977,6 @@
   },
   {
     "id": 1749,
-    "entrezid": 879332,
     "description": "glycosyl transferase family protein",
     "aliases": "-",
     "obsolete": false,
@@ -22738,7 +20989,6 @@
   },
   {
     "id": 1750,
-    "entrezid": 879333,
     "description": "helicase",
     "aliases": "-",
     "obsolete": false,
@@ -22751,7 +21001,6 @@
   },
   {
     "id": 1751,
-    "entrezid": 879334,
     "description": "acyl transferase",
     "aliases": "-",
     "obsolete": false,
@@ -22764,7 +21013,6 @@
   },
   {
     "id": 1752,
-    "entrezid": 879335,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22777,7 +21025,6 @@
   },
   {
     "id": 1753,
-    "entrezid": 879336,
     "description": "trichloroethylene chemotactic transducer CttP",
     "aliases": "-",
     "obsolete": false,
@@ -22790,7 +21037,6 @@
   },
   {
     "id": 1754,
-    "entrezid": 879337,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22803,7 +21049,6 @@
   },
   {
     "id": 1755,
-    "entrezid": 879338,
     "description": "purine-binding chemotaxis protein",
     "aliases": "-",
     "obsolete": false,
@@ -22816,7 +21061,6 @@
   },
   {
     "id": 1756,
-    "entrezid": 879339,
     "description": "usher CupC3",
     "aliases": "-",
     "obsolete": false,
@@ -22829,7 +21073,6 @@
   },
   {
     "id": 1757,
-    "entrezid": 879340,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -22842,7 +21085,6 @@
   },
   {
     "id": 1758,
-    "entrezid": 879341,
     "description": "serine/threonine phosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -22855,7 +21097,6 @@
   },
   {
     "id": 1759,
-    "entrezid": 879342,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22868,7 +21109,6 @@
   },
   {
     "id": 1760,
-    "entrezid": 879343,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22881,7 +21121,6 @@
   },
   {
     "id": 1761,
-    "entrezid": 879344,
     "description": "NAD(P)H dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -22894,7 +21133,6 @@
   },
   {
     "id": 1762,
-    "entrezid": 879345,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -22907,7 +21145,6 @@
   },
   {
     "id": 1763,
-    "entrezid": 879346,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22920,7 +21157,6 @@
   },
   {
     "id": 1764,
-    "entrezid": 879347,
     "description": "cbb3-type cytochrome C oxidase subunit I",
     "aliases": "-",
     "obsolete": false,
@@ -22933,7 +21169,6 @@
   },
   {
     "id": 1765,
-    "entrezid": 879348,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22946,7 +21181,6 @@
   },
   {
     "id": 1766,
-    "entrezid": 879349,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -22959,7 +21193,6 @@
   },
   {
     "id": 1767,
-    "entrezid": 879350,
     "description": "beta alanine--pyruvate transaminase",
     "aliases": "-",
     "obsolete": false,
@@ -22972,7 +21205,6 @@
   },
   {
     "id": 1768,
-    "entrezid": 879351,
     "description": "protease PfpI",
     "aliases": "-",
     "obsolete": false,
@@ -22985,7 +21217,6 @@
   },
   {
     "id": 1769,
-    "entrezid": 879352,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -22998,7 +21229,6 @@
   },
   {
     "id": 1770,
-    "entrezid": 879353,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23011,7 +21241,6 @@
   },
   {
     "id": 1771,
-    "entrezid": 879354,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -23024,7 +21253,6 @@
   },
   {
     "id": 1772,
-    "entrezid": 879355,
     "description": "pimeloyl-CoA synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -23037,7 +21265,6 @@
   },
   {
     "id": 1773,
-    "entrezid": 879356,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23050,7 +21277,6 @@
   },
   {
     "id": 1774,
-    "entrezid": 879357,
     "description": "sigma factor AlgU negative regulator MucA",
     "aliases": "-",
     "obsolete": false,
@@ -23063,7 +21289,6 @@
   },
   {
     "id": 1775,
-    "entrezid": 879358,
     "description": "translocator outer membrane protein PopD",
     "aliases": "-",
     "obsolete": false,
@@ -23076,7 +21301,6 @@
   },
   {
     "id": 1776,
-    "entrezid": 879359,
     "description": "molybdenum cofactor biosynthesis protein A",
     "aliases": "-",
     "obsolete": false,
@@ -23089,7 +21313,6 @@
   },
   {
     "id": 1777,
-    "entrezid": 879360,
     "description": "molybdopterin biosynthesis protein B",
     "aliases": "-",
     "obsolete": false,
@@ -23102,7 +21325,6 @@
   },
   {
     "id": 1778,
-    "entrezid": 879361,
     "description": "serine/threonine protein kinase PpkA",
     "aliases": "-",
     "obsolete": false,
@@ -23115,7 +21337,6 @@
   },
   {
     "id": 1779,
-    "entrezid": 879362,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23128,7 +21349,6 @@
   },
   {
     "id": 1780,
-    "entrezid": 879363,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -23141,7 +21361,6 @@
   },
   {
     "id": 1781,
-    "entrezid": 879364,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23154,7 +21373,6 @@
   },
   {
     "id": 1782,
-    "entrezid": 879365,
     "description": "aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -23167,7 +21385,6 @@
   },
   {
     "id": 1783,
-    "entrezid": 879366,
     "description": "protease",
     "aliases": "-",
     "obsolete": false,
@@ -23180,7 +21397,6 @@
   },
   {
     "id": 1784,
-    "entrezid": 879367,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23193,7 +21409,6 @@
   },
   {
     "id": 1785,
-    "entrezid": 879368,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23206,7 +21421,6 @@
   },
   {
     "id": 1786,
-    "entrezid": 879369,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23219,7 +21433,6 @@
   },
   {
     "id": 1787,
-    "entrezid": 879370,
     "description": "amino acid permease",
     "aliases": "-",
     "obsolete": false,
@@ -23232,7 +21445,6 @@
   },
   {
     "id": 1788,
-    "entrezid": 879371,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23245,7 +21457,6 @@
   },
   {
     "id": 1789,
-    "entrezid": 879372,
     "description": "recombination protein RecR",
     "aliases": "-",
     "obsolete": false,
@@ -23258,7 +21469,6 @@
   },
   {
     "id": 1790,
-    "entrezid": 879373,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23271,7 +21481,6 @@
   },
   {
     "id": 1791,
-    "entrezid": 879374,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23284,7 +21493,6 @@
   },
   {
     "id": 1792,
-    "entrezid": 879375,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23297,7 +21505,6 @@
   },
   {
     "id": 1793,
-    "entrezid": 879376,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23310,7 +21517,6 @@
   },
   {
     "id": 1794,
-    "entrezid": 879377,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23323,7 +21529,6 @@
   },
   {
     "id": 1795,
-    "entrezid": 879378,
     "description": "ring-cleaving dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -23336,7 +21541,6 @@
   },
   {
     "id": 1796,
-    "entrezid": 879379,
     "description": "23S rRNA (cytidine(2498)-2'-O)-methyltransferase RlmM",
     "aliases": "-",
     "obsolete": false,
@@ -23349,7 +21553,6 @@
   },
   {
     "id": 1797,
-    "entrezid": 879380,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23362,7 +21565,6 @@
   },
   {
     "id": 1798,
-    "entrezid": 879381,
     "description": "flagellar biosynthesis chaperone",
     "aliases": "-",
     "obsolete": false,
@@ -23375,7 +21577,6 @@
   },
   {
     "id": 1799,
-    "entrezid": 879382,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23388,7 +21589,6 @@
   },
   {
     "id": 1800,
-    "entrezid": 879383,
     "description": "type III secretion regulator",
     "aliases": "-",
     "obsolete": false,
@@ -23401,7 +21601,6 @@
   },
   {
     "id": 1801,
-    "entrezid": 879384,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -23414,7 +21613,6 @@
   },
   {
     "id": 1802,
-    "entrezid": 879385,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23427,7 +21625,6 @@
   },
   {
     "id": 1803,
-    "entrezid": 879386,
     "description": "glycosyl transferase family protein",
     "aliases": "-",
     "obsolete": false,
@@ -23440,7 +21637,6 @@
   },
   {
     "id": 1804,
-    "entrezid": 879387,
     "description": "cis,cis-muconate transporter MucK",
     "aliases": "-",
     "obsolete": false,
@@ -23453,7 +21649,6 @@
   },
   {
     "id": 1805,
-    "entrezid": 879388,
     "description": "cytochrome c oxidase assembly protein SenC",
     "aliases": "-",
     "obsolete": false,
@@ -23466,7 +21661,6 @@
   },
   {
     "id": 1806,
-    "entrezid": 879389,
     "description": "pyruvate carboxylase",
     "aliases": "-",
     "obsolete": false,
@@ -23479,7 +21673,6 @@
   },
   {
     "id": 1807,
-    "entrezid": 879390,
     "description": "transposase",
     "aliases": "-",
     "obsolete": false,
@@ -23492,7 +21685,6 @@
   },
   {
     "id": 1808,
-    "entrezid": 879391,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23505,7 +21697,6 @@
   },
   {
     "id": 1809,
-    "entrezid": 879392,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23518,7 +21709,6 @@
   },
   {
     "id": 1810,
-    "entrezid": 879393,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -23531,7 +21721,6 @@
   },
   {
     "id": 1811,
-    "entrezid": 879394,
     "description": "adenine phosphoribosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -23544,7 +21733,6 @@
   },
   {
     "id": 1812,
-    "entrezid": 879395,
     "description": "protoheme IX farnesyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -23557,7 +21745,6 @@
   },
   {
     "id": 1813,
-    "entrezid": 879396,
     "description": "type VI secretion protein IcmF",
     "aliases": "-",
     "obsolete": false,
@@ -23570,7 +21757,6 @@
   },
   {
     "id": 1814,
-    "entrezid": 879397,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23583,7 +21769,6 @@
   },
   {
     "id": 1815,
-    "entrezid": 879398,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23596,7 +21781,6 @@
   },
   {
     "id": 1816,
-    "entrezid": 879399,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -23609,7 +21793,6 @@
   },
   {
     "id": 1817,
-    "entrezid": 879400,
     "description": "Baeyer-Villiger monooxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -23622,7 +21805,6 @@
   },
   {
     "id": 1818,
-    "entrezid": 879401,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23635,7 +21817,6 @@
   },
   {
     "id": 1819,
-    "entrezid": 879402,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23648,7 +21829,6 @@
   },
   {
     "id": 1820,
-    "entrezid": 879403,
     "description": "ureidoglycolate hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -23661,7 +21841,6 @@
   },
   {
     "id": 1821,
-    "entrezid": 879404,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23674,7 +21853,6 @@
   },
   {
     "id": 1822,
-    "entrezid": 879405,
     "description": "deoxyuridine 5'-triphosphate nucleotidohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -23687,7 +21865,6 @@
   },
   {
     "id": 1823,
-    "entrezid": 879406,
     "description": "phosphomannomutase",
     "aliases": "-",
     "obsolete": false,
@@ -23700,7 +21877,6 @@
   },
   {
     "id": 1824,
-    "entrezid": 879407,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -23713,7 +21889,6 @@
   },
   {
     "id": 1825,
-    "entrezid": 879408,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23726,7 +21901,6 @@
   },
   {
     "id": 1826,
-    "entrezid": 879409,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23739,7 +21913,6 @@
   },
   {
     "id": 1827,
-    "entrezid": 879410,
     "description": "D-erythrose 4-phosphate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -23752,7 +21925,6 @@
   },
   {
     "id": 1828,
-    "entrezid": 879411,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -23765,7 +21937,6 @@
   },
   {
     "id": 1829,
-    "entrezid": 879412,
     "description": "aconitate hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -23778,7 +21949,6 @@
   },
   {
     "id": 1830,
-    "entrezid": 879413,
     "description": "Fha domain-containing protein",
     "aliases": "-",
     "obsolete": false,
@@ -23791,7 +21961,6 @@
   },
   {
     "id": 1831,
-    "entrezid": 879414,
     "description": "type II secretion system protein",
     "aliases": "-",
     "obsolete": false,
@@ -23804,7 +21973,6 @@
   },
   {
     "id": 1832,
-    "entrezid": 879415,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23817,7 +21985,6 @@
   },
   {
     "id": 1833,
-    "entrezid": 879416,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23830,7 +21997,6 @@
   },
   {
     "id": 1834,
-    "entrezid": 879417,
     "description": "thymidylate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -23843,7 +22009,6 @@
   },
   {
     "id": 1835,
-    "entrezid": 879418,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23856,7 +22021,6 @@
   },
   {
     "id": 1836,
-    "entrezid": 879419,
     "description": "glycosyl transferase family protein",
     "aliases": "-",
     "obsolete": false,
@@ -23869,7 +22033,6 @@
   },
   {
     "id": 1837,
-    "entrezid": 879420,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -23882,7 +22045,6 @@
   },
   {
     "id": 1838,
-    "entrezid": 879421,
     "description": "adenylate cyclase",
     "aliases": "-",
     "obsolete": false,
@@ -23895,7 +22057,6 @@
   },
   {
     "id": 1839,
-    "entrezid": 879422,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23908,7 +22069,6 @@
   },
   {
     "id": 1840,
-    "entrezid": 879423,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -23921,7 +22081,6 @@
   },
   {
     "id": 1841,
-    "entrezid": 879424,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23934,7 +22093,6 @@
   },
   {
     "id": 1842,
-    "entrezid": 879425,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23947,7 +22105,6 @@
   },
   {
     "id": 1843,
-    "entrezid": 879426,
     "description": "50S ribosomal protein L35",
     "aliases": "-",
     "obsolete": false,
@@ -23960,7 +22117,6 @@
   },
   {
     "id": 1844,
-    "entrezid": 879427,
     "description": "translation initiation factor IF-3",
     "aliases": "-",
     "obsolete": false,
@@ -23973,7 +22129,6 @@
   },
   {
     "id": 1845,
-    "entrezid": 879428,
     "description": "para-aminobenzoate synthase component I",
     "aliases": "-",
     "obsolete": false,
@@ -23986,7 +22141,6 @@
   },
   {
     "id": 1846,
-    "entrezid": 879429,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -23999,7 +22153,6 @@
   },
   {
     "id": 1847,
-    "entrezid": 879430,
     "description": "spermidine/putrescine-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -24012,7 +22165,6 @@
   },
   {
     "id": 1848,
-    "entrezid": 879431,
     "description": "alkyl hydroperoxide reductase",
     "aliases": "-",
     "obsolete": false,
@@ -24025,7 +22177,6 @@
   },
   {
     "id": 1849,
-    "entrezid": 879432,
     "description": "HTH-type transcriptional activator BauR",
     "aliases": "-",
     "obsolete": false,
@@ -24038,7 +22189,6 @@
   },
   {
     "id": 1850,
-    "entrezid": 879433,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -24051,7 +22201,6 @@
   },
   {
     "id": 1851,
-    "entrezid": 879434,
     "description": "transcriptional regulator ArgR",
     "aliases": "-",
     "obsolete": false,
@@ -24064,7 +22213,6 @@
   },
   {
     "id": 1852,
-    "entrezid": 879435,
     "description": "threonine dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -24077,7 +22225,6 @@
   },
   {
     "id": 1853,
-    "entrezid": 879436,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24090,7 +22237,6 @@
   },
   {
     "id": 1854,
-    "entrezid": 879437,
     "description": "arginine N-succinyltransferase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -24103,7 +22249,6 @@
   },
   {
     "id": 1855,
-    "entrezid": 879438,
     "description": "citrate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -24116,7 +22261,6 @@
   },
   {
     "id": 1856,
-    "entrezid": 879439,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24129,7 +22273,6 @@
   },
   {
     "id": 1857,
-    "entrezid": 879440,
     "description": "MFS metabolite transporter",
     "aliases": "-",
     "obsolete": false,
@@ -24142,7 +22285,6 @@
   },
   {
     "id": 1858,
-    "entrezid": 879441,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24155,7 +22297,6 @@
   },
   {
     "id": 1859,
-    "entrezid": 879442,
     "description": "amino acid APC family transporter",
     "aliases": "-",
     "obsolete": false,
@@ -24168,7 +22309,6 @@
   },
   {
     "id": 1860,
-    "entrezid": 879443,
     "description": "glutathione peroxidase",
     "aliases": "-",
     "obsolete": false,
@@ -24181,7 +22321,6 @@
   },
   {
     "id": 1861,
-    "entrezid": 879444,
     "description": "gamma-glutamyltranspeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -24194,7 +22333,6 @@
   },
   {
     "id": 1862,
-    "entrezid": 879445,
     "description": "amidase",
     "aliases": "-",
     "obsolete": false,
@@ -24207,7 +22345,6 @@
   },
   {
     "id": 1863,
-    "entrezid": 879446,
     "description": "protein secretion apparatus assembly protein",
     "aliases": "-",
     "obsolete": false,
@@ -24220,7 +22357,6 @@
   },
   {
     "id": 1864,
-    "entrezid": 879447,
     "description": "8-oxoguanine deaminase",
     "aliases": "-",
     "obsolete": false,
@@ -24233,7 +22369,6 @@
   },
   {
     "id": 1865,
-    "entrezid": 879448,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24246,7 +22381,6 @@
   },
   {
     "id": 1866,
-    "entrezid": 879449,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24259,7 +22393,6 @@
   },
   {
     "id": 1867,
-    "entrezid": 879450,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24272,7 +22405,6 @@
   },
   {
     "id": 1868,
-    "entrezid": 879451,
     "description": "nonspecific ribonucleoside hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -24285,7 +22417,6 @@
   },
   {
     "id": 1869,
-    "entrezid": 879452,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24298,7 +22429,6 @@
   },
   {
     "id": 1870,
-    "entrezid": 879453,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24311,7 +22441,6 @@
   },
   {
     "id": 1871,
-    "entrezid": 879454,
     "description": "glyoxylate carboligase",
     "aliases": "-",
     "obsolete": false,
@@ -24324,7 +22453,6 @@
   },
   {
     "id": 1872,
-    "entrezid": 879455,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24337,7 +22465,6 @@
   },
   {
     "id": 1873,
-    "entrezid": 879456,
     "description": "type 4 fimbrial biogenesis protein PilW",
     "aliases": "-",
     "obsolete": false,
@@ -24350,7 +22477,6 @@
   },
   {
     "id": 1874,
-    "entrezid": 879457,
     "description": "chaperone protein ClpB",
     "aliases": "-",
     "obsolete": false,
@@ -24363,7 +22489,6 @@
   },
   {
     "id": 1875,
-    "entrezid": 879458,
     "description": "flagellar basal body L-ring protein",
     "aliases": "-",
     "obsolete": false,
@@ -24376,7 +22501,6 @@
   },
   {
     "id": 1876,
-    "entrezid": 879459,
     "description": "type 4 fimbrial biogenesis protein PilB",
     "aliases": "-",
     "obsolete": false,
@@ -24389,7 +22513,6 @@
   },
   {
     "id": 1877,
-    "entrezid": 879460,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -24402,7 +22525,6 @@
   },
   {
     "id": 1878,
-    "entrezid": 879461,
     "description": "pili assembly chaperone",
     "aliases": "-",
     "obsolete": false,
@@ -24415,7 +22537,6 @@
   },
   {
     "id": 1879,
-    "entrezid": 879462,
     "description": "cytochrome c55X",
     "aliases": "-",
     "obsolete": false,
@@ -24428,7 +22549,6 @@
   },
   {
     "id": 1880,
-    "entrezid": 879463,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24441,7 +22561,6 @@
   },
   {
     "id": 1881,
-    "entrezid": 879464,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24454,7 +22573,6 @@
   },
   {
     "id": 1882,
-    "entrezid": 879465,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24467,7 +22585,6 @@
   },
   {
     "id": 1883,
-    "entrezid": 879466,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24480,7 +22597,6 @@
   },
   {
     "id": 1884,
-    "entrezid": 879467,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24493,7 +22609,6 @@
   },
   {
     "id": 1885,
-    "entrezid": 879468,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24506,7 +22621,6 @@
   },
   {
     "id": 1886,
-    "entrezid": 879469,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24519,7 +22633,6 @@
   },
   {
     "id": 1887,
-    "entrezid": 879470,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -24532,7 +22645,6 @@
   },
   {
     "id": 1888,
-    "entrezid": 879471,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -24545,7 +22657,6 @@
   },
   {
     "id": 1889,
-    "entrezid": 879472,
     "description": "transporter TonB",
     "aliases": "-",
     "obsolete": false,
@@ -24558,7 +22669,6 @@
   },
   {
     "id": 1890,
-    "entrezid": 879473,
     "description": "anaerobically-induced outer membrane porin OprE",
     "aliases": "-",
     "obsolete": false,
@@ -24571,7 +22681,6 @@
   },
   {
     "id": 1891,
-    "entrezid": 879474,
     "description": "glutamate--cysteine ligase",
     "aliases": "-",
     "obsolete": false,
@@ -24584,7 +22693,6 @@
   },
   {
     "id": 1892,
-    "entrezid": 879475,
     "description": "N-acetylglutamate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -24597,7 +22705,6 @@
   },
   {
     "id": 1893,
-    "entrezid": 879476,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24610,7 +22717,6 @@
   },
   {
     "id": 1894,
-    "entrezid": 879477,
     "description": "malate synthase G",
     "aliases": "-",
     "obsolete": false,
@@ -24623,7 +22729,6 @@
   },
   {
     "id": 1895,
-    "entrezid": 879478,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -24636,7 +22741,6 @@
   },
   {
     "id": 1896,
-    "entrezid": 879479,
     "description": "tryptophan synthase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -24649,7 +22753,6 @@
   },
   {
     "id": 1897,
-    "entrezid": 879480,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -24662,7 +22765,6 @@
   },
   {
     "id": 1898,
-    "entrezid": 879481,
     "description": "chorismate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -24675,7 +22777,6 @@
   },
   {
     "id": 1899,
-    "entrezid": 879482,
     "description": "iron-sulfur cluster insertion protein ErpA",
     "aliases": "-",
     "obsolete": false,
@@ -24688,7 +22789,6 @@
   },
   {
     "id": 1900,
-    "entrezid": 879483,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24701,7 +22801,6 @@
   },
   {
     "id": 1901,
-    "entrezid": 879484,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24714,7 +22813,6 @@
   },
   {
     "id": 1902,
-    "entrezid": 879485,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24727,7 +22825,6 @@
   },
   {
     "id": 1903,
-    "entrezid": 879486,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24740,7 +22837,6 @@
   },
   {
     "id": 1904,
-    "entrezid": 879487,
     "description": "GTPase Era",
     "aliases": "-",
     "obsolete": false,
@@ -24753,7 +22849,6 @@
   },
   {
     "id": 1905,
-    "entrezid": 879488,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24766,7 +22861,6 @@
   },
   {
     "id": 1906,
-    "entrezid": 879489,
     "description": "malonate decarboxylase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -24779,7 +22873,6 @@
   },
   {
     "id": 1907,
-    "entrezid": 879490,
     "description": "biopolymer transport protein ExbD",
     "aliases": "-",
     "obsolete": false,
@@ -24792,7 +22885,6 @@
   },
   {
     "id": 1908,
-    "entrezid": 879491,
     "description": "2-hydroxy-3-oxopropionate reductase",
     "aliases": "-",
     "obsolete": false,
@@ -24805,7 +22897,6 @@
   },
   {
     "id": 1909,
-    "entrezid": 879492,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24818,7 +22909,6 @@
   },
   {
     "id": 1910,
-    "entrezid": 879493,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24831,7 +22921,6 @@
   },
   {
     "id": 1911,
-    "entrezid": 879494,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24844,7 +22933,6 @@
   },
   {
     "id": 1912,
-    "entrezid": 879495,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24857,7 +22945,6 @@
   },
   {
     "id": 1913,
-    "entrezid": 879496,
     "description": "acyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -24870,7 +22957,6 @@
   },
   {
     "id": 1914,
-    "entrezid": 879497,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24883,7 +22969,6 @@
   },
   {
     "id": 1915,
-    "entrezid": 879498,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24896,7 +22981,6 @@
   },
   {
     "id": 1916,
-    "entrezid": 879499,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24909,7 +22993,6 @@
   },
   {
     "id": 1917,
-    "entrezid": 879500,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24922,7 +23005,6 @@
   },
   {
     "id": 1918,
-    "entrezid": 879501,
     "description": "NAD(P)H dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -24935,7 +23017,6 @@
   },
   {
     "id": 1919,
-    "entrezid": 879502,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -24948,7 +23029,6 @@
   },
   {
     "id": 1920,
-    "entrezid": 879503,
     "description": "heme d1 biosynthesis protein NirJ",
     "aliases": "-",
     "obsolete": false,
@@ -24961,7 +23041,6 @@
   },
   {
     "id": 1921,
-    "entrezid": 879504,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -24974,7 +23053,6 @@
   },
   {
     "id": 1922,
-    "entrezid": 879505,
     "description": "gamma-glutamyltranspeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -24987,7 +23065,6 @@
   },
   {
     "id": 1923,
-    "entrezid": 879506,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25000,7 +23077,6 @@
   },
   {
     "id": 1924,
-    "entrezid": 879507,
     "description": "malonate decarboxylase subunit gamma",
     "aliases": "-",
     "obsolete": false,
@@ -25013,7 +23089,6 @@
   },
   {
     "id": 1925,
-    "entrezid": 879508,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25026,7 +23101,6 @@
   },
   {
     "id": 1926,
-    "entrezid": 879509,
     "description": "ammonium transporter",
     "aliases": "-",
     "obsolete": false,
@@ -25039,7 +23113,6 @@
   },
   {
     "id": 1927,
-    "entrezid": 879510,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25052,7 +23125,6 @@
   },
   {
     "id": 1928,
-    "entrezid": 879511,
     "description": "type VI secretion system protein VgrG",
     "aliases": "-",
     "obsolete": false,
@@ -25065,7 +23137,6 @@
   },
   {
     "id": 1929,
-    "entrezid": 879512,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25078,7 +23149,6 @@
   },
   {
     "id": 1930,
-    "entrezid": 879513,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25091,7 +23161,6 @@
   },
   {
     "id": 1931,
-    "entrezid": 879514,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -25104,7 +23173,6 @@
   },
   {
     "id": 1932,
-    "entrezid": 879515,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -25117,7 +23185,6 @@
   },
   {
     "id": 1933,
-    "entrezid": 879516,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -25130,7 +23197,6 @@
   },
   {
     "id": 1934,
-    "entrezid": 879517,
     "description": "alkane-1 monooxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -25143,7 +23209,6 @@
   },
   {
     "id": 1935,
-    "entrezid": 879518,
     "description": "histidine porin OpdC",
     "aliases": "-",
     "obsolete": false,
@@ -25156,7 +23221,6 @@
   },
   {
     "id": 1936,
-    "entrezid": 879519,
     "description": "translation initiation factor Sui1",
     "aliases": "-",
     "obsolete": false,
@@ -25169,7 +23233,6 @@
   },
   {
     "id": 1937,
-    "entrezid": 879520,
     "description": "sulfurtransferase TusA",
     "aliases": "-",
     "obsolete": false,
@@ -25182,7 +23245,6 @@
   },
   {
     "id": 1938,
-    "entrezid": 879521,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25195,7 +23257,6 @@
   },
   {
     "id": 1939,
-    "entrezid": 879522,
     "description": "protein AmbD",
     "aliases": "-",
     "obsolete": false,
@@ -25208,7 +23269,6 @@
   },
   {
     "id": 1940,
-    "entrezid": 879523,
     "description": "4Fe-4S ferredoxin",
     "aliases": "-",
     "obsolete": false,
@@ -25221,7 +23281,6 @@
   },
   {
     "id": 1941,
-    "entrezid": 879524,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -25234,7 +23293,6 @@
   },
   {
     "id": 1942,
-    "entrezid": 879525,
     "description": "4-hydroxy-tetrahydrodipicolinate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -25247,7 +23305,6 @@
   },
   {
     "id": 1943,
-    "entrezid": 879526,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25260,7 +23317,6 @@
   },
   {
     "id": 1944,
-    "entrezid": 879527,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25273,7 +23329,6 @@
   },
   {
     "id": 1945,
-    "entrezid": 879528,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -25286,7 +23341,6 @@
   },
   {
     "id": 1946,
-    "entrezid": 879529,
     "description": "malonate transporter MadM",
     "aliases": "-",
     "obsolete": false,
@@ -25299,7 +23353,6 @@
   },
   {
     "id": 1947,
-    "entrezid": 879530,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25312,7 +23365,6 @@
   },
   {
     "id": 1948,
-    "entrezid": 879531,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25325,7 +23377,6 @@
   },
   {
     "id": 1949,
-    "entrezid": 879532,
     "description": "alcohol dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -25338,7 +23389,6 @@
   },
   {
     "id": 1950,
-    "entrezid": 879533,
     "description": "NAD-dependent protein deacylase",
     "aliases": "-",
     "obsolete": false,
@@ -25351,7 +23401,6 @@
   },
   {
     "id": 1951,
-    "entrezid": 879534,
     "description": "thiolase",
     "aliases": "-",
     "obsolete": false,
@@ -25364,7 +23413,6 @@
   },
   {
     "id": 1952,
-    "entrezid": 879535,
     "description": "cell division protein ZipA",
     "aliases": "-",
     "obsolete": false,
@@ -25377,7 +23425,6 @@
   },
   {
     "id": 1953,
-    "entrezid": 879536,
     "description": "translocation protein in type III secretion",
     "aliases": "-",
     "obsolete": false,
@@ -25390,7 +23437,6 @@
   },
   {
     "id": 1954,
-    "entrezid": 879537,
     "description": "gluconate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -25403,7 +23449,6 @@
   },
   {
     "id": 1955,
-    "entrezid": 879538,
     "description": "heme d1 biosynthesis protein NirD",
     "aliases": "-",
     "obsolete": false,
@@ -25416,7 +23461,6 @@
   },
   {
     "id": 1956,
-    "entrezid": 879539,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25429,7 +23473,6 @@
   },
   {
     "id": 1957,
-    "entrezid": 879540,
     "description": "2-heptyl-3-hydroxy-4(1H)-quinolone synthase",
     "aliases": "-",
     "obsolete": false,
@@ -25442,7 +23485,6 @@
   },
   {
     "id": 1958,
-    "entrezid": 879541,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -25455,7 +23497,6 @@
   },
   {
     "id": 1959,
-    "entrezid": 879542,
     "description": "phosphate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -25468,7 +23509,6 @@
   },
   {
     "id": 1960,
-    "entrezid": 879543,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25481,7 +23521,6 @@
   },
   {
     "id": 1961,
-    "entrezid": 879544,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25494,7 +23533,6 @@
   },
   {
     "id": 1962,
-    "entrezid": 879545,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25507,7 +23545,6 @@
   },
   {
     "id": 1963,
-    "entrezid": 879546,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -25520,7 +23557,6 @@
   },
   {
     "id": 1964,
-    "entrezid": 879547,
     "description": "arachidonate 15-lipoxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -25533,7 +23569,6 @@
   },
   {
     "id": 1965,
-    "entrezid": 879548,
     "description": "Bkd operon transcriptional regulator BkdR",
     "aliases": "-",
     "obsolete": false,
@@ -25546,7 +23581,6 @@
   },
   {
     "id": 1966,
-    "entrezid": 879549,
     "description": "phosphoribosylformylglycinamidine cyclo-ligase",
     "aliases": "-",
     "obsolete": false,
@@ -25559,7 +23593,6 @@
   },
   {
     "id": 1967,
-    "entrezid": 879550,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25572,7 +23605,6 @@
   },
   {
     "id": 1968,
-    "entrezid": 879551,
     "description": "carbon-phosphorus lyase complex accessory protein",
     "aliases": "-",
     "obsolete": false,
@@ -25585,7 +23617,6 @@
   },
   {
     "id": 1969,
-    "entrezid": 879552,
     "description": "chaperone SurA",
     "aliases": "-",
     "obsolete": false,
@@ -25598,7 +23629,6 @@
   },
   {
     "id": 1970,
-    "entrezid": 879553,
     "description": "secretion protein ClpV1",
     "aliases": "-",
     "obsolete": false,
@@ -25611,7 +23641,6 @@
   },
   {
     "id": 1971,
-    "entrezid": 879554,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -25624,7 +23653,6 @@
   },
   {
     "id": 1972,
-    "entrezid": 879555,
     "description": "amino acid permease",
     "aliases": "-",
     "obsolete": false,
@@ -25637,7 +23665,6 @@
   },
   {
     "id": 1973,
-    "entrezid": 879556,
     "description": "acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -25650,7 +23677,6 @@
   },
   {
     "id": 1974,
-    "entrezid": 879557,
     "description": "acetyl-CoA carboxylase biotin carboxyl carrier protein subunit",
     "aliases": "-",
     "obsolete": false,
@@ -25663,7 +23689,6 @@
   },
   {
     "id": 1975,
-    "entrezid": 879558,
     "description": "acetyl-CoA carboxylase biotin carboxylase subunit",
     "aliases": "-",
     "obsolete": false,
@@ -25676,7 +23701,6 @@
   },
   {
     "id": 1976,
-    "entrezid": 879559,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25689,7 +23713,6 @@
   },
   {
     "id": 1977,
-    "entrezid": 879560,
     "description": "adhesion protein",
     "aliases": "-",
     "obsolete": false,
@@ -25702,7 +23725,6 @@
   },
   {
     "id": 1978,
-    "entrezid": 879561,
     "description": "rubredoxin",
     "aliases": "-",
     "obsolete": false,
@@ -25715,7 +23737,6 @@
   },
   {
     "id": 1979,
-    "entrezid": 879562,
     "description": "rubredoxin",
     "aliases": "-",
     "obsolete": false,
@@ -25728,7 +23749,6 @@
   },
   {
     "id": 1980,
-    "entrezid": 879563,
     "description": "proline--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -25741,7 +23761,6 @@
   },
   {
     "id": 1981,
-    "entrezid": 879564,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -25754,7 +23773,6 @@
   },
   {
     "id": 1982,
-    "entrezid": 879565,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25767,7 +23785,6 @@
   },
   {
     "id": 1983,
-    "entrezid": 879566,
     "description": "elongation factor G",
     "aliases": "-",
     "obsolete": false,
@@ -25780,7 +23797,6 @@
   },
   {
     "id": 1984,
-    "entrezid": 879567,
     "description": "type III export protein PscI",
     "aliases": "-",
     "obsolete": false,
@@ -25793,7 +23809,6 @@
   },
   {
     "id": 1985,
-    "entrezid": 879568,
     "description": "type III export apparatus protein",
     "aliases": "-",
     "obsolete": false,
@@ -25806,7 +23821,6 @@
   },
   {
     "id": 1986,
-    "entrezid": 879569,
     "description": "chemotaxis transducer",
     "aliases": "-",
     "obsolete": false,
@@ -25819,7 +23833,6 @@
   },
   {
     "id": 1987,
-    "entrezid": 879570,
     "description": "thiol:disulfide interchange protein",
     "aliases": "-",
     "obsolete": false,
@@ -25832,7 +23845,6 @@
   },
   {
     "id": 1988,
-    "entrezid": 879571,
     "description": "cytochrome C",
     "aliases": "-",
     "obsolete": false,
@@ -25845,7 +23857,6 @@
   },
   {
     "id": 1989,
-    "entrezid": 879572,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25858,7 +23869,6 @@
   },
   {
     "id": 1990,
-    "entrezid": 879573,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25871,7 +23881,6 @@
   },
   {
     "id": 1991,
-    "entrezid": 879574,
     "description": "multiple drug resistance protein MarC",
     "aliases": "-",
     "obsolete": false,
@@ -25884,7 +23893,6 @@
   },
   {
     "id": 1992,
-    "entrezid": 879575,
     "description": "acetylornithine deacetylase",
     "aliases": "-",
     "obsolete": false,
@@ -25897,7 +23905,6 @@
   },
   {
     "id": 1993,
-    "entrezid": 879576,
     "description": "transmembrane sensor",
     "aliases": "-",
     "obsolete": false,
@@ -25910,7 +23917,6 @@
   },
   {
     "id": 1994,
-    "entrezid": 879577,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25923,7 +23929,6 @@
   },
   {
     "id": 1995,
-    "entrezid": 879578,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25936,7 +23941,6 @@
   },
   {
     "id": 1996,
-    "entrezid": 879579,
     "description": "secreted protein Hcp",
     "aliases": "-",
     "obsolete": false,
@@ -25949,7 +23953,6 @@
   },
   {
     "id": 1997,
-    "entrezid": 879580,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25962,7 +23965,6 @@
   },
   {
     "id": 1998,
-    "entrezid": 879581,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25975,7 +23977,6 @@
   },
   {
     "id": 1999,
-    "entrezid": 879583,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -25988,7 +23989,6 @@
   },
   {
     "id": 2000,
-    "entrezid": 879584,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26001,7 +24001,6 @@
   },
   {
     "id": 2001,
-    "entrezid": 879585,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -26014,7 +24013,6 @@
   },
   {
     "id": 2002,
-    "entrezid": 879586,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26027,7 +24025,6 @@
   },
   {
     "id": 2003,
-    "entrezid": 879587,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26040,7 +24037,6 @@
   },
   {
     "id": 2004,
-    "entrezid": 879588,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26053,7 +24049,6 @@
   },
   {
     "id": 2005,
-    "entrezid": 879589,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26066,7 +24061,6 @@
   },
   {
     "id": 2006,
-    "entrezid": 879590,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26079,7 +24073,6 @@
   },
   {
     "id": 2007,
-    "entrezid": 879591,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -26092,7 +24085,6 @@
   },
   {
     "id": 2008,
-    "entrezid": 879592,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26105,7 +24097,6 @@
   },
   {
     "id": 2009,
-    "entrezid": 879593,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26118,7 +24109,6 @@
   },
   {
     "id": 2010,
-    "entrezid": 879594,
     "description": "arginine decarboxylase",
     "aliases": "-",
     "obsolete": false,
@@ -26131,7 +24121,6 @@
   },
   {
     "id": 2011,
-    "entrezid": 879595,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26144,7 +24133,6 @@
   },
   {
     "id": 2012,
-    "entrezid": 879596,
     "description": "delta-9 fatty acid desaturase DesA",
     "aliases": "-",
     "obsolete": false,
@@ -26157,7 +24145,6 @@
   },
   {
     "id": 2013,
-    "entrezid": 879597,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26170,7 +24157,6 @@
   },
   {
     "id": 2014,
-    "entrezid": 879598,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26183,7 +24169,6 @@
   },
   {
     "id": 2015,
-    "entrezid": 879599,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26196,7 +24181,6 @@
   },
   {
     "id": 2016,
-    "entrezid": 879600,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -26209,7 +24193,6 @@
   },
   {
     "id": 2017,
-    "entrezid": 879601,
     "description": "regulatory protein TypA",
     "aliases": "-",
     "obsolete": false,
@@ -26222,7 +24205,6 @@
   },
   {
     "id": 2018,
-    "entrezid": 879602,
     "description": "resistance-nodulation-cell division (RND) efflux transporter",
     "aliases": "-",
     "obsolete": false,
@@ -26235,7 +24217,6 @@
   },
   {
     "id": 2019,
-    "entrezid": 879603,
     "description": "resistance-nodulation-cell division (RND) efflux membrane fusion protein",
     "aliases": "-",
     "obsolete": false,
@@ -26248,7 +24229,6 @@
   },
   {
     "id": 2020,
-    "entrezid": 879604,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26261,7 +24241,6 @@
   },
   {
     "id": 2021,
-    "entrezid": 879605,
     "description": "30S ribosomal protein S20",
     "aliases": "-",
     "obsolete": false,
@@ -26274,7 +24253,6 @@
   },
   {
     "id": 2022,
-    "entrezid": 879606,
     "description": "type 4 fimbrial biogenesis protein FimU",
     "aliases": "-",
     "obsolete": false,
@@ -26287,7 +24265,6 @@
   },
   {
     "id": 2023,
-    "entrezid": 879607,
     "description": "type 4 fimbrial biogenesis protein PilV",
     "aliases": "-",
     "obsolete": false,
@@ -26300,7 +24277,6 @@
   },
   {
     "id": 2024,
-    "entrezid": 879608,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26313,7 +24289,6 @@
   },
   {
     "id": 2025,
-    "entrezid": 879609,
     "description": "Holliday junction ATP-dependent DNA helicase RuvA",
     "aliases": "-",
     "obsolete": false,
@@ -26326,7 +24301,6 @@
   },
   {
     "id": 2026,
-    "entrezid": 879610,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26339,7 +24313,6 @@
   },
   {
     "id": 2027,
-    "entrezid": 879611,
     "description": "transcription elongation factor GreB",
     "aliases": "-",
     "obsolete": false,
@@ -26352,7 +24325,6 @@
   },
   {
     "id": 2028,
-    "entrezid": 879612,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26365,7 +24337,6 @@
   },
   {
     "id": 2029,
-    "entrezid": 879613,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26378,7 +24349,6 @@
   },
   {
     "id": 2030,
-    "entrezid": 879615,
     "description": "NAD(P)H-dependent FMN reductase",
     "aliases": "-",
     "obsolete": false,
@@ -26391,7 +24361,6 @@
   },
   {
     "id": 2031,
-    "entrezid": 879616,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -26404,7 +24373,6 @@
   },
   {
     "id": 2032,
-    "entrezid": 879617,
     "description": "alcohol dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -26417,7 +24385,6 @@
   },
   {
     "id": 2033,
-    "entrezid": 879618,
     "description": "flagellar basal body rod protein FlgC",
     "aliases": "-",
     "obsolete": false,
@@ -26430,7 +24397,6 @@
   },
   {
     "id": 2034,
-    "entrezid": 879619,
     "description": "8-amino-7-oxononanoate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -26443,7 +24409,6 @@
   },
   {
     "id": 2035,
-    "entrezid": 879620,
     "description": "acetylglutamate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -26456,7 +24421,6 @@
   },
   {
     "id": 2036,
-    "entrezid": 879621,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -26469,7 +24433,6 @@
   },
   {
     "id": 2037,
-    "entrezid": 879622,
     "description": "sulfate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -26482,7 +24445,6 @@
   },
   {
     "id": 2038,
-    "entrezid": 879623,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26495,7 +24457,6 @@
   },
   {
     "id": 2039,
-    "entrezid": 879624,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26508,7 +24469,6 @@
   },
   {
     "id": 2040,
-    "entrezid": 879625,
     "description": "replicative DNA helicase",
     "aliases": "-",
     "obsolete": false,
@@ -26521,7 +24481,6 @@
   },
   {
     "id": 2041,
-    "entrezid": 879626,
     "description": "50S ribosomal protein L9",
     "aliases": "-",
     "obsolete": false,
@@ -26534,7 +24493,6 @@
   },
   {
     "id": 2042,
-    "entrezid": 879627,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26547,7 +24505,6 @@
   },
   {
     "id": 2043,
-    "entrezid": 879628,
     "description": "glucosyltransferase MdoH",
     "aliases": "-",
     "obsolete": false,
@@ -26560,7 +24517,6 @@
   },
   {
     "id": 2044,
-    "entrezid": 879629,
     "description": "glucan biosynthesis protein G",
     "aliases": "-",
     "obsolete": false,
@@ -26573,7 +24529,6 @@
   },
   {
     "id": 2045,
-    "entrezid": 879630,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26586,7 +24541,6 @@
   },
   {
     "id": 2046,
-    "entrezid": 879631,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26599,7 +24553,6 @@
   },
   {
     "id": 2047,
-    "entrezid": 879632,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -26612,7 +24565,6 @@
   },
   {
     "id": 2048,
-    "entrezid": 879633,
     "description": "3-guanidinopropionate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -26625,7 +24577,6 @@
   },
   {
     "id": 2049,
-    "entrezid": 879634,
     "description": "type III export protein PscF",
     "aliases": "-",
     "obsolete": false,
@@ -26638,7 +24589,6 @@
   },
   {
     "id": 2050,
-    "entrezid": 879635,
     "description": "alginate biosynthesis protein AlgZ/FimS",
     "aliases": "-",
     "obsolete": false,
@@ -26651,7 +24601,6 @@
   },
   {
     "id": 2051,
-    "entrezid": 879636,
     "description": "argininosuccinate lyase",
     "aliases": "-",
     "obsolete": false,
@@ -26664,7 +24613,6 @@
   },
   {
     "id": 2052,
-    "entrezid": 879637,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -26677,7 +24625,6 @@
   },
   {
     "id": 2053,
-    "entrezid": 879638,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -26690,7 +24637,6 @@
   },
   {
     "id": 2054,
-    "entrezid": 879639,
     "description": "3-oxoadipate enol-lactonase",
     "aliases": "-",
     "obsolete": false,
@@ -26703,7 +24649,6 @@
   },
   {
     "id": 2055,
-    "entrezid": 879640,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26716,7 +24661,6 @@
   },
   {
     "id": 2056,
-    "entrezid": 879641,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26729,7 +24673,6 @@
   },
   {
     "id": 2057,
-    "entrezid": 879642,
     "description": "DNA-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -26742,7 +24685,6 @@
   },
   {
     "id": 2058,
-    "entrezid": 879643,
     "description": "rubredoxin reductase",
     "aliases": "-",
     "obsolete": false,
@@ -26755,7 +24697,6 @@
   },
   {
     "id": 2059,
-    "entrezid": 879644,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26768,7 +24709,6 @@
   },
   {
     "id": 2060,
-    "entrezid": 879645,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26781,7 +24721,6 @@
   },
   {
     "id": 2061,
-    "entrezid": 879646,
     "description": "acetyl-CoA acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -26794,7 +24733,6 @@
   },
   {
     "id": 2062,
-    "entrezid": 879647,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26807,7 +24745,6 @@
   },
   {
     "id": 2063,
-    "entrezid": 879648,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26820,7 +24757,6 @@
   },
   {
     "id": 2064,
-    "entrezid": 879649,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26833,7 +24769,6 @@
   },
   {
     "id": 2065,
-    "entrezid": 879650,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26846,7 +24781,6 @@
   },
   {
     "id": 2066,
-    "entrezid": 879651,
     "description": "methanesulfonate monooxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -26859,7 +24793,6 @@
   },
   {
     "id": 2067,
-    "entrezid": 879652,
     "description": "heat shock protein",
     "aliases": "-",
     "obsolete": false,
@@ -26872,7 +24805,6 @@
   },
   {
     "id": 2068,
-    "entrezid": 879653,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26885,7 +24817,6 @@
   },
   {
     "id": 2069,
-    "entrezid": 879654,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26898,7 +24829,6 @@
   },
   {
     "id": 2070,
-    "entrezid": 879655,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -26911,7 +24841,6 @@
   },
   {
     "id": 2071,
-    "entrezid": 879656,
     "description": "acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -26924,7 +24853,6 @@
   },
   {
     "id": 2072,
-    "entrezid": 879657,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26937,7 +24865,6 @@
   },
   {
     "id": 2073,
-    "entrezid": 879658,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26950,7 +24877,6 @@
   },
   {
     "id": 2074,
-    "entrezid": 879659,
     "description": "2-isopropylmalate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -26963,7 +24889,6 @@
   },
   {
     "id": 2075,
-    "entrezid": 879660,
     "description": "2-hydroxyacid dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -26976,7 +24901,6 @@
   },
   {
     "id": 2076,
-    "entrezid": 879661,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -26989,7 +24913,6 @@
   },
   {
     "id": 2077,
-    "entrezid": 879662,
     "description": "flagellar basal body protein FliL",
     "aliases": "-",
     "obsolete": false,
@@ -27002,7 +24925,6 @@
   },
   {
     "id": 2078,
-    "entrezid": 879663,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -27015,7 +24937,6 @@
   },
   {
     "id": 2079,
-    "entrezid": 879664,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27028,7 +24949,6 @@
   },
   {
     "id": 2080,
-    "entrezid": 879665,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27041,7 +24961,6 @@
   },
   {
     "id": 2081,
-    "entrezid": 879666,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -27054,7 +24973,6 @@
   },
   {
     "id": 2082,
-    "entrezid": 879667,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27067,7 +24985,6 @@
   },
   {
     "id": 2083,
-    "entrezid": 879668,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -27080,7 +24997,6 @@
   },
   {
     "id": 2084,
-    "entrezid": 879669,
     "description": "4-hydroxy-3-methylbut-2-enyl diphosphate reductase",
     "aliases": "-",
     "obsolete": false,
@@ -27093,7 +25009,6 @@
   },
   {
     "id": 2085,
-    "entrezid": 879670,
     "description": "sec-independent translocase",
     "aliases": "-",
     "obsolete": false,
@@ -27106,7 +25021,6 @@
   },
   {
     "id": 2086,
-    "entrezid": 879671,
     "description": "transporter TatC",
     "aliases": "-",
     "obsolete": false,
@@ -27119,7 +25033,6 @@
   },
   {
     "id": 2087,
-    "entrezid": 879672,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27132,7 +25045,6 @@
   },
   {
     "id": 2088,
-    "entrezid": 879673,
     "description": "ECF subfamily sigma-70 factor",
     "aliases": "-",
     "obsolete": false,
@@ -27145,7 +25057,6 @@
   },
   {
     "id": 2089,
-    "entrezid": 879674,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27158,7 +25069,6 @@
   },
   {
     "id": 2090,
-    "entrezid": 879675,
     "description": "secretion pathway ATPase",
     "aliases": "-",
     "obsolete": false,
@@ -27171,7 +25081,6 @@
   },
   {
     "id": 2091,
-    "entrezid": 879676,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27184,7 +25093,6 @@
   },
   {
     "id": 2092,
-    "entrezid": 879677,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27197,7 +25105,6 @@
   },
   {
     "id": 2093,
-    "entrezid": 879678,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27210,7 +25117,6 @@
   },
   {
     "id": 2094,
-    "entrezid": 879679,
     "description": "HTH-type transcriptional regulator PrtR",
     "aliases": "-",
     "obsolete": false,
@@ -27223,7 +25129,6 @@
   },
   {
     "id": 2095,
-    "entrezid": 879680,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27236,7 +25141,6 @@
   },
   {
     "id": 2096,
-    "entrezid": 879681,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27249,7 +25153,6 @@
   },
   {
     "id": 2097,
-    "entrezid": 879682,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27262,7 +25165,6 @@
   },
   {
     "id": 2098,
-    "entrezid": 879683,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -27275,7 +25177,6 @@
   },
   {
     "id": 2099,
-    "entrezid": 879685,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27288,7 +25189,6 @@
   },
   {
     "id": 2100,
-    "entrezid": 879686,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27301,7 +25201,6 @@
   },
   {
     "id": 2101,
-    "entrezid": 879687,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27314,7 +25213,6 @@
   },
   {
     "id": 2102,
-    "entrezid": 879688,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27327,7 +25225,6 @@
   },
   {
     "id": 2103,
-    "entrezid": 879689,
     "description": "C4-dicarboxylate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -27340,7 +25237,6 @@
   },
   {
     "id": 2104,
-    "entrezid": 879690,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -27353,7 +25249,6 @@
   },
   {
     "id": 2105,
-    "entrezid": 879691,
     "description": "acyl-CoA thioesterase",
     "aliases": "-",
     "obsolete": false,
@@ -27366,7 +25261,6 @@
   },
   {
     "id": 2106,
-    "entrezid": 879692,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27379,7 +25273,6 @@
   },
   {
     "id": 2107,
-    "entrezid": 879693,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -27392,7 +25285,6 @@
   },
   {
     "id": 2108,
-    "entrezid": 879694,
     "description": "aldehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -27405,7 +25297,6 @@
   },
   {
     "id": 2109,
-    "entrezid": 879695,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27418,7 +25309,6 @@
   },
   {
     "id": 2110,
-    "entrezid": 879696,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27431,7 +25321,6 @@
   },
   {
     "id": 2111,
-    "entrezid": 879697,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27444,7 +25333,6 @@
   },
   {
     "id": 2112,
-    "entrezid": 879698,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27457,7 +25345,6 @@
   },
   {
     "id": 2113,
-    "entrezid": 879699,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27470,7 +25357,6 @@
   },
   {
     "id": 2114,
-    "entrezid": 879700,
     "description": "polyphosphate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -27483,7 +25369,6 @@
   },
   {
     "id": 2115,
-    "entrezid": 879701,
     "description": "delta-aminolevulinic acid dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -27496,7 +25381,6 @@
   },
   {
     "id": 2116,
-    "entrezid": 879702,
     "description": "thiamine biosynthesis protein ThiC",
     "aliases": "-",
     "obsolete": false,
@@ -27509,7 +25393,6 @@
   },
   {
     "id": 2117,
-    "entrezid": 879703,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27522,7 +25405,6 @@
   },
   {
     "id": 2118,
-    "entrezid": 879704,
     "description": "biofilm formation protein PslG",
     "aliases": "-",
     "obsolete": false,
@@ -27535,7 +25417,6 @@
   },
   {
     "id": 2119,
-    "entrezid": 879705,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27548,7 +25429,6 @@
   },
   {
     "id": 2120,
-    "entrezid": 879706,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -27561,7 +25441,6 @@
   },
   {
     "id": 2121,
-    "entrezid": 879707,
     "description": "OsmE family transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -27574,7 +25453,6 @@
   },
   {
     "id": 2122,
-    "entrezid": 879708,
     "description": "HxcT pseudopilin",
     "aliases": "-",
     "obsolete": false,
@@ -27587,7 +25465,6 @@
   },
   {
     "id": 2123,
-    "entrezid": 879709,
     "description": "phenylalanine 4-monooxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -27600,7 +25477,6 @@
   },
   {
     "id": 2124,
-    "entrezid": 879710,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -27613,7 +25489,6 @@
   },
   {
     "id": 2125,
-    "entrezid": 879711,
     "description": "glutamine amidotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -27626,7 +25501,6 @@
   },
   {
     "id": 2126,
-    "entrezid": 879712,
     "description": "exoenzyme S transcriptional regulator ExsA",
     "aliases": "-",
     "obsolete": false,
@@ -27639,7 +25513,6 @@
   },
   {
     "id": 2127,
-    "entrezid": 879713,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27652,7 +25525,6 @@
   },
   {
     "id": 2128,
-    "entrezid": 879714,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27665,7 +25537,6 @@
   },
   {
     "id": 2129,
-    "entrezid": 879715,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27678,7 +25549,6 @@
   },
   {
     "id": 2130,
-    "entrezid": 879716,
     "description": "shikimate 5-dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -27691,7 +25561,6 @@
   },
   {
     "id": 2131,
-    "entrezid": 879717,
     "description": "biofilm formation protein PslA",
     "aliases": "-",
     "obsolete": false,
@@ -27704,7 +25573,6 @@
   },
   {
     "id": 2132,
-    "entrezid": 879718,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27717,7 +25585,6 @@
   },
   {
     "id": 2133,
-    "entrezid": 879719,
     "description": "anti-RNA polymerase sigma 70 factor",
     "aliases": "-",
     "obsolete": false,
@@ -27730,7 +25597,6 @@
   },
   {
     "id": 2134,
-    "entrezid": 879720,
     "description": "disulfide bond formation protein",
     "aliases": "-",
     "obsolete": false,
@@ -27743,7 +25609,6 @@
   },
   {
     "id": 2135,
-    "entrezid": 879721,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -27756,7 +25621,6 @@
   },
   {
     "id": 2136,
-    "entrezid": 879722,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27769,7 +25633,6 @@
   },
   {
     "id": 2137,
-    "entrezid": 879723,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27782,7 +25645,6 @@
   },
   {
     "id": 2138,
-    "entrezid": 879724,
     "description": "uroporphyrinogen-III synthase",
     "aliases": "-",
     "obsolete": false,
@@ -27795,7 +25657,6 @@
   },
   {
     "id": 2139,
-    "entrezid": 879725,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -27808,7 +25669,6 @@
   },
   {
     "id": 2140,
-    "entrezid": 879726,
     "description": "chemotaxis transducer",
     "aliases": "-",
     "obsolete": false,
@@ -27821,7 +25681,6 @@
   },
   {
     "id": 2141,
-    "entrezid": 879727,
     "description": "transcriptional activator GpuR",
     "aliases": "-",
     "obsolete": false,
@@ -27834,7 +25693,6 @@
   },
   {
     "id": 2142,
-    "entrezid": 879728,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27847,7 +25705,6 @@
   },
   {
     "id": 2143,
-    "entrezid": 879729,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27860,7 +25717,6 @@
   },
   {
     "id": 2144,
-    "entrezid": 879730,
     "description": "agmatine deiminase",
     "aliases": "-",
     "obsolete": false,
@@ -27873,7 +25729,6 @@
   },
   {
     "id": 2145,
-    "entrezid": 879731,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27886,7 +25741,6 @@
   },
   {
     "id": 2146,
-    "entrezid": 879732,
     "description": "acetyl-CoA synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -27899,7 +25753,6 @@
   },
   {
     "id": 2147,
-    "entrezid": 879733,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27912,7 +25765,6 @@
   },
   {
     "id": 2148,
-    "entrezid": 879734,
     "description": "ornithine cyclodeaminase",
     "aliases": "-",
     "obsolete": false,
@@ -27925,7 +25777,6 @@
   },
   {
     "id": 2149,
-    "entrezid": 879735,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -27938,7 +25789,6 @@
   },
   {
     "id": 2150,
-    "entrezid": 879736,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27951,7 +25801,6 @@
   },
   {
     "id": 2151,
-    "entrezid": 879737,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27964,7 +25813,6 @@
   },
   {
     "id": 2152,
-    "entrezid": 879738,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27977,7 +25825,6 @@
   },
   {
     "id": 2153,
-    "entrezid": 879739,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -27990,7 +25837,6 @@
   },
   {
     "id": 2154,
-    "entrezid": 879740,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28003,7 +25849,6 @@
   },
   {
     "id": 2155,
-    "entrezid": 879741,
     "description": "DNA topoisomerase IV subunit A",
     "aliases": "-",
     "obsolete": false,
@@ -28016,7 +25861,6 @@
   },
   {
     "id": 2156,
-    "entrezid": 879742,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28029,7 +25873,6 @@
   },
   {
     "id": 2157,
-    "entrezid": 879743,
     "description": "ubiquinone/menaquinone biosynthesis methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -28042,7 +25885,6 @@
   },
   {
     "id": 2158,
-    "entrezid": 879744,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28055,7 +25897,6 @@
   },
   {
     "id": 2159,
-    "entrezid": 879745,
     "description": "ring-hydroxylating dioxygenase subunit",
     "aliases": "-",
     "obsolete": false,
@@ -28068,7 +25909,6 @@
   },
   {
     "id": 2160,
-    "entrezid": 879746,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28081,7 +25921,6 @@
   },
   {
     "id": 2161,
-    "entrezid": 879747,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28094,7 +25933,6 @@
   },
   {
     "id": 2162,
-    "entrezid": 879748,
     "description": "vanillate porin OpdK",
     "aliases": "-",
     "obsolete": false,
@@ -28107,7 +25945,6 @@
   },
   {
     "id": 2163,
-    "entrezid": 879749,
     "description": "aldehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -28120,7 +25957,6 @@
   },
   {
     "id": 2164,
-    "entrezid": 879750,
     "description": "pyoverdine synthetase D",
     "aliases": "-",
     "obsolete": false,
@@ -28133,7 +25969,6 @@
   },
   {
     "id": 2165,
-    "entrezid": 879751,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28146,7 +25981,6 @@
   },
   {
     "id": 2166,
-    "entrezid": 879752,
     "description": "phosphoribosylformylglycinamidine synthase",
     "aliases": "-",
     "obsolete": false,
@@ -28159,7 +25993,6 @@
   },
   {
     "id": 2167,
-    "entrezid": 879753,
     "description": "thioesterase",
     "aliases": "-",
     "obsolete": false,
@@ -28172,7 +26005,6 @@
   },
   {
     "id": 2168,
-    "entrezid": 879754,
     "description": "protein AmbC",
     "aliases": "-",
     "obsolete": false,
@@ -28185,7 +26017,6 @@
   },
   {
     "id": 2169,
-    "entrezid": 879755,
     "description": "type III secretion system protein",
     "aliases": "-",
     "obsolete": false,
@@ -28198,7 +26029,6 @@
   },
   {
     "id": 2170,
-    "entrezid": 879756,
     "description": "adenosine diphosphate sugar pyrophosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -28211,7 +26041,6 @@
   },
   {
     "id": 2171,
-    "entrezid": 879757,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28224,7 +26053,6 @@
   },
   {
     "id": 2172,
-    "entrezid": 879758,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -28237,7 +26065,6 @@
   },
   {
     "id": 2173,
-    "entrezid": 879759,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28250,7 +26077,6 @@
   },
   {
     "id": 2256,
-    "entrezid": 879842,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28263,7 +26089,6 @@
   },
   {
     "id": 2174,
-    "entrezid": 879760,
     "description": "spermidine/putrescine ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -28276,7 +26101,6 @@
   },
   {
     "id": 2175,
-    "entrezid": 879761,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28289,7 +26113,6 @@
   },
   {
     "id": 2176,
-    "entrezid": 879762,
     "description": "heme d1 biosynthesis protein NirL",
     "aliases": "-",
     "obsolete": false,
@@ -28302,7 +26125,6 @@
   },
   {
     "id": 2177,
-    "entrezid": 879763,
     "description": "type III secretion system ATPase",
     "aliases": "-",
     "obsolete": false,
@@ -28315,7 +26137,6 @@
   },
   {
     "id": 2178,
-    "entrezid": 879764,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -28328,7 +26149,6 @@
   },
   {
     "id": 2179,
-    "entrezid": 879765,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -28341,7 +26161,6 @@
   },
   {
     "id": 2180,
-    "entrezid": 879766,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -28354,7 +26173,6 @@
   },
   {
     "id": 2181,
-    "entrezid": 879767,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28367,7 +26185,6 @@
   },
   {
     "id": 2182,
-    "entrezid": 879768,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28380,7 +26197,6 @@
   },
   {
     "id": 2183,
-    "entrezid": 879769,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -28393,7 +26209,6 @@
   },
   {
     "id": 2184,
-    "entrezid": 879770,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28406,7 +26221,6 @@
   },
   {
     "id": 2185,
-    "entrezid": 879771,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28419,7 +26233,6 @@
   },
   {
     "id": 2186,
-    "entrezid": 879772,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28432,7 +26245,6 @@
   },
   {
     "id": 2187,
-    "entrezid": 879773,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28445,7 +26257,6 @@
   },
   {
     "id": 2188,
-    "entrezid": 879774,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28458,7 +26269,6 @@
   },
   {
     "id": 2189,
-    "entrezid": 879775,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28471,7 +26281,6 @@
   },
   {
     "id": 2190,
-    "entrezid": 879776,
     "description": "urease accessory protein",
     "aliases": "-",
     "obsolete": false,
@@ -28484,7 +26293,6 @@
   },
   {
     "id": 2191,
-    "entrezid": 879777,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28497,7 +26305,6 @@
   },
   {
     "id": 2192,
-    "entrezid": 879778,
     "description": "heme oxygenase BphO",
     "aliases": "-",
     "obsolete": false,
@@ -28510,7 +26317,6 @@
   },
   {
     "id": 2193,
-    "entrezid": 879779,
     "description": "acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -28523,7 +26329,6 @@
   },
   {
     "id": 2194,
-    "entrezid": 879780,
     "description": "respiratory nitrate reductase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -28536,7 +26341,6 @@
   },
   {
     "id": 2195,
-    "entrezid": 879781,
     "description": "nitrite extrusion protein 2",
     "aliases": "-",
     "obsolete": false,
@@ -28549,7 +26353,6 @@
   },
   {
     "id": 2196,
-    "entrezid": 879782,
     "description": "respiratory nitrate reductase subunit delta",
     "aliases": "-",
     "obsolete": false,
@@ -28562,7 +26365,6 @@
   },
   {
     "id": 2197,
-    "entrezid": 879783,
     "description": "respiratory nitrate reductase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -28575,7 +26377,6 @@
   },
   {
     "id": 2198,
-    "entrezid": 879784,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28588,7 +26389,6 @@
   },
   {
     "id": 2199,
-    "entrezid": 879785,
     "description": "phosphatidylcholine synthase",
     "aliases": "-",
     "obsolete": false,
@@ -28601,7 +26401,6 @@
   },
   {
     "id": 2200,
-    "entrezid": 879786,
     "description": "molybdenum cofactor biosynthesis protein A",
     "aliases": "-",
     "obsolete": false,
@@ -28614,7 +26413,6 @@
   },
   {
     "id": 2201,
-    "entrezid": 879787,
     "description": "tRNA (guanine-N(7)-)-methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -28627,7 +26425,6 @@
   },
   {
     "id": 2202,
-    "entrezid": 879788,
     "description": "carbohydrate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -28640,7 +26437,6 @@
   },
   {
     "id": 2203,
-    "entrezid": 879789,
     "description": "FAD-dependent glycerol-3-phosphate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -28653,7 +26449,6 @@
   },
   {
     "id": 2204,
-    "entrezid": 879790,
     "description": "resistance-nodulation-cell division (RND) efflux membrane fusion protein",
     "aliases": "-",
     "obsolete": false,
@@ -28666,7 +26461,6 @@
   },
   {
     "id": 2205,
-    "entrezid": 879791,
     "description": "lactoylglutathione lyase",
     "aliases": "-",
     "obsolete": false,
@@ -28679,7 +26473,6 @@
   },
   {
     "id": 2206,
-    "entrezid": 879792,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28692,7 +26485,6 @@
   },
   {
     "id": 2207,
-    "entrezid": 879793,
     "description": "outer membrane protein OprG",
     "aliases": "-",
     "obsolete": false,
@@ -28705,7 +26497,6 @@
   },
   {
     "id": 2208,
-    "entrezid": 879794,
     "description": "pyocin protein",
     "aliases": "-",
     "obsolete": false,
@@ -28718,7 +26509,6 @@
   },
   {
     "id": 2209,
-    "entrezid": 879795,
     "description": "DNA invertase",
     "aliases": "-",
     "obsolete": false,
@@ -28731,7 +26521,6 @@
   },
   {
     "id": 2210,
-    "entrezid": 879796,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28744,7 +26533,6 @@
   },
   {
     "id": 2211,
-    "entrezid": 879797,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28757,7 +26545,6 @@
   },
   {
     "id": 2212,
-    "entrezid": 879798,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28770,7 +26557,6 @@
   },
   {
     "id": 2213,
-    "entrezid": 879799,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28783,7 +26569,6 @@
   },
   {
     "id": 2214,
-    "entrezid": 879800,
     "description": "amino acid-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -28796,7 +26581,6 @@
   },
   {
     "id": 2215,
-    "entrezid": 879801,
     "description": "carboxylesterase",
     "aliases": "-",
     "obsolete": false,
@@ -28809,7 +26593,6 @@
   },
   {
     "id": 2216,
-    "entrezid": 879802,
     "description": "thiazole synthase",
     "aliases": "-",
     "obsolete": false,
@@ -28822,7 +26605,6 @@
   },
   {
     "id": 2217,
-    "entrezid": 879803,
     "description": "acyl-CoA synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -28835,7 +26617,6 @@
   },
   {
     "id": 2218,
-    "entrezid": 879804,
     "description": "ATP-dependent RNA helicase RhlB",
     "aliases": "-",
     "obsolete": false,
@@ -28848,7 +26629,6 @@
   },
   {
     "id": 2219,
-    "entrezid": 879805,
     "description": "NAD(P)H-dependent anabolic L-arginine dehydrogenase DauB",
     "aliases": "-",
     "obsolete": false,
@@ -28861,7 +26641,6 @@
   },
   {
     "id": 2220,
-    "entrezid": 879806,
     "description": "FAD-dependent catabolic D-arginine dehydrogenase DauA",
     "aliases": "-",
     "obsolete": false,
@@ -28874,7 +26653,6 @@
   },
   {
     "id": 2221,
-    "entrezid": 879807,
     "description": "GIY-YIG nuclease superfamily protein",
     "aliases": "-",
     "obsolete": false,
@@ -28887,7 +26665,6 @@
   },
   {
     "id": 2222,
-    "entrezid": 879808,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28900,7 +26677,6 @@
   },
   {
     "id": 2223,
-    "entrezid": 879809,
     "description": "dihydroorotase",
     "aliases": "-",
     "obsolete": false,
@@ -28913,7 +26689,6 @@
   },
   {
     "id": 2224,
-    "entrezid": 879810,
     "description": "ribonuclease T",
     "aliases": "-",
     "obsolete": false,
@@ -28926,7 +26701,6 @@
   },
   {
     "id": 2225,
-    "entrezid": 879811,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28939,7 +26713,6 @@
   },
   {
     "id": 2226,
-    "entrezid": 879812,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -28952,7 +26725,6 @@
   },
   {
     "id": 2227,
-    "entrezid": 879813,
     "description": "sulfur carrier protein ThiS",
     "aliases": "-",
     "obsolete": false,
@@ -28965,7 +26737,6 @@
   },
   {
     "id": 2228,
-    "entrezid": 879814,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28978,7 +26749,6 @@
   },
   {
     "id": 2229,
-    "entrezid": 879815,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -28991,7 +26761,6 @@
   },
   {
     "id": 2230,
-    "entrezid": 879816,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29004,7 +26773,6 @@
   },
   {
     "id": 2231,
-    "entrezid": 879817,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29017,7 +26785,6 @@
   },
   {
     "id": 2232,
-    "entrezid": 879818,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29030,7 +26797,6 @@
   },
   {
     "id": 2233,
-    "entrezid": 879819,
     "description": "pyocin-S2 immunity protein",
     "aliases": "-",
     "obsolete": false,
@@ -29043,7 +26809,6 @@
   },
   {
     "id": 2234,
-    "entrezid": 879820,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -29056,7 +26821,6 @@
   },
   {
     "id": 2235,
-    "entrezid": 879821,
     "description": "amino acid binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -29069,7 +26833,6 @@
   },
   {
     "id": 2236,
-    "entrezid": 879822,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29082,7 +26845,6 @@
   },
   {
     "id": 2237,
-    "entrezid": 879823,
     "description": "regulatory protein NosR",
     "aliases": "-",
     "obsolete": false,
@@ -29095,7 +26857,6 @@
   },
   {
     "id": 2238,
-    "entrezid": 879824,
     "description": "nitrous-oxide reductase",
     "aliases": "-",
     "obsolete": false,
@@ -29108,7 +26869,6 @@
   },
   {
     "id": 2239,
-    "entrezid": 879825,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29121,7 +26881,6 @@
   },
   {
     "id": 2240,
-    "entrezid": 879826,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29134,7 +26893,6 @@
   },
   {
     "id": 2241,
-    "entrezid": 879827,
     "description": "nucleotide sugar dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -29147,7 +26905,6 @@
   },
   {
     "id": 2242,
-    "entrezid": 879828,
     "description": "PTS system fructose-specific transporter subunit IIBC",
     "aliases": "-",
     "obsolete": false,
@@ -29160,7 +26917,6 @@
   },
   {
     "id": 2243,
-    "entrezid": 879829,
     "description": "2,4-dienoyl-CoA reductase",
     "aliases": "-",
     "obsolete": false,
@@ -29173,7 +26929,6 @@
   },
   {
     "id": 2244,
-    "entrezid": 879830,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29186,7 +26941,6 @@
   },
   {
     "id": 2245,
-    "entrezid": 879831,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29199,7 +26953,6 @@
   },
   {
     "id": 2246,
-    "entrezid": 879832,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -29212,7 +26965,6 @@
   },
   {
     "id": 2247,
-    "entrezid": 879833,
     "description": "cytochrome P450",
     "aliases": "-",
     "obsolete": false,
@@ -29225,7 +26977,6 @@
   },
   {
     "id": 2248,
-    "entrezid": 879834,
     "description": "O6-methylguanine-DNA methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -29238,7 +26989,6 @@
   },
   {
     "id": 2249,
-    "entrezid": 879835,
     "description": "monofunctional biosynthetic peptidoglycan transglycosylase",
     "aliases": "-",
     "obsolete": false,
@@ -29251,7 +27001,6 @@
   },
   {
     "id": 2250,
-    "entrezid": 879836,
     "description": "SAM-dependent methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -29264,7 +27013,6 @@
   },
   {
     "id": 2251,
-    "entrezid": 879837,
     "description": "exoenzyme S",
     "aliases": "-",
     "obsolete": false,
@@ -29277,7 +27025,6 @@
   },
   {
     "id": 2252,
-    "entrezid": 879838,
     "description": "alginate production protein AlgE",
     "aliases": "-",
     "obsolete": false,
@@ -29290,7 +27037,6 @@
   },
   {
     "id": 2253,
-    "entrezid": 879839,
     "description": "alginate-c5-mannuronan-epimerase AlgG",
     "aliases": "-",
     "obsolete": false,
@@ -29303,7 +27049,6 @@
   },
   {
     "id": 2254,
-    "entrezid": 879840,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29316,7 +27061,6 @@
   },
   {
     "id": 2255,
-    "entrezid": 879841,
     "description": "nucleoid-associated protein NdpA",
     "aliases": "-",
     "obsolete": false,
@@ -29329,7 +27073,6 @@
   },
   {
     "id": 2257,
-    "entrezid": 879843,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29342,7 +27085,6 @@
   },
   {
     "id": 2258,
-    "entrezid": 879844,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29355,7 +27097,6 @@
   },
   {
     "id": 2259,
-    "entrezid": 879845,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29368,7 +27109,6 @@
   },
   {
     "id": 2260,
-    "entrezid": 879846,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29381,7 +27121,6 @@
   },
   {
     "id": 2261,
-    "entrezid": 879847,
     "description": "phosphopantetheine adenylyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -29394,7 +27133,6 @@
   },
   {
     "id": 2262,
-    "entrezid": 879848,
     "description": "chaperone",
     "aliases": "-",
     "obsolete": false,
@@ -29407,7 +27145,6 @@
   },
   {
     "id": 2263,
-    "entrezid": 879850,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29420,7 +27157,6 @@
   },
   {
     "id": 2264,
-    "entrezid": 879851,
     "description": "outer membrane lipoprotein OprI",
     "aliases": "-",
     "obsolete": false,
@@ -29433,7 +27169,6 @@
   },
   {
     "id": 2265,
-    "entrezid": 879852,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29446,7 +27181,6 @@
   },
   {
     "id": 2266,
-    "entrezid": 879853,
     "description": "maleylacetoacetate isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -29459,7 +27193,6 @@
   },
   {
     "id": 2267,
-    "entrezid": 879854,
     "description": "heme acquisition protein HasA",
     "aliases": "-",
     "obsolete": false,
@@ -29472,7 +27205,6 @@
   },
   {
     "id": 2268,
-    "entrezid": 879855,
     "description": "heme uptake outer membrane receptor HasR",
     "aliases": "-",
     "obsolete": false,
@@ -29485,7 +27217,6 @@
   },
   {
     "id": 2269,
-    "entrezid": 879856,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29498,7 +27229,6 @@
   },
   {
     "id": 2270,
-    "entrezid": 879857,
     "description": "transferase",
     "aliases": "-",
     "obsolete": false,
@@ -29511,7 +27241,6 @@
   },
   {
     "id": 2271,
-    "entrezid": 879858,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -29524,7 +27253,6 @@
   },
   {
     "id": 2272,
-    "entrezid": 879859,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -29537,7 +27265,6 @@
   },
   {
     "id": 2273,
-    "entrezid": 879860,
     "description": "sodium:sulfate symporter",
     "aliases": "-",
     "obsolete": false,
@@ -29550,7 +27277,6 @@
   },
   {
     "id": 2274,
-    "entrezid": 879861,
     "description": "flagellar motor protein MotA",
     "aliases": "-",
     "obsolete": false,
@@ -29563,7 +27289,6 @@
   },
   {
     "id": 2275,
-    "entrezid": 879862,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29576,7 +27301,6 @@
   },
   {
     "id": 2276,
-    "entrezid": 879863,
     "description": "alcohol dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -29589,7 +27313,6 @@
   },
   {
     "id": 2277,
-    "entrezid": 879864,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -29602,7 +27325,6 @@
   },
   {
     "id": 2278,
-    "entrezid": 879865,
     "description": "leucyl aminopeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -29615,7 +27337,6 @@
   },
   {
     "id": 2279,
-    "entrezid": 879866,
     "description": "UDP-glucose 6-dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -29628,7 +27349,6 @@
   },
   {
     "id": 2280,
-    "entrezid": 879867,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29641,7 +27361,6 @@
   },
   {
     "id": 2281,
-    "entrezid": 879868,
     "description": "glutathione S-transferase",
     "aliases": "-",
     "obsolete": false,
@@ -29654,7 +27373,6 @@
   },
   {
     "id": 2282,
-    "entrezid": 879869,
     "description": "electron transport complex subunit C",
     "aliases": "-",
     "obsolete": false,
@@ -29667,7 +27385,6 @@
   },
   {
     "id": 2283,
-    "entrezid": 879870,
     "description": "electron transport complex subunit D",
     "aliases": "-",
     "obsolete": false,
@@ -29680,7 +27397,6 @@
   },
   {
     "id": 2284,
-    "entrezid": 879871,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29693,7 +27409,6 @@
   },
   {
     "id": 2285,
-    "entrezid": 879872,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29706,7 +27421,6 @@
   },
   {
     "id": 2286,
-    "entrezid": 879873,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29719,7 +27433,6 @@
   },
   {
     "id": 2287,
-    "entrezid": 879874,
     "description": "transcriptional regulator PsrA",
     "aliases": "-",
     "obsolete": false,
@@ -29732,7 +27445,6 @@
   },
   {
     "id": 2288,
-    "entrezid": 879875,
     "description": "LexA repressor",
     "aliases": "-",
     "obsolete": false,
@@ -29745,7 +27457,6 @@
   },
   {
     "id": 2289,
-    "entrezid": 879876,
     "description": "pyruvate dehydrogenase E1 component subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -29758,7 +27469,6 @@
   },
   {
     "id": 2290,
-    "entrezid": 879877,
     "description": "leucine dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -29771,7 +27481,6 @@
   },
   {
     "id": 2291,
-    "entrezid": 879878,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29784,7 +27493,6 @@
   },
   {
     "id": 2292,
-    "entrezid": 879879,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29797,7 +27505,6 @@
   },
   {
     "id": 2293,
-    "entrezid": 879880,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29810,7 +27517,6 @@
   },
   {
     "id": 2294,
-    "entrezid": 879881,
     "description": "molecular chaperone Hsp31/glyoxalase",
     "aliases": "-",
     "obsolete": false,
@@ -29823,7 +27529,6 @@
   },
   {
     "id": 2295,
-    "entrezid": 879882,
     "description": "DNA polymerase III subunit chi",
     "aliases": "-",
     "obsolete": false,
@@ -29836,7 +27541,6 @@
   },
   {
     "id": 2296,
-    "entrezid": 879883,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29849,7 +27553,6 @@
   },
   {
     "id": 2297,
-    "entrezid": 879884,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29862,7 +27565,6 @@
   },
   {
     "id": 2298,
-    "entrezid": 879885,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29875,7 +27577,6 @@
   },
   {
     "id": 2299,
-    "entrezid": 879886,
     "description": "queuine tRNA-ribosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -29888,7 +27589,6 @@
   },
   {
     "id": 2300,
-    "entrezid": 879887,
     "description": "S-adenosylmethionine--tRNA ribosyltransferase-isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -29901,7 +27601,6 @@
   },
   {
     "id": 2301,
-    "entrezid": 879888,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29914,7 +27613,6 @@
   },
   {
     "id": 2302,
-    "entrezid": 879889,
     "description": "cytochrome C",
     "aliases": "-",
     "obsolete": false,
@@ -29927,7 +27625,6 @@
   },
   {
     "id": 2303,
-    "entrezid": 879890,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -29940,7 +27637,6 @@
   },
   {
     "id": 2304,
-    "entrezid": 879891,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -29953,7 +27649,6 @@
   },
   {
     "id": 2305,
-    "entrezid": 879892,
     "description": "nucleoside diphosphate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -29966,7 +27661,6 @@
   },
   {
     "id": 2306,
-    "entrezid": 879893,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -29979,7 +27673,6 @@
   },
   {
     "id": 2307,
-    "entrezid": 879894,
     "description": "3-oxoacyl-ACP synthase",
     "aliases": "-",
     "obsolete": false,
@@ -29992,7 +27685,6 @@
   },
   {
     "id": 2308,
-    "entrezid": 879895,
     "description": "acyl carrier protein",
     "aliases": "-",
     "obsolete": false,
@@ -30005,7 +27697,6 @@
   },
   {
     "id": 2309,
-    "entrezid": 879896,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30018,7 +27709,6 @@
   },
   {
     "id": 2310,
-    "entrezid": 879897,
     "description": "DNA topoisomerase IV subunit B",
     "aliases": "-",
     "obsolete": false,
@@ -30031,7 +27721,6 @@
   },
   {
     "id": 2311,
-    "entrezid": 879898,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30044,7 +27733,6 @@
   },
   {
     "id": 2312,
-    "entrezid": 879899,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -30057,7 +27745,6 @@
   },
   {
     "id": 2313,
-    "entrezid": 879900,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30070,7 +27757,6 @@
   },
   {
     "id": 2314,
-    "entrezid": 879901,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30083,7 +27769,6 @@
   },
   {
     "id": 2315,
-    "entrezid": 879902,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30096,7 +27781,6 @@
   },
   {
     "id": 2316,
-    "entrezid": 879903,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30109,7 +27793,6 @@
   },
   {
     "id": 2317,
-    "entrezid": 879904,
     "description": "preprotein translocase subunit SecF",
     "aliases": "-",
     "obsolete": false,
@@ -30122,7 +27805,6 @@
   },
   {
     "id": 2318,
-    "entrezid": 879905,
     "description": "valine--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -30135,7 +27817,6 @@
   },
   {
     "id": 2319,
-    "entrezid": 879906,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30148,7 +27829,6 @@
   },
   {
     "id": 2320,
-    "entrezid": 879907,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30161,7 +27841,6 @@
   },
   {
     "id": 2321,
-    "entrezid": 879908,
     "description": "type III secretion system regulator SuhB",
     "aliases": "-",
     "obsolete": false,
@@ -30174,7 +27853,6 @@
   },
   {
     "id": 2322,
-    "entrezid": 879909,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30187,7 +27865,6 @@
   },
   {
     "id": 2323,
-    "entrezid": 879910,
     "description": "tRNA pseudouridine synthase A",
     "aliases": "-",
     "obsolete": false,
@@ -30200,7 +27877,6 @@
   },
   {
     "id": 2324,
-    "entrezid": 879911,
     "description": "motility protein FimV",
     "aliases": "-",
     "obsolete": false,
@@ -30213,7 +27889,6 @@
   },
   {
     "id": 2325,
-    "entrezid": 879912,
     "description": "acessory protein NosL",
     "aliases": "-",
     "obsolete": false,
@@ -30226,7 +27901,6 @@
   },
   {
     "id": 2326,
-    "entrezid": 879913,
     "description": "ferredoxin-NADP reductase",
     "aliases": "-",
     "obsolete": false,
@@ -30239,7 +27913,6 @@
   },
   {
     "id": 2327,
-    "entrezid": 879914,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30252,7 +27925,6 @@
   },
   {
     "id": 2328,
-    "entrezid": 879915,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30265,7 +27937,6 @@
   },
   {
     "id": 2329,
-    "entrezid": 879916,
     "description": "iron-binding protein IscA",
     "aliases": "-",
     "obsolete": false,
@@ -30278,7 +27949,6 @@
   },
   {
     "id": 2330,
-    "entrezid": 879917,
     "description": "scaffold protein",
     "aliases": "-",
     "obsolete": false,
@@ -30291,7 +27961,6 @@
   },
   {
     "id": 2331,
-    "entrezid": 879918,
     "description": "cysteine desulfurase",
     "aliases": "-",
     "obsolete": false,
@@ -30304,7 +27973,6 @@
   },
   {
     "id": 2332,
-    "entrezid": 879919,
     "description": "HTH-type transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -30317,7 +27985,6 @@
   },
   {
     "id": 2333,
-    "entrezid": 879920,
     "description": "drug efflux transporter",
     "aliases": "-",
     "obsolete": false,
@@ -30330,7 +27997,6 @@
   },
   {
     "id": 2334,
-    "entrezid": 879921,
     "description": "UDP-N-acetyl-d-glucosamine 6-dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -30343,7 +28009,6 @@
   },
   {
     "id": 2335,
-    "entrezid": 879922,
     "description": "O-antigen chain length regulator",
     "aliases": "-",
     "obsolete": false,
@@ -30356,7 +28021,6 @@
   },
   {
     "id": 2336,
-    "entrezid": 879923,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30369,7 +28033,6 @@
   },
   {
     "id": 2337,
-    "entrezid": 879924,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30382,7 +28045,6 @@
   },
   {
     "id": 2338,
-    "entrezid": 879925,
     "description": "NAD-dependent malic enzyme",
     "aliases": "-",
     "obsolete": false,
@@ -30395,7 +28057,6 @@
   },
   {
     "id": 2339,
-    "entrezid": 879926,
     "description": "O-acetylserine synthase",
     "aliases": "-",
     "obsolete": false,
@@ -30408,7 +28069,6 @@
   },
   {
     "id": 2340,
-    "entrezid": 879927,
     "description": "methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -30421,7 +28081,6 @@
   },
   {
     "id": 2341,
-    "entrezid": 879928,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30434,7 +28093,6 @@
   },
   {
     "id": 2342,
-    "entrezid": 879929,
     "description": "pellicle/biofilm biosynthesis Wzx-like polysaccharide transporter PelG",
     "aliases": "-",
     "obsolete": false,
@@ -30447,7 +28105,6 @@
   },
   {
     "id": 2343,
-    "entrezid": 879930,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30460,7 +28117,6 @@
   },
   {
     "id": 2344,
-    "entrezid": 879931,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30473,7 +28129,6 @@
   },
   {
     "id": 2345,
-    "entrezid": 879932,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30486,7 +28141,6 @@
   },
   {
     "id": 2346,
-    "entrezid": 879933,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -30499,7 +28153,6 @@
   },
   {
     "id": 2347,
-    "entrezid": 879934,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -30512,7 +28165,6 @@
   },
   {
     "id": 2348,
-    "entrezid": 879935,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30525,7 +28177,6 @@
   },
   {
     "id": 2349,
-    "entrezid": 879936,
     "description": "chaperone protein HscA",
     "aliases": "-",
     "obsolete": false,
@@ -30538,7 +28189,6 @@
   },
   {
     "id": 2350,
-    "entrezid": 879937,
     "description": "co-chaperone HscB",
     "aliases": "-",
     "obsolete": false,
@@ -30551,7 +28201,6 @@
   },
   {
     "id": 2351,
-    "entrezid": 879938,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30564,7 +28213,6 @@
   },
   {
     "id": 2352,
-    "entrezid": 879939,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30577,7 +28225,6 @@
   },
   {
     "id": 2353,
-    "entrezid": 879940,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30590,7 +28237,6 @@
   },
   {
     "id": 2354,
-    "entrezid": 879941,
     "description": "2-isopropylmalate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -30603,7 +28249,6 @@
   },
   {
     "id": 2355,
-    "entrezid": 879942,
     "description": "peroxidase",
     "aliases": "-",
     "obsolete": false,
@@ -30616,7 +28261,6 @@
   },
   {
     "id": 2356,
-    "entrezid": 879943,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30629,7 +28273,6 @@
   },
   {
     "id": 2357,
-    "entrezid": 879944,
     "description": "(2Fe-2S) ferredoxin",
     "aliases": "-",
     "obsolete": false,
@@ -30642,7 +28285,6 @@
   },
   {
     "id": 2358,
-    "entrezid": 879945,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30655,7 +28297,6 @@
   },
   {
     "id": 2359,
-    "entrezid": 879946,
     "description": "glycosylase",
     "aliases": "-",
     "obsolete": false,
@@ -30668,7 +28309,6 @@
   },
   {
     "id": 2360,
-    "entrezid": 879947,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -30681,7 +28321,6 @@
   },
   {
     "id": 2361,
-    "entrezid": 879948,
     "description": "phosphonate C-P lyase system protein PhnK",
     "aliases": "-",
     "obsolete": false,
@@ -30694,7 +28333,6 @@
   },
   {
     "id": 2362,
-    "entrezid": 879949,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -30707,7 +28345,6 @@
   },
   {
     "id": 2363,
-    "entrezid": 879950,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30720,7 +28357,6 @@
   },
   {
     "id": 2364,
-    "entrezid": 879951,
     "description": "amino acid permease",
     "aliases": "-",
     "obsolete": false,
@@ -30733,7 +28369,6 @@
   },
   {
     "id": 2365,
-    "entrezid": 879952,
     "description": "aldolase",
     "aliases": "-",
     "obsolete": false,
@@ -30746,7 +28381,6 @@
   },
   {
     "id": 2366,
-    "entrezid": 879953,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -30759,7 +28393,6 @@
   },
   {
     "id": 2367,
-    "entrezid": 879954,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -30772,7 +28405,6 @@
   },
   {
     "id": 2368,
-    "entrezid": 879955,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30785,7 +28417,6 @@
   },
   {
     "id": 2369,
-    "entrezid": 879956,
     "description": "amino acid ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -30798,7 +28429,6 @@
   },
   {
     "id": 2370,
-    "entrezid": 879957,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30811,7 +28441,6 @@
   },
   {
     "id": 2371,
-    "entrezid": 879958,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30824,7 +28453,6 @@
   },
   {
     "id": 2372,
-    "entrezid": 879959,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30837,7 +28465,6 @@
   },
   {
     "id": 2373,
-    "entrezid": 879960,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30850,7 +28477,6 @@
   },
   {
     "id": 2374,
-    "entrezid": 879961,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30863,7 +28489,6 @@
   },
   {
     "id": 2375,
-    "entrezid": 879962,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -30876,7 +28501,6 @@
   },
   {
     "id": 2376,
-    "entrezid": 879963,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -30889,7 +28513,6 @@
   },
   {
     "id": 2377,
-    "entrezid": 879964,
     "description": "C4-dicarboxylate-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -30902,7 +28525,6 @@
   },
   {
     "id": 2378,
-    "entrezid": 879965,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -30915,7 +28537,6 @@
   },
   {
     "id": 2379,
-    "entrezid": 879966,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30928,7 +28549,6 @@
   },
   {
     "id": 2380,
-    "entrezid": 879967,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -30941,7 +28561,6 @@
   },
   {
     "id": 2381,
-    "entrezid": 879968,
     "description": "UTP-glucose-1-phosphate uridylyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -30954,7 +28573,6 @@
   },
   {
     "id": 2382,
-    "entrezid": 879969,
     "description": "amino acid ABC transporter substrate-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -30967,7 +28585,6 @@
   },
   {
     "id": 2383,
-    "entrezid": 879970,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -30980,7 +28597,6 @@
   },
   {
     "id": 2384,
-    "entrezid": 879971,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -30993,7 +28609,6 @@
   },
   {
     "id": 2385,
-    "entrezid": 879972,
     "description": "pyroglutatmate porin OpdO",
     "aliases": "-",
     "obsolete": false,
@@ -31006,7 +28621,6 @@
   },
   {
     "id": 2386,
-    "entrezid": 879973,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -31019,7 +28633,6 @@
   },
   {
     "id": 2387,
-    "entrezid": 879974,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31032,7 +28645,6 @@
   },
   {
     "id": 2388,
-    "entrezid": 879975,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -31045,7 +28657,6 @@
   },
   {
     "id": 2389,
-    "entrezid": 879976,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31058,7 +28669,6 @@
   },
   {
     "id": 2390,
-    "entrezid": 879977,
     "description": "copper ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -31071,7 +28681,6 @@
   },
   {
     "id": 2391,
-    "entrezid": 879978,
     "description": "membrane protein NosY",
     "aliases": "-",
     "obsolete": false,
@@ -31084,7 +28693,6 @@
   },
   {
     "id": 2392,
-    "entrezid": 879979,
     "description": "electron transport complex subunit G",
     "aliases": "-",
     "obsolete": false,
@@ -31097,7 +28705,6 @@
   },
   {
     "id": 2393,
-    "entrezid": 879980,
     "description": "electron transport complex subunit E",
     "aliases": "-",
     "obsolete": false,
@@ -31110,7 +28717,6 @@
   },
   {
     "id": 2394,
-    "entrezid": 879981,
     "description": "NAD-dependent protein deacylase",
     "aliases": "-",
     "obsolete": false,
@@ -31123,7 +28729,6 @@
   },
   {
     "id": 2395,
-    "entrezid": 879982,
     "description": "dTDP-D-glucose 4,6-dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -31136,7 +28741,6 @@
   },
   {
     "id": 2396,
-    "entrezid": 879983,
     "description": "dTDP-4-dehydrorhamnose reductase",
     "aliases": "-",
     "obsolete": false,
@@ -31149,7 +28753,6 @@
   },
   {
     "id": 2397,
-    "entrezid": 879984,
     "description": "aconitate hydratase B",
     "aliases": "-",
     "obsolete": false,
@@ -31162,7 +28765,6 @@
   },
   {
     "id": 2398,
-    "entrezid": 879985,
     "description": "electron transport complex subunit A",
     "aliases": "-",
     "obsolete": false,
@@ -31175,7 +28777,6 @@
   },
   {
     "id": 2399,
-    "entrezid": 879986,
     "description": "electron transport complex subunit B",
     "aliases": "-",
     "obsolete": false,
@@ -31188,7 +28789,6 @@
   },
   {
     "id": 2400,
-    "entrezid": 879987,
     "description": "transmembrane sensor",
     "aliases": "-",
     "obsolete": false,
@@ -31201,7 +28801,6 @@
   },
   {
     "id": 2401,
-    "entrezid": 879988,
     "description": "exoribonuclease R",
     "aliases": "-",
     "obsolete": false,
@@ -31214,7 +28813,6 @@
   },
   {
     "id": 2402,
-    "entrezid": 879989,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31227,7 +28825,6 @@
   },
   {
     "id": 2403,
-    "entrezid": 879990,
     "description": "glucose-1-phosphate thymidylyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -31240,7 +28837,6 @@
   },
   {
     "id": 2404,
-    "entrezid": 879991,
     "description": "dTDP-4-dehydrorhamnose 3,5-epimerase",
     "aliases": "-",
     "obsolete": false,
@@ -31253,7 +28849,6 @@
   },
   {
     "id": 2405,
-    "entrezid": 879992,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31266,7 +28861,6 @@
   },
   {
     "id": 2406,
-    "entrezid": 879993,
     "description": "adenylosuccinate lyase",
     "aliases": "-",
     "obsolete": false,
@@ -31279,7 +28873,6 @@
   },
   {
     "id": 2407,
-    "entrezid": 879994,
     "description": "transcriptional regulator MvfR",
     "aliases": "-",
     "obsolete": false,
@@ -31292,7 +28885,6 @@
   },
   {
     "id": 2408,
-    "entrezid": 879995,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31305,7 +28897,6 @@
   },
   {
     "id": 2409,
-    "entrezid": 879996,
     "description": "3-hydroxybutyrate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -31318,7 +28909,6 @@
   },
   {
     "id": 2410,
-    "entrezid": 879997,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31331,7 +28921,6 @@
   },
   {
     "id": 2411,
-    "entrezid": 879998,
     "description": "mannitol dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -31344,7 +28933,6 @@
   },
   {
     "id": 2412,
-    "entrezid": 879999,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31357,7 +28945,6 @@
   },
   {
     "id": 2413,
-    "entrezid": 880000,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31370,7 +28957,6 @@
   },
   {
     "id": 2414,
-    "entrezid": 880001,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31383,7 +28969,6 @@
   },
   {
     "id": 2415,
-    "entrezid": 880002,
     "description": "phosphonate ABC transporter substrate-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -31396,7 +28981,6 @@
   },
   {
     "id": 2416,
-    "entrezid": 880003,
     "description": "phosphonate ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -31409,7 +28993,6 @@
   },
   {
     "id": 2417,
-    "entrezid": 880004,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -31422,7 +29005,6 @@
   },
   {
     "id": 2418,
-    "entrezid": 880005,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31435,7 +29017,6 @@
   },
   {
     "id": 2419,
-    "entrezid": 880006,
     "description": "multidrug resistance protein",
     "aliases": "-",
     "obsolete": false,
@@ -31448,7 +29029,6 @@
   },
   {
     "id": 2420,
-    "entrezid": 880007,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31461,7 +29041,6 @@
   },
   {
     "id": 2421,
-    "entrezid": 880008,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -31474,7 +29053,6 @@
   },
   {
     "id": 2422,
-    "entrezid": 880009,
     "description": "acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -31487,7 +29065,6 @@
   },
   {
     "id": 2423,
-    "entrezid": 880010,
     "description": "xylulose kinase",
     "aliases": "-",
     "obsolete": false,
@@ -31500,7 +29077,6 @@
   },
   {
     "id": 2424,
-    "entrezid": 880011,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31513,7 +29089,6 @@
   },
   {
     "id": 2425,
-    "entrezid": 880012,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -31526,7 +29101,6 @@
   },
   {
     "id": 2426,
-    "entrezid": 880013,
     "description": "copper-binding periplasmic protein",
     "aliases": "-",
     "obsolete": false,
@@ -31539,7 +29113,6 @@
   },
   {
     "id": 2427,
-    "entrezid": 880014,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31552,7 +29125,6 @@
   },
   {
     "id": 2428,
-    "entrezid": 880015,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31565,7 +29137,6 @@
   },
   {
     "id": 2429,
-    "entrezid": 880016,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31578,7 +29149,6 @@
   },
   {
     "id": 2430,
-    "entrezid": 880017,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31591,7 +29161,6 @@
   },
   {
     "id": 2431,
-    "entrezid": 880018,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31604,7 +29173,6 @@
   },
   {
     "id": 2432,
-    "entrezid": 880019,
     "description": "metalloprotease secretion protein",
     "aliases": "-",
     "obsolete": false,
@@ -31617,7 +29185,6 @@
   },
   {
     "id": 2433,
-    "entrezid": 880020,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -31630,7 +29197,6 @@
   },
   {
     "id": 2434,
-    "entrezid": 880021,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31643,7 +29209,6 @@
   },
   {
     "id": 2435,
-    "entrezid": 880022,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31656,7 +29221,6 @@
   },
   {
     "id": 2436,
-    "entrezid": 880023,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31669,7 +29233,6 @@
   },
   {
     "id": 2437,
-    "entrezid": 880024,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -31682,7 +29245,6 @@
   },
   {
     "id": 2438,
-    "entrezid": 880025,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -31695,7 +29257,6 @@
   },
   {
     "id": 2439,
-    "entrezid": 880026,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31708,7 +29269,6 @@
   },
   {
     "id": 2440,
-    "entrezid": 880027,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31721,7 +29281,6 @@
   },
   {
     "id": 2441,
-    "entrezid": 880028,
     "description": "cAMP phosphodiesterase",
     "aliases": "-",
     "obsolete": false,
@@ -31734,7 +29293,6 @@
   },
   {
     "id": 2442,
-    "entrezid": 880029,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31747,7 +29305,6 @@
   },
   {
     "id": 2443,
-    "entrezid": 880030,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31760,7 +29317,6 @@
   },
   {
     "id": 2444,
-    "entrezid": 880031,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31773,7 +29329,6 @@
   },
   {
     "id": 2445,
-    "entrezid": 880032,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31786,7 +29341,6 @@
   },
   {
     "id": 2446,
-    "entrezid": 880033,
     "description": "3-oxoacyl-ACP reductase",
     "aliases": "-",
     "obsolete": false,
@@ -31799,7 +29353,6 @@
   },
   {
     "id": 2447,
-    "entrezid": 880034,
     "description": "S-adenosylmethionine-dependent methyltransferase RcsF",
     "aliases": "-",
     "obsolete": false,
@@ -31812,7 +29365,6 @@
   },
   {
     "id": 2448,
-    "entrezid": 880035,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31825,7 +29377,6 @@
   },
   {
     "id": 2449,
-    "entrezid": 880036,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31838,7 +29389,6 @@
   },
   {
     "id": 2450,
-    "entrezid": 880037,
     "description": "thiamine pyrophosphate protein",
     "aliases": "-",
     "obsolete": false,
@@ -31851,7 +29401,6 @@
   },
   {
     "id": 2451,
-    "entrezid": 880038,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31864,7 +29413,6 @@
   },
   {
     "id": 2452,
-    "entrezid": 880039,
     "description": "ring-cleaving dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -31877,7 +29425,6 @@
   },
   {
     "id": 2453,
-    "entrezid": 880040,
     "description": "phospholipase D",
     "aliases": "-",
     "obsolete": false,
@@ -31890,7 +29437,6 @@
   },
   {
     "id": 2454,
-    "entrezid": 880041,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31903,7 +29449,6 @@
   },
   {
     "id": 2455,
-    "entrezid": 880042,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31916,7 +29461,6 @@
   },
   {
     "id": 2456,
-    "entrezid": 880043,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31929,7 +29473,6 @@
   },
   {
     "id": 2457,
-    "entrezid": 880044,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31942,7 +29485,6 @@
   },
   {
     "id": 2458,
-    "entrezid": 880045,
     "description": "Fis family transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -31955,7 +29497,6 @@
   },
   {
     "id": 2459,
-    "entrezid": 880046,
     "description": "bifunctional phosphoribosylaminoimidazolecarboxamide formyltransferase/IMP cyclohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -31968,7 +29509,6 @@
   },
   {
     "id": 2460,
-    "entrezid": 880047,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -31981,7 +29521,6 @@
   },
   {
     "id": 2461,
-    "entrezid": 880048,
     "description": "dihydroaeruginoic acid synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -31994,7 +29533,6 @@
   },
   {
     "id": 2462,
-    "entrezid": 880049,
     "description": "transcriptional regulator PchR",
     "aliases": "-",
     "obsolete": false,
@@ -32007,7 +29545,6 @@
   },
   {
     "id": 2463,
-    "entrezid": 880050,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32020,7 +29557,6 @@
   },
   {
     "id": 2464,
-    "entrezid": 880051,
     "description": "cbb3-type cytochrome C oxidase subunit I",
     "aliases": "-",
     "obsolete": false,
@@ -32033,7 +29569,6 @@
   },
   {
     "id": 2465,
-    "entrezid": 880052,
     "description": "formyltetrahydrofolate deformylase",
     "aliases": "-",
     "obsolete": false,
@@ -32046,7 +29581,6 @@
   },
   {
     "id": 2466,
-    "entrezid": 880053,
     "description": "glutathione-independent formaldehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -32059,7 +29593,6 @@
   },
   {
     "id": 2467,
-    "entrezid": 880054,
     "description": "dehydrogenase E1 component",
     "aliases": "-",
     "obsolete": false,
@@ -32072,7 +29605,6 @@
   },
   {
     "id": 2468,
-    "entrezid": 880055,
     "description": "acetoin catabolism protein AcoB",
     "aliases": "-",
     "obsolete": false,
@@ -32085,7 +29617,6 @@
   },
   {
     "id": 2469,
-    "entrezid": 880056,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32098,7 +29629,6 @@
   },
   {
     "id": 2470,
-    "entrezid": 880057,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32111,7 +29641,6 @@
   },
   {
     "id": 2471,
-    "entrezid": 880058,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32124,7 +29653,6 @@
   },
   {
     "id": 2472,
-    "entrezid": 880059,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -32137,7 +29665,6 @@
   },
   {
     "id": 2473,
-    "entrezid": 880060,
     "description": "sarcosine oxidase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -32150,7 +29677,6 @@
   },
   {
     "id": 2474,
-    "entrezid": 880061,
     "description": "sarcosine oxidase subunit delta",
     "aliases": "-",
     "obsolete": false,
@@ -32163,7 +29689,6 @@
   },
   {
     "id": 2475,
-    "entrezid": 880062,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -32176,7 +29701,6 @@
   },
   {
     "id": 2476,
-    "entrezid": 880063,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32189,7 +29713,6 @@
   },
   {
     "id": 2477,
-    "entrezid": 880064,
     "description": "low specificity l-threonine aldolase",
     "aliases": "-",
     "obsolete": false,
@@ -32202,7 +29725,6 @@
   },
   {
     "id": 2478,
-    "entrezid": 880065,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32215,7 +29737,6 @@
   },
   {
     "id": 2479,
-    "entrezid": 880066,
     "description": "serine hydroxymethyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -32228,7 +29749,6 @@
   },
   {
     "id": 2480,
-    "entrezid": 880067,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32241,7 +29761,6 @@
   },
   {
     "id": 2481,
-    "entrezid": 880068,
     "description": "glycosyl transferase family protein",
     "aliases": "-",
     "obsolete": false,
@@ -32254,7 +29773,6 @@
   },
   {
     "id": 2482,
-    "entrezid": 880069,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32267,7 +29785,6 @@
   },
   {
     "id": 2483,
-    "entrezid": 880070,
     "description": "protein GbcB",
     "aliases": "-",
     "obsolete": false,
@@ -32280,7 +29797,6 @@
   },
   {
     "id": 2484,
-    "entrezid": 880071,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32293,7 +29809,6 @@
   },
   {
     "id": 2485,
-    "entrezid": 880073,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -32306,7 +29821,6 @@
   },
   {
     "id": 2486,
-    "entrezid": 880074,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -32319,7 +29833,6 @@
   },
   {
     "id": 2487,
-    "entrezid": 880075,
     "description": "cyclic di-GMP phosphodiesterase",
     "aliases": "-",
     "obsolete": false,
@@ -32332,7 +29845,6 @@
   },
   {
     "id": 2488,
-    "entrezid": 880076,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32345,7 +29857,6 @@
   },
   {
     "id": 2489,
-    "entrezid": 880077,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32358,7 +29869,6 @@
   },
   {
     "id": 2490,
-    "entrezid": 880078,
     "description": "sensor/response regulator hybrid protein",
     "aliases": "-",
     "obsolete": false,
@@ -32371,7 +29881,6 @@
   },
   {
     "id": 2491,
-    "entrezid": 880079,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32384,7 +29893,6 @@
   },
   {
     "id": 2492,
-    "entrezid": 880080,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32397,7 +29905,6 @@
   },
   {
     "id": 2493,
-    "entrezid": 880081,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32410,7 +29917,6 @@
   },
   {
     "id": 2494,
-    "entrezid": 880082,
     "description": "pyochelin biosynthetic protein PchG",
     "aliases": "-",
     "obsolete": false,
@@ -32423,7 +29929,6 @@
   },
   {
     "id": 2495,
-    "entrezid": 880083,
     "description": "pyochelin synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -32436,7 +29941,6 @@
   },
   {
     "id": 2496,
-    "entrezid": 880084,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32449,7 +29953,6 @@
   },
   {
     "id": 2497,
-    "entrezid": 880085,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -32462,7 +29965,6 @@
   },
   {
     "id": 2498,
-    "entrezid": 880086,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32475,7 +29977,6 @@
   },
   {
     "id": 2499,
-    "entrezid": 880087,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -32488,7 +29989,6 @@
   },
   {
     "id": 2500,
-    "entrezid": 880088,
     "description": "ATP synthase subunit C",
     "aliases": "-",
     "obsolete": false,
@@ -32501,7 +30001,6 @@
   },
   {
     "id": 2501,
-    "entrezid": 880089,
     "description": "ATP synthase subunit A",
     "aliases": "-",
     "obsolete": false,
@@ -32514,7 +30013,6 @@
   },
   {
     "id": 2502,
-    "entrezid": 880090,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -32527,7 +30025,6 @@
   },
   {
     "id": 2503,
-    "entrezid": 880091,
     "description": "porin",
     "aliases": "-",
     "obsolete": false,
@@ -32540,7 +30037,6 @@
   },
   {
     "id": 2504,
-    "entrezid": 880092,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32553,7 +30049,6 @@
   },
   {
     "id": 2505,
-    "entrezid": 880093,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32566,7 +30061,6 @@
   },
   {
     "id": 2506,
-    "entrezid": 880094,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32579,7 +30073,6 @@
   },
   {
     "id": 2507,
-    "entrezid": 880095,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32592,7 +30085,6 @@
   },
   {
     "id": 2508,
-    "entrezid": 880096,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32605,7 +30097,6 @@
   },
   {
     "id": 2509,
-    "entrezid": 880097,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -32618,7 +30109,6 @@
   },
   {
     "id": 2510,
-    "entrezid": 880098,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32631,7 +30121,6 @@
   },
   {
     "id": 2511,
-    "entrezid": 880099,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32644,7 +30133,6 @@
   },
   {
     "id": 2512,
-    "entrezid": 880100,
     "description": "5-carboxy-2-hydroxymuconate semialdehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -32657,7 +30145,6 @@
   },
   {
     "id": 2513,
-    "entrezid": 880101,
     "description": "homoprotocatechuate 2,3-dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -32670,7 +30157,6 @@
   },
   {
     "id": 2514,
-    "entrezid": 880102,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32683,7 +30169,6 @@
   },
   {
     "id": 2515,
-    "entrezid": 880103,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32696,7 +30181,6 @@
   },
   {
     "id": 2516,
-    "entrezid": 880104,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32709,7 +30193,6 @@
   },
   {
     "id": 2517,
-    "entrezid": 880105,
     "description": "tyrosine--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -32722,7 +30205,6 @@
   },
   {
     "id": 2518,
-    "entrezid": 880106,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32735,7 +30217,6 @@
   },
   {
     "id": 2519,
-    "entrezid": 880107,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32748,7 +30229,6 @@
   },
   {
     "id": 2520,
-    "entrezid": 880108,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -32761,7 +30241,6 @@
   },
   {
     "id": 2521,
-    "entrezid": 880109,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32774,7 +30253,6 @@
   },
   {
     "id": 2522,
-    "entrezid": 880110,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32787,7 +30265,6 @@
   },
   {
     "id": 2523,
-    "entrezid": 880111,
     "description": "sensor histidine kinase",
     "aliases": "-",
     "obsolete": false,
@@ -32800,7 +30277,6 @@
   },
   {
     "id": 2524,
-    "entrezid": 880112,
     "description": "secretion protein",
     "aliases": "-",
     "obsolete": false,
@@ -32813,7 +30289,6 @@
   },
   {
     "id": 2525,
-    "entrezid": 880113,
     "description": "toxin transporter",
     "aliases": "-",
     "obsolete": false,
@@ -32826,7 +30301,6 @@
   },
   {
     "id": 2526,
-    "entrezid": 880114,
     "description": "type II secretion system protein D",
     "aliases": "-",
     "obsolete": false,
@@ -32839,7 +30313,6 @@
   },
   {
     "id": 2527,
-    "entrezid": 880115,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -32852,7 +30325,6 @@
   },
   {
     "id": 2528,
-    "entrezid": 880116,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32865,7 +30337,6 @@
   },
   {
     "id": 2529,
-    "entrezid": 880118,
     "description": "transcriptional regulator AcoR",
     "aliases": "-",
     "obsolete": false,
@@ -32878,7 +30349,6 @@
   },
   {
     "id": 2530,
-    "entrezid": 880119,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -32891,7 +30361,6 @@
   },
   {
     "id": 2531,
-    "entrezid": 880120,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -32904,7 +30373,6 @@
   },
   {
     "id": 2532,
-    "entrezid": 880121,
     "description": "peptidase",
     "aliases": "-",
     "obsolete": false,
@@ -32917,7 +30385,6 @@
   },
   {
     "id": 2533,
-    "entrezid": 880122,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32930,7 +30397,6 @@
   },
   {
     "id": 2534,
-    "entrezid": 880123,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32943,7 +30409,6 @@
   },
   {
     "id": 2535,
-    "entrezid": 880124,
     "description": "formate dehydrogenase-O major subunit",
     "aliases": "-",
     "obsolete": false,
@@ -32956,7 +30421,6 @@
   },
   {
     "id": 2536,
-    "entrezid": 880125,
     "description": "lipase LipC",
     "aliases": "-",
     "obsolete": false,
@@ -32969,7 +30433,6 @@
   },
   {
     "id": 2537,
-    "entrezid": 880126,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32982,7 +30445,6 @@
   },
   {
     "id": 2538,
-    "entrezid": 880127,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -32995,7 +30457,6 @@
   },
   {
     "id": 2539,
-    "entrezid": 880128,
     "description": "coenzyme PQQ synthesis protein E",
     "aliases": "-",
     "obsolete": false,
@@ -33008,7 +30469,6 @@
   },
   {
     "id": 2540,
-    "entrezid": 880129,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -33021,7 +30481,6 @@
   },
   {
     "id": 2541,
-    "entrezid": 880130,
     "description": "methylated-DNA--protein-cysteine methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -33034,7 +30493,6 @@
   },
   {
     "id": 2542,
-    "entrezid": 880131,
     "description": "polyamine ABC transporter permease PotC",
     "aliases": "-",
     "obsolete": false,
@@ -33047,7 +30505,6 @@
   },
   {
     "id": 2543,
-    "entrezid": 880132,
     "description": "polyamine ABC transporter substrate-binding protein PotD",
     "aliases": "-",
     "obsolete": false,
@@ -33060,7 +30517,6 @@
   },
   {
     "id": 2544,
-    "entrezid": 880133,
     "description": "branched-chain alpha-keto acid dehydrogenase subunit E2",
     "aliases": "-",
     "obsolete": false,
@@ -33073,7 +30529,6 @@
   },
   {
     "id": 2545,
-    "entrezid": 880134,
     "description": "2,3-butanediol dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -33086,7 +30541,6 @@
   },
   {
     "id": 2546,
-    "entrezid": 880135,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33099,7 +30553,6 @@
   },
   {
     "id": 2547,
-    "entrezid": 880136,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33112,7 +30565,6 @@
   },
   {
     "id": 2548,
-    "entrezid": 880137,
     "description": "50S ribosomal protein L31 type B",
     "aliases": "-",
     "obsolete": false,
@@ -33125,7 +30577,6 @@
   },
   {
     "id": 2549,
-    "entrezid": 880138,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33138,7 +30589,6 @@
   },
   {
     "id": 2550,
-    "entrezid": 880139,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -33151,7 +30601,6 @@
   },
   {
     "id": 2551,
-    "entrezid": 880140,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33164,7 +30613,6 @@
   },
   {
     "id": 2552,
-    "entrezid": 880141,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -33177,7 +30625,6 @@
   },
   {
     "id": 2553,
-    "entrezid": 880142,
     "description": "50S ribosomal protein L36",
     "aliases": "-",
     "obsolete": false,
@@ -33190,7 +30637,6 @@
   },
   {
     "id": 2554,
-    "entrezid": 880143,
     "description": "phosphate acyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -33203,7 +30649,6 @@
   },
   {
     "id": 2555,
-    "entrezid": 880144,
     "description": "50S ribosomal protein L32",
     "aliases": "-",
     "obsolete": false,
@@ -33216,7 +30661,6 @@
   },
   {
     "id": 2556,
-    "entrezid": 880145,
     "description": "3-deoxy-D-manno-octulosonic acid transferase",
     "aliases": "-",
     "obsolete": false,
@@ -33229,7 +30673,6 @@
   },
   {
     "id": 2557,
-    "entrezid": 880146,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -33242,7 +30685,6 @@
   },
   {
     "id": 2558,
-    "entrezid": 880147,
     "description": "SMR multidrug efflux transporter",
     "aliases": "-",
     "obsolete": false,
@@ -33255,7 +30697,6 @@
   },
   {
     "id": 2559,
-    "entrezid": 880148,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -33268,7 +30709,6 @@
   },
   {
     "id": 2560,
-    "entrezid": 880149,
     "description": "diacylglycerol kinase",
     "aliases": "-",
     "obsolete": false,
@@ -33281,7 +30721,6 @@
   },
   {
     "id": 2561,
-    "entrezid": 880150,
     "description": "response regulator ErdR",
     "aliases": "-",
     "obsolete": false,
@@ -33294,7 +30733,6 @@
   },
   {
     "id": 2562,
-    "entrezid": 880151,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33307,7 +30745,6 @@
   },
   {
     "id": 2563,
-    "entrezid": 880152,
     "description": "glycerol uptake facilitator protein",
     "aliases": "-",
     "obsolete": false,
@@ -33320,7 +30757,6 @@
   },
   {
     "id": 2564,
-    "entrezid": 880153,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -33333,7 +30769,6 @@
   },
   {
     "id": 2565,
-    "entrezid": 880154,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33346,7 +30781,6 @@
   },
   {
     "id": 2566,
-    "entrezid": 880155,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33359,7 +30793,6 @@
   },
   {
     "id": 2567,
-    "entrezid": 880156,
     "description": "2,4-dienoyl-CoA reductase",
     "aliases": "-",
     "obsolete": false,
@@ -33372,7 +30805,6 @@
   },
   {
     "id": 2568,
-    "entrezid": 880157,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33385,7 +30817,6 @@
   },
   {
     "id": 2569,
-    "entrezid": 880158,
     "description": "electron transfer flavoprotein subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -33398,7 +30829,6 @@
   },
   {
     "id": 2570,
-    "entrezid": 880159,
     "description": "electron transfer flavoprotein-ubiquinone oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -33411,7 +30841,6 @@
   },
   {
     "id": 2571,
-    "entrezid": 880160,
     "description": "TonB-dependent receptor",
     "aliases": "-",
     "obsolete": false,
@@ -33424,7 +30853,6 @@
   },
   {
     "id": 2572,
-    "entrezid": 880161,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -33437,7 +30865,6 @@
   },
   {
     "id": 2573,
-    "entrezid": 880162,
     "description": "glycerol kinase",
     "aliases": "-",
     "obsolete": false,
@@ -33450,7 +30877,6 @@
   },
   {
     "id": 2574,
-    "entrezid": 880163,
     "description": "glycerol-3-phosphate regulon repressor",
     "aliases": "-",
     "obsolete": false,
@@ -33463,7 +30889,6 @@
   },
   {
     "id": 2575,
-    "entrezid": 880164,
     "description": "cell division inhibitor SulA",
     "aliases": "-",
     "obsolete": false,
@@ -33476,7 +30901,6 @@
   },
   {
     "id": 2576,
-    "entrezid": 880165,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33489,7 +30913,6 @@
   },
   {
     "id": 2577,
-    "entrezid": 880166,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33502,7 +30925,6 @@
   },
   {
     "id": 2578,
-    "entrezid": 880167,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33515,7 +30937,6 @@
   },
   {
     "id": 2579,
-    "entrezid": 880168,
     "description": "phosphotyrosine protein phosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -33528,7 +30949,6 @@
   },
   {
     "id": 2580,
-    "entrezid": 880169,
     "description": "3-deoxy-manno-octulosonate cytidylyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -33541,7 +30961,6 @@
   },
   {
     "id": 2581,
-    "entrezid": 880170,
     "description": "formate dehydrogenase subunit epsilon",
     "aliases": "-",
     "obsolete": false,
@@ -33554,7 +30973,6 @@
   },
   {
     "id": 2582,
-    "entrezid": 880171,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33567,7 +30985,6 @@
   },
   {
     "id": 2583,
-    "entrezid": 880172,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33580,7 +30997,6 @@
   },
   {
     "id": 2584,
-    "entrezid": 880173,
     "description": "recombinase A",
     "aliases": "-",
     "obsolete": false,
@@ -33593,7 +31009,6 @@
   },
   {
     "id": 2585,
-    "entrezid": 880174,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -33606,7 +31021,6 @@
   },
   {
     "id": 2586,
-    "entrezid": 880175,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33619,7 +31033,6 @@
   },
   {
     "id": 2587,
-    "entrezid": 880176,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33632,7 +31045,6 @@
   },
   {
     "id": 2588,
-    "entrezid": 880177,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33645,7 +31057,6 @@
   },
   {
     "id": 2589,
-    "entrezid": 880178,
     "description": "glycerol kinase",
     "aliases": "-",
     "obsolete": false,
@@ -33658,7 +31069,6 @@
   },
   {
     "id": 2590,
-    "entrezid": 880179,
     "description": "glycerol-3-phosphate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -33671,7 +31081,6 @@
   },
   {
     "id": 2591,
-    "entrezid": 880180,
     "description": "membrane protein GlpM",
     "aliases": "-",
     "obsolete": false,
@@ -33684,7 +31093,6 @@
   },
   {
     "id": 2592,
-    "entrezid": 880181,
     "description": "amidase",
     "aliases": "-",
     "obsolete": false,
@@ -33697,7 +31105,6 @@
   },
   {
     "id": 2593,
-    "entrezid": 880182,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33710,7 +31117,6 @@
   },
   {
     "id": 2594,
-    "entrezid": 880183,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -33723,7 +31129,6 @@
   },
   {
     "id": 2595,
-    "entrezid": 880184,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33736,7 +31141,6 @@
   },
   {
     "id": 2596,
-    "entrezid": 880185,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33749,7 +31153,6 @@
   },
   {
     "id": 2597,
-    "entrezid": 880186,
     "description": "glutathione S-transferase",
     "aliases": "-",
     "obsolete": false,
@@ -33762,7 +31165,6 @@
   },
   {
     "id": 2598,
-    "entrezid": 880187,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33775,7 +31177,6 @@
   },
   {
     "id": 2599,
-    "entrezid": 880188,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33788,7 +31189,6 @@
   },
   {
     "id": 2600,
-    "entrezid": 880189,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33801,7 +31201,6 @@
   },
   {
     "id": 2601,
-    "entrezid": 880190,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33814,7 +31213,6 @@
   },
   {
     "id": 2602,
-    "entrezid": 880191,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -33827,7 +31225,6 @@
   },
   {
     "id": 2603,
-    "entrezid": 880192,
     "description": "nitrate-inducible formate dehydrogenase subunit gamma",
     "aliases": "-",
     "obsolete": false,
@@ -33840,7 +31237,6 @@
   },
   {
     "id": 2604,
-    "entrezid": 880193,
     "description": "nitrate-inducible formate dehydrogenase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -33853,7 +31249,6 @@
   },
   {
     "id": 2605,
-    "entrezid": 880194,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33866,7 +31261,6 @@
   },
   {
     "id": 2606,
-    "entrezid": 880195,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33879,7 +31273,6 @@
   },
   {
     "id": 2607,
-    "entrezid": 880196,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33892,7 +31285,6 @@
   },
   {
     "id": 2608,
-    "entrezid": 880197,
     "description": "selenocysteine-specific elongation factor",
     "aliases": "-",
     "obsolete": false,
@@ -33905,7 +31297,6 @@
   },
   {
     "id": 2609,
-    "entrezid": 880198,
     "description": "selenocysteine synthase",
     "aliases": "-",
     "obsolete": false,
@@ -33918,7 +31309,6 @@
   },
   {
     "id": 2610,
-    "entrezid": 880199,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33931,7 +31321,6 @@
   },
   {
     "id": 2611,
-    "entrezid": 880200,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -33944,7 +31333,6 @@
   },
   {
     "id": 2612,
-    "entrezid": 880201,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33957,7 +31345,6 @@
   },
   {
     "id": 2613,
-    "entrezid": 880202,
     "description": "amino acid permease",
     "aliases": "-",
     "obsolete": false,
@@ -33970,7 +31357,6 @@
   },
   {
     "id": 2614,
-    "entrezid": 880203,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -33983,7 +31369,6 @@
   },
   {
     "id": 2615,
-    "entrezid": 880204,
     "description": "Na(+)-translocating NADH-quinone reductase subunit C",
     "aliases": "-",
     "obsolete": false,
@@ -33996,7 +31381,6 @@
   },
   {
     "id": 2616,
-    "entrezid": 880205,
     "description": "Na(+)-translocating NADH-quinone reductase subunit B",
     "aliases": "-",
     "obsolete": false,
@@ -34009,7 +31393,6 @@
   },
   {
     "id": 2617,
-    "entrezid": 880206,
     "description": "acetyl-CoA acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -34022,7 +31405,6 @@
   },
   {
     "id": 2618,
-    "entrezid": 880207,
     "description": "3-hydroxyacyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -34035,7 +31417,6 @@
   },
   {
     "id": 2619,
-    "entrezid": 880208,
     "description": "endopeptidase IV",
     "aliases": "-",
     "obsolete": false,
@@ -34048,7 +31429,6 @@
   },
   {
     "id": 2620,
-    "entrezid": 880209,
     "description": "peptidyl-prolyl cis-trans isomerase C2",
     "aliases": "-",
     "obsolete": false,
@@ -34061,7 +31441,6 @@
   },
   {
     "id": 2621,
-    "entrezid": 880210,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -34074,7 +31453,6 @@
   },
   {
     "id": 2622,
-    "entrezid": 880211,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -34087,7 +31465,6 @@
   },
   {
     "id": 2623,
-    "entrezid": 880212,
     "description": "resistance-nodulation-cell division (RND) multidrug efflux membrane fusion protein MexE",
     "aliases": "-",
     "obsolete": false,
@@ -34100,7 +31477,6 @@
   },
   {
     "id": 2624,
-    "entrezid": 880213,
     "description": "ferric enterobactin transporter FepD",
     "aliases": "-",
     "obsolete": false,
@@ -34113,7 +31489,6 @@
   },
   {
     "id": 2625,
-    "entrezid": 880214,
     "description": "ferric enterobactin transporter FepG",
     "aliases": "-",
     "obsolete": false,
@@ -34126,7 +31501,6 @@
   },
   {
     "id": 2626,
-    "entrezid": 880215,
     "description": "S-methyl-5'-thioinosine phosphorylase",
     "aliases": "-",
     "obsolete": false,
@@ -34139,7 +31513,6 @@
   },
   {
     "id": 2627,
-    "entrezid": 880216,
     "description": "beta-hexosaminidase",
     "aliases": "-",
     "obsolete": false,
@@ -34152,7 +31525,6 @@
   },
   {
     "id": 2628,
-    "entrezid": 880217,
     "description": "sensor histidine kinase",
     "aliases": "-",
     "obsolete": false,
@@ -34165,7 +31537,6 @@
   },
   {
     "id": 2629,
-    "entrezid": 880218,
     "description": "enoyl-CoA hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -34178,7 +31549,6 @@
   },
   {
     "id": 2630,
-    "entrezid": 880219,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34191,7 +31561,6 @@
   },
   {
     "id": 2631,
-    "entrezid": 880220,
     "description": "transcriptional regulator MetR",
     "aliases": "-",
     "obsolete": false,
@@ -34204,7 +31573,6 @@
   },
   {
     "id": 2632,
-    "entrezid": 880221,
     "description": "porin",
     "aliases": "-",
     "obsolete": false,
@@ -34217,7 +31585,6 @@
   },
   {
     "id": 2633,
-    "entrezid": 880222,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -34230,7 +31597,6 @@
   },
   {
     "id": 2634,
-    "entrezid": 880223,
     "description": "acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -34243,7 +31609,6 @@
   },
   {
     "id": 2635,
-    "entrezid": 880224,
     "description": "1-phosphofructokinase",
     "aliases": "-",
     "obsolete": false,
@@ -34256,7 +31621,6 @@
   },
   {
     "id": 2636,
-    "entrezid": 880225,
     "description": "PTS system fructose-specific transporter subunit FruI",
     "aliases": "-",
     "obsolete": false,
@@ -34269,7 +31633,6 @@
   },
   {
     "id": 2637,
-    "entrezid": 880226,
     "description": "aminoglycoside 3-N-acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -34282,7 +31645,6 @@
   },
   {
     "id": 2638,
-    "entrezid": 880227,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -34295,7 +31657,6 @@
   },
   {
     "id": 2639,
-    "entrezid": 880228,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34308,7 +31669,6 @@
   },
   {
     "id": 2640,
-    "entrezid": 880229,
     "description": "DNA mismatch repair protein MutS",
     "aliases": "-",
     "obsolete": false,
@@ -34321,7 +31681,6 @@
   },
   {
     "id": 2641,
-    "entrezid": 880230,
     "description": "ferredoxin I",
     "aliases": "-",
     "obsolete": false,
@@ -34334,7 +31693,6 @@
   },
   {
     "id": 2642,
-    "entrezid": 880231,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34347,7 +31705,6 @@
   },
   {
     "id": 2643,
-    "entrezid": 880232,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34360,7 +31717,6 @@
   },
   {
     "id": 2644,
-    "entrezid": 880233,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34373,7 +31729,6 @@
   },
   {
     "id": 2645,
-    "entrezid": 880234,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -34386,7 +31741,6 @@
   },
   {
     "id": 2646,
-    "entrezid": 880235,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -34399,7 +31753,6 @@
   },
   {
     "id": 2647,
-    "entrezid": 880236,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34412,7 +31765,6 @@
   },
   {
     "id": 2648,
-    "entrezid": 880237,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34425,7 +31777,6 @@
   },
   {
     "id": 2649,
-    "entrezid": 880238,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -34438,7 +31789,6 @@
   },
   {
     "id": 2650,
-    "entrezid": 880239,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34451,7 +31801,6 @@
   },
   {
     "id": 2651,
-    "entrezid": 880240,
     "description": "protein GbcA",
     "aliases": "-",
     "obsolete": false,
@@ -34464,7 +31813,6 @@
   },
   {
     "id": 2652,
-    "entrezid": 880241,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34477,7 +31825,6 @@
   },
   {
     "id": 2653,
-    "entrezid": 880242,
     "description": "aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -34490,7 +31837,6 @@
   },
   {
     "id": 2654,
-    "entrezid": 880243,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34503,7 +31849,6 @@
   },
   {
     "id": 2655,
-    "entrezid": 880244,
     "description": "recombination regulator RecX",
     "aliases": "-",
     "obsolete": false,
@@ -34516,7 +31861,6 @@
   },
   {
     "id": 2656,
-    "entrezid": 880245,
     "description": "2,5-diketo-D-gluconate reductase B",
     "aliases": "-",
     "obsolete": false,
@@ -34529,7 +31873,6 @@
   },
   {
     "id": 2657,
-    "entrezid": 880246,
     "description": "second ferric pyoverdine receptor FpvB",
     "aliases": "-",
     "obsolete": false,
@@ -34542,7 +31885,6 @@
   },
   {
     "id": 2658,
-    "entrezid": 880247,
     "description": "D-tyrosyl-tRNA(Tyr) deacylase",
     "aliases": "-",
     "obsolete": false,
@@ -34555,7 +31897,6 @@
   },
   {
     "id": 2659,
-    "entrezid": 880248,
     "description": "prolyl aminopeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -34568,7 +31909,6 @@
   },
   {
     "id": 2660,
-    "entrezid": 880249,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34581,7 +31921,6 @@
   },
   {
     "id": 2661,
-    "entrezid": 880250,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34594,7 +31933,6 @@
   },
   {
     "id": 2662,
-    "entrezid": 880251,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34607,7 +31945,6 @@
   },
   {
     "id": 2663,
-    "entrezid": 880252,
     "description": "amino acid permease",
     "aliases": "-",
     "obsolete": false,
@@ -34620,7 +31957,6 @@
   },
   {
     "id": 2664,
-    "entrezid": 880253,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34633,7 +31969,6 @@
   },
   {
     "id": 2665,
-    "entrezid": 880254,
     "description": "L-sorbosone dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -34646,7 +31981,6 @@
   },
   {
     "id": 2666,
-    "entrezid": 880255,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34659,7 +31993,6 @@
   },
   {
     "id": 2667,
-    "entrezid": 880256,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34672,7 +32005,6 @@
   },
   {
     "id": 2668,
-    "entrezid": 880257,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -34685,7 +32017,6 @@
   },
   {
     "id": 2669,
-    "entrezid": 880258,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34698,7 +32029,6 @@
   },
   {
     "id": 2670,
-    "entrezid": 880259,
     "description": "aldolase",
     "aliases": "-",
     "obsolete": false,
@@ -34711,7 +32041,6 @@
   },
   {
     "id": 2671,
-    "entrezid": 880260,
     "description": "2-oxo-hepta-3-ene-1,7-dioic acid hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -34724,7 +32053,6 @@
   },
   {
     "id": 2672,
-    "entrezid": 880261,
     "description": "sensor/response regulator hybrid protein",
     "aliases": "-",
     "obsolete": false,
@@ -34737,7 +32065,6 @@
   },
   {
     "id": 2673,
-    "entrezid": 880262,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34750,7 +32077,6 @@
   },
   {
     "id": 2674,
-    "entrezid": 880263,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -34763,7 +32089,6 @@
   },
   {
     "id": 2675,
-    "entrezid": 880264,
     "description": "quercetin 2,3-dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -34776,7 +32101,6 @@
   },
   {
     "id": 2676,
-    "entrezid": 880265,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34789,7 +32113,6 @@
   },
   {
     "id": 2677,
-    "entrezid": 880266,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -34802,7 +32125,6 @@
   },
   {
     "id": 2678,
-    "entrezid": 880267,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -34815,7 +32137,6 @@
   },
   {
     "id": 2679,
-    "entrezid": 880268,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -34828,7 +32149,6 @@
   },
   {
     "id": 2680,
-    "entrezid": 880269,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34841,7 +32161,6 @@
   },
   {
     "id": 2681,
-    "entrezid": 880270,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34854,7 +32173,6 @@
   },
   {
     "id": 2682,
-    "entrezid": 880271,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34867,7 +32185,6 @@
   },
   {
     "id": 2683,
-    "entrezid": 880272,
     "description": "acyl-homoserine lactone acylase QuiP",
     "aliases": "-",
     "obsolete": false,
@@ -34880,7 +32197,6 @@
   },
   {
     "id": 2684,
-    "entrezid": 880273,
     "description": "iron/ascorbate oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -34893,7 +32209,6 @@
   },
   {
     "id": 2685,
-    "entrezid": 880274,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -34906,7 +32221,6 @@
   },
   {
     "id": 2686,
-    "entrezid": 880275,
     "description": "protease",
     "aliases": "-",
     "obsolete": false,
@@ -34919,7 +32233,6 @@
   },
   {
     "id": 2687,
-    "entrezid": 880276,
     "description": "nuclease",
     "aliases": "-",
     "obsolete": false,
@@ -34932,7 +32245,6 @@
   },
   {
     "id": 2688,
-    "entrezid": 880277,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -34945,7 +32257,6 @@
   },
   {
     "id": 2689,
-    "entrezid": 880278,
     "description": "glutathione S-transferase",
     "aliases": "-",
     "obsolete": false,
@@ -34958,7 +32269,6 @@
   },
   {
     "id": 2690,
-    "entrezid": 880279,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34971,7 +32281,6 @@
   },
   {
     "id": 2691,
-    "entrezid": 880280,
     "description": "heat shock protein",
     "aliases": "-",
     "obsolete": false,
@@ -34984,7 +32293,6 @@
   },
   {
     "id": 2692,
-    "entrezid": 880281,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -34997,7 +32305,6 @@
   },
   {
     "id": 2693,
-    "entrezid": 880282,
     "description": "NADH pyrophosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -35010,7 +32317,6 @@
   },
   {
     "id": 2694,
-    "entrezid": 880283,
     "description": "choline transporter BetT",
     "aliases": "-",
     "obsolete": false,
@@ -35023,7 +32329,6 @@
   },
   {
     "id": 2695,
-    "entrezid": 880284,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -35036,7 +32341,6 @@
   },
   {
     "id": 2696,
-    "entrezid": 880285,
     "description": "porin",
     "aliases": "-",
     "obsolete": false,
@@ -35049,7 +32353,6 @@
   },
   {
     "id": 2697,
-    "entrezid": 880286,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35062,7 +32365,6 @@
   },
   {
     "id": 2698,
-    "entrezid": 880287,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -35075,7 +32377,6 @@
   },
   {
     "id": 2699,
-    "entrezid": 880288,
     "description": "ribosomal protein S6 modification protein",
     "aliases": "-",
     "obsolete": false,
@@ -35088,7 +32389,6 @@
   },
   {
     "id": 2700,
-    "entrezid": 880289,
     "description": "LD-carboxypeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -35101,7 +32401,6 @@
   },
   {
     "id": 2701,
-    "entrezid": 880290,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35114,7 +32413,6 @@
   },
   {
     "id": 2702,
-    "entrezid": 880291,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35127,7 +32425,6 @@
   },
   {
     "id": 2703,
-    "entrezid": 880292,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35140,7 +32437,6 @@
   },
   {
     "id": 2704,
-    "entrezid": 880293,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35153,7 +32449,6 @@
   },
   {
     "id": 2705,
-    "entrezid": 880294,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35166,7 +32461,6 @@
   },
   {
     "id": 2706,
-    "entrezid": 880295,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35179,7 +32473,6 @@
   },
   {
     "id": 2707,
-    "entrezid": 880296,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -35192,7 +32485,6 @@
   },
   {
     "id": 2708,
-    "entrezid": 880297,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -35205,7 +32497,6 @@
   },
   {
     "id": 2709,
-    "entrezid": 880298,
     "description": "sulfate transporter CysZ",
     "aliases": "-",
     "obsolete": false,
@@ -35218,7 +32509,6 @@
   },
   {
     "id": 2710,
-    "entrezid": 880299,
     "description": "coniferyl aldehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -35231,7 +32521,6 @@
   },
   {
     "id": 2711,
-    "entrezid": 880300,
     "description": "protein AmgS",
     "aliases": "-",
     "obsolete": false,
@@ -35244,7 +32533,6 @@
   },
   {
     "id": 2712,
-    "entrezid": 880301,
     "description": "osmolarity response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -35257,7 +32545,6 @@
   },
   {
     "id": 2713,
-    "entrezid": 880302,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35270,7 +32557,6 @@
   },
   {
     "id": 2714,
-    "entrezid": 880303,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35283,7 +32569,6 @@
   },
   {
     "id": 2715,
-    "entrezid": 880304,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35296,7 +32581,6 @@
   },
   {
     "id": 2716,
-    "entrezid": 880305,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -35309,7 +32593,6 @@
   },
   {
     "id": 2717,
-    "entrezid": 880306,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35322,7 +32605,6 @@
   },
   {
     "id": 2718,
-    "entrezid": 880307,
     "description": "30S ribosomal protein S21",
     "aliases": "-",
     "obsolete": false,
@@ -35335,7 +32617,6 @@
   },
   {
     "id": 2719,
-    "entrezid": 880308,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35348,7 +32629,6 @@
   },
   {
     "id": 2720,
-    "entrezid": 880309,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35361,7 +32641,6 @@
   },
   {
     "id": 2721,
-    "entrezid": 880310,
     "description": "signal recognition particle protein Ffh",
     "aliases": "-",
     "obsolete": false,
@@ -35374,7 +32653,6 @@
   },
   {
     "id": 2722,
-    "entrezid": 880311,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35387,7 +32665,6 @@
   },
   {
     "id": 2723,
-    "entrezid": 880312,
     "description": "porin",
     "aliases": "-",
     "obsolete": false,
@@ -35400,7 +32677,6 @@
   },
   {
     "id": 2724,
-    "entrezid": 880313,
     "description": "acetolactate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -35413,7 +32689,6 @@
   },
   {
     "id": 2725,
-    "entrezid": 880314,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35426,7 +32701,6 @@
   },
   {
     "id": 2726,
-    "entrezid": 880315,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -35439,7 +32713,6 @@
   },
   {
     "id": 2727,
-    "entrezid": 880316,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35452,7 +32725,6 @@
   },
   {
     "id": 2728,
-    "entrezid": 880317,
     "description": "4-hydroxybenzoate octaprenyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -35465,7 +32737,6 @@
   },
   {
     "id": 2729,
-    "entrezid": 880318,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35478,7 +32749,6 @@
   },
   {
     "id": 2730,
-    "entrezid": 880319,
     "description": "sodium/hydrogen antiporter",
     "aliases": "-",
     "obsolete": false,
@@ -35491,7 +32761,6 @@
   },
   {
     "id": 2731,
-    "entrezid": 880320,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35504,7 +32773,6 @@
   },
   {
     "id": 2732,
-    "entrezid": 880321,
     "description": "ferric enterobactin transporter FepC",
     "aliases": "-",
     "obsolete": false,
@@ -35517,7 +32785,6 @@
   },
   {
     "id": 2733,
-    "entrezid": 880322,
     "description": "iron-enterobactin transporter periplasmic binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -35530,7 +32797,6 @@
   },
   {
     "id": 2734,
-    "entrezid": 880323,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35543,7 +32809,6 @@
   },
   {
     "id": 2735,
-    "entrezid": 880324,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35556,7 +32821,6 @@
   },
   {
     "id": 2736,
-    "entrezid": 880325,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35569,7 +32833,6 @@
   },
   {
     "id": 2737,
-    "entrezid": 880326,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35582,7 +32845,6 @@
   },
   {
     "id": 2738,
-    "entrezid": 880327,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35595,7 +32857,6 @@
   },
   {
     "id": 2739,
-    "entrezid": 880328,
     "description": "aldehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -35608,7 +32869,6 @@
   },
   {
     "id": 2740,
-    "entrezid": 880329,
     "description": "monooxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -35621,7 +32881,6 @@
   },
   {
     "id": 2741,
-    "entrezid": 880330,
     "description": "thiol:disulfide interchange protein DsbC",
     "aliases": "-",
     "obsolete": false,
@@ -35634,7 +32893,6 @@
   },
   {
     "id": 2742,
-    "entrezid": 880331,
     "description": "site-specific tyrosine recombinase XerD",
     "aliases": "-",
     "obsolete": false,
@@ -35647,7 +32905,6 @@
   },
   {
     "id": 2743,
-    "entrezid": 880332,
     "description": "resistance-nodulation-cell division (RND) divalent metal cation efflux transporter CzcA",
     "aliases": "-",
     "obsolete": false,
@@ -35660,7 +32917,6 @@
   },
   {
     "id": 2744,
-    "entrezid": 880333,
     "description": "resistance-nodulation-cell division (RND) divalent metal cation efflux membrane fusion protein CzcB",
     "aliases": "-",
     "obsolete": false,
@@ -35673,7 +32929,6 @@
   },
   {
     "id": 2745,
-    "entrezid": 880334,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -35686,7 +32941,6 @@
   },
   {
     "id": 2746,
-    "entrezid": 880335,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35699,7 +32953,6 @@
   },
   {
     "id": 2747,
-    "entrezid": 880336,
     "description": "threonine synthase",
     "aliases": "-",
     "obsolete": false,
@@ -35712,7 +32965,6 @@
   },
   {
     "id": 2748,
-    "entrezid": 880337,
     "description": "homoserine dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -35725,7 +32977,6 @@
   },
   {
     "id": 2749,
-    "entrezid": 880338,
     "description": "acyl-CoA thioesterase",
     "aliases": "-",
     "obsolete": false,
@@ -35738,7 +32989,6 @@
   },
   {
     "id": 2750,
-    "entrezid": 880339,
     "description": "50S ribosomal protein L19",
     "aliases": "-",
     "obsolete": false,
@@ -35751,7 +33001,6 @@
   },
   {
     "id": 2751,
-    "entrezid": 880340,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -35764,7 +33013,6 @@
   },
   {
     "id": 2752,
-    "entrezid": 880341,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -35777,7 +33025,6 @@
   },
   {
     "id": 2753,
-    "entrezid": 880342,
     "description": "1,6-dihydroxycyclohexa-2,4-diene-1-carboxylate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -35790,7 +33037,6 @@
   },
   {
     "id": 2754,
-    "entrezid": 880343,
     "description": "toluate 1,2-dioxygenase electron transfer subunit",
     "aliases": "-",
     "obsolete": false,
@@ -35803,7 +33049,6 @@
   },
   {
     "id": 2755,
-    "entrezid": 880344,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -35816,7 +33061,6 @@
   },
   {
     "id": 2756,
-    "entrezid": 880345,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35829,7 +33073,6 @@
   },
   {
     "id": 2757,
-    "entrezid": 880346,
     "description": "resistance-nodulation-cell division (RND) efflux transporter",
     "aliases": "-",
     "obsolete": false,
@@ -35842,7 +33085,6 @@
   },
   {
     "id": 2758,
-    "entrezid": 880347,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35855,7 +33097,6 @@
   },
   {
     "id": 2759,
-    "entrezid": 880348,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35868,7 +33109,6 @@
   },
   {
     "id": 2760,
-    "entrezid": 880349,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35881,7 +33121,6 @@
   },
   {
     "id": 2761,
-    "entrezid": 880350,
     "description": "protein BfiS",
     "aliases": "-",
     "obsolete": false,
@@ -35894,7 +33133,6 @@
   },
   {
     "id": 2762,
-    "entrezid": 880351,
     "description": "acyl-CoA synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -35907,7 +33145,6 @@
   },
   {
     "id": 2763,
-    "entrezid": 880352,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -35920,7 +33157,6 @@
   },
   {
     "id": 2764,
-    "entrezid": 880353,
     "description": "DNA topoisomerase I",
     "aliases": "-",
     "obsolete": false,
@@ -35933,7 +33169,6 @@
   },
   {
     "id": 2765,
-    "entrezid": 880354,
     "description": "coenzyme PQQ synthesis protein B",
     "aliases": "-",
     "obsolete": false,
@@ -35946,7 +33181,6 @@
   },
   {
     "id": 2766,
-    "entrezid": 880355,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -35959,7 +33193,6 @@
   },
   {
     "id": 2767,
-    "entrezid": 880356,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -35972,7 +33205,6 @@
   },
   {
     "id": 2768,
-    "entrezid": 880357,
     "description": "tRNA (guanine-N(1)-)-methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -35985,7 +33217,6 @@
   },
   {
     "id": 2769,
-    "entrezid": 880358,
     "description": "ribosome maturation factor RimM",
     "aliases": "-",
     "obsolete": false,
@@ -35998,7 +33229,6 @@
   },
   {
     "id": 2770,
-    "entrezid": 880359,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36011,7 +33241,6 @@
   },
   {
     "id": 2771,
-    "entrezid": 880360,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36024,7 +33253,6 @@
   },
   {
     "id": 2772,
-    "entrezid": 880361,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36037,7 +33265,6 @@
   },
   {
     "id": 2773,
-    "entrezid": 880362,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -36050,7 +33277,6 @@
   },
   {
     "id": 2774,
-    "entrezid": 880363,
     "description": "2-Cys peroxiredoxin",
     "aliases": "-",
     "obsolete": false,
@@ -36063,7 +33289,6 @@
   },
   {
     "id": 2775,
-    "entrezid": 880364,
     "description": "sodium:alanine symporter",
     "aliases": "-",
     "obsolete": false,
@@ -36076,7 +33301,6 @@
   },
   {
     "id": 2776,
-    "entrezid": 880365,
     "description": "phytochrome BphP",
     "aliases": "-",
     "obsolete": false,
@@ -36089,7 +33313,6 @@
   },
   {
     "id": 2777,
-    "entrezid": 880366,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36102,7 +33325,6 @@
   },
   {
     "id": 2778,
-    "entrezid": 880367,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36115,7 +33337,6 @@
   },
   {
     "id": 2779,
-    "entrezid": 880368,
     "description": "elastase LasB",
     "aliases": "-",
     "obsolete": false,
@@ -36128,7 +33349,6 @@
   },
   {
     "id": 2780,
-    "entrezid": 880369,
     "description": "single-stranded-DNA-specific exonuclease RecJ",
     "aliases": "-",
     "obsolete": false,
@@ -36141,7 +33361,6 @@
   },
   {
     "id": 2781,
-    "entrezid": 880370,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36154,7 +33373,6 @@
   },
   {
     "id": 2782,
-    "entrezid": 880371,
     "description": "metalloprotease",
     "aliases": "-",
     "obsolete": false,
@@ -36167,7 +33385,6 @@
   },
   {
     "id": 2783,
-    "entrezid": 880372,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36180,7 +33397,6 @@
   },
   {
     "id": 2784,
-    "entrezid": 880373,
     "description": "FMN oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -36193,7 +33409,6 @@
   },
   {
     "id": 2785,
-    "entrezid": 880374,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36206,7 +33421,6 @@
   },
   {
     "id": 2786,
-    "entrezid": 880375,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -36219,7 +33433,6 @@
   },
   {
     "id": 2787,
-    "entrezid": 880376,
     "description": "MexR antirepressor ArmR",
     "aliases": "-",
     "obsolete": false,
@@ -36232,7 +33445,6 @@
   },
   {
     "id": 2788,
-    "entrezid": 880377,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -36245,7 +33457,6 @@
   },
   {
     "id": 2789,
-    "entrezid": 880378,
     "description": "type 4 fimbrial biogenesis protein PilZ",
     "aliases": "-",
     "obsolete": false,
@@ -36258,7 +33469,6 @@
   },
   {
     "id": 2790,
-    "entrezid": 880379,
     "description": "DNA polymerase III subunit delta'",
     "aliases": "-",
     "obsolete": false,
@@ -36271,7 +33481,6 @@
   },
   {
     "id": 2791,
-    "entrezid": 880380,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36284,7 +33493,6 @@
   },
   {
     "id": 2792,
-    "entrezid": 880381,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36297,7 +33505,6 @@
   },
   {
     "id": 2793,
-    "entrezid": 880382,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -36310,7 +33517,6 @@
   },
   {
     "id": 2794,
-    "entrezid": 880383,
     "description": "lysine--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -36323,7 +33529,6 @@
   },
   {
     "id": 2795,
-    "entrezid": 880384,
     "description": "peptide chain release factor 1",
     "aliases": "-",
     "obsolete": false,
@@ -36336,7 +33541,6 @@
   },
   {
     "id": 2796,
-    "entrezid": 880385,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36349,7 +33553,6 @@
   },
   {
     "id": 2797,
-    "entrezid": 880386,
     "description": "FkbP-type peptidyl-prolyl cis-trans isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -36362,7 +33565,6 @@
   },
   {
     "id": 2798,
-    "entrezid": 880387,
     "description": "cytochrome C550",
     "aliases": "-",
     "obsolete": false,
@@ -36375,7 +33577,6 @@
   },
   {
     "id": 2799,
-    "entrezid": 880388,
     "description": "CDP-diacylglycerol--glycerol-3-phosphate 3-phosphatidyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -36388,7 +33589,6 @@
   },
   {
     "id": 2800,
-    "entrezid": 880389,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36401,7 +33601,6 @@
   },
   {
     "id": 2801,
-    "entrezid": 880390,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36414,7 +33613,6 @@
   },
   {
     "id": 2802,
-    "entrezid": 880391,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36427,7 +33625,6 @@
   },
   {
     "id": 2803,
-    "entrezid": 880392,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -36440,7 +33637,6 @@
   },
   {
     "id": 2804,
-    "entrezid": 880393,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36453,7 +33649,6 @@
   },
   {
     "id": 2805,
-    "entrezid": 880394,
     "description": "chemotaxis sensor/effector fusion protein",
     "aliases": "-",
     "obsolete": false,
@@ -36466,7 +33661,6 @@
   },
   {
     "id": 2806,
-    "entrezid": 880395,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36479,7 +33673,6 @@
   },
   {
     "id": 2807,
-    "entrezid": 880396,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -36492,7 +33685,6 @@
   },
   {
     "id": 2808,
-    "entrezid": 880397,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36505,7 +33697,6 @@
   },
   {
     "id": 2809,
-    "entrezid": 880398,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36518,7 +33709,6 @@
   },
   {
     "id": 2810,
-    "entrezid": 880399,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36531,7 +33721,6 @@
   },
   {
     "id": 2811,
-    "entrezid": 880400,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36544,7 +33733,6 @@
   },
   {
     "id": 2812,
-    "entrezid": 880401,
     "description": "Mg(2+) transport ATPase",
     "aliases": "-",
     "obsolete": false,
@@ -36557,7 +33745,6 @@
   },
   {
     "id": 2813,
-    "entrezid": 880402,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36570,7 +33757,6 @@
   },
   {
     "id": 2814,
-    "entrezid": 880403,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36583,7 +33769,6 @@
   },
   {
     "id": 2815,
-    "entrezid": 880404,
     "description": "spermidine dehydrogenase SpdH",
     "aliases": "-",
     "obsolete": false,
@@ -36596,7 +33781,6 @@
   },
   {
     "id": 2816,
-    "entrezid": 880405,
     "description": "pellicle/biofilm biosynthesis protein PelD",
     "aliases": "-",
     "obsolete": false,
@@ -36609,7 +33793,6 @@
   },
   {
     "id": 2817,
-    "entrezid": 880406,
     "description": "pellicle/biofilm biosynthesis outer membrane protein PelC",
     "aliases": "-",
     "obsolete": false,
@@ -36622,7 +33805,6 @@
   },
   {
     "id": 2818,
-    "entrezid": 880407,
     "description": "transposase",
     "aliases": "-",
     "obsolete": false,
@@ -36635,7 +33817,6 @@
   },
   {
     "id": 2819,
-    "entrezid": 880408,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36648,7 +33829,6 @@
   },
   {
     "id": 2820,
-    "entrezid": 880409,
     "description": "chemotaxis transducer",
     "aliases": "-",
     "obsolete": false,
@@ -36661,7 +33841,6 @@
   },
   {
     "id": 2821,
-    "entrezid": 880410,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -36674,7 +33853,6 @@
   },
   {
     "id": 2822,
-    "entrezid": 880411,
     "description": "two-component sensor CopS",
     "aliases": "-",
     "obsolete": false,
@@ -36687,7 +33865,6 @@
   },
   {
     "id": 2823,
-    "entrezid": 880412,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -36700,7 +33877,6 @@
   },
   {
     "id": 2824,
-    "entrezid": 880413,
     "description": "NAD+ dependent aldehyde dehydrogenase ExaC",
     "aliases": "-",
     "obsolete": false,
@@ -36713,7 +33889,6 @@
   },
   {
     "id": 2825,
-    "entrezid": 880414,
     "description": "glyceraldehyde-3-phosphate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -36726,7 +33901,6 @@
   },
   {
     "id": 2826,
-    "entrezid": 880415,
     "description": "transcription-repair coupling factor",
     "aliases": "-",
     "obsolete": false,
@@ -36739,7 +33913,6 @@
   },
   {
     "id": 2827,
-    "entrezid": 880416,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -36752,7 +33925,6 @@
   },
   {
     "id": 2828,
-    "entrezid": 880417,
     "description": "transcriptional regulator MexT",
     "aliases": "-",
     "obsolete": false,
@@ -36765,7 +33937,6 @@
   },
   {
     "id": 2829,
-    "entrezid": 880418,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36778,7 +33949,6 @@
   },
   {
     "id": 2830,
-    "entrezid": 880419,
     "description": "Fe(III)-pyochelin outer membrane receptor",
     "aliases": "-",
     "obsolete": false,
@@ -36791,7 +33961,6 @@
   },
   {
     "id": 2831,
-    "entrezid": 880420,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -36804,7 +33973,6 @@
   },
   {
     "id": 2832,
-    "entrezid": 880421,
     "description": "RNA polymerase sigma factor RpoS",
     "aliases": "-",
     "obsolete": false,
@@ -36817,7 +33985,6 @@
   },
   {
     "id": 2833,
-    "entrezid": 880422,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36830,7 +33997,6 @@
   },
   {
     "id": 2834,
-    "entrezid": 880423,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36843,7 +34009,6 @@
   },
   {
     "id": 2835,
-    "entrezid": 880424,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36856,7 +34021,6 @@
   },
   {
     "id": 2836,
-    "entrezid": 880425,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -36869,7 +34033,6 @@
   },
   {
     "id": 2837,
-    "entrezid": 880426,
     "description": "enoyl-CoA hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -36882,7 +34045,6 @@
   },
   {
     "id": 2838,
-    "entrezid": 880427,
     "description": "amino acid permease",
     "aliases": "-",
     "obsolete": false,
@@ -36895,7 +34057,6 @@
   },
   {
     "id": 2839,
-    "entrezid": 880428,
     "description": "2-dehydro-3-deoxyphosphooctonate aldolase",
     "aliases": "-",
     "obsolete": false,
@@ -36908,7 +34069,6 @@
   },
   {
     "id": 2840,
-    "entrezid": 880429,
     "description": "polyamine transporter ATP-binding protein PotA",
     "aliases": "-",
     "obsolete": false,
@@ -36921,7 +34081,6 @@
   },
   {
     "id": 2841,
-    "entrezid": 880430,
     "description": "polyamine ABC transporter permease PotB",
     "aliases": "-",
     "obsolete": false,
@@ -36934,7 +34093,6 @@
   },
   {
     "id": 2842,
-    "entrezid": 880431,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36947,7 +34105,6 @@
   },
   {
     "id": 2843,
-    "entrezid": 880432,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -36960,7 +34117,6 @@
   },
   {
     "id": 2844,
-    "entrezid": 880433,
     "description": "3-oxoacyl-[acyl-carrier-protein] reductase FabG",
     "aliases": "-",
     "obsolete": false,
@@ -36973,7 +34129,6 @@
   },
   {
     "id": 2845,
-    "entrezid": 880434,
     "description": "malonyl CoA-ACP transacylase",
     "aliases": "-",
     "obsolete": false,
@@ -36986,7 +34141,6 @@
   },
   {
     "id": 2846,
-    "entrezid": 880435,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -36999,7 +34153,6 @@
   },
   {
     "id": 2847,
-    "entrezid": 880436,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37012,7 +34165,6 @@
   },
   {
     "id": 2848,
-    "entrezid": 880437,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37025,7 +34177,6 @@
   },
   {
     "id": 2849,
-    "entrezid": 880438,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37038,7 +34189,6 @@
   },
   {
     "id": 2850,
-    "entrezid": 880439,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37051,7 +34201,6 @@
   },
   {
     "id": 2851,
-    "entrezid": 880440,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37064,7 +34213,6 @@
   },
   {
     "id": 2852,
-    "entrezid": 880441,
     "description": "protein-L-isoaspartate O-methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -37077,7 +34225,6 @@
   },
   {
     "id": 2853,
-    "entrezid": 880442,
     "description": "5'-nucleotidase SurE",
     "aliases": "-",
     "obsolete": false,
@@ -37090,7 +34237,6 @@
   },
   {
     "id": 2854,
-    "entrezid": 880443,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -37103,7 +34249,6 @@
   },
   {
     "id": 2855,
-    "entrezid": 880444,
     "description": "gluconolactonase PpgL",
     "aliases": "-",
     "obsolete": false,
@@ -37116,7 +34261,6 @@
   },
   {
     "id": 2856,
-    "entrezid": 880445,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -37129,7 +34273,6 @@
   },
   {
     "id": 2857,
-    "entrezid": 880446,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37142,7 +34285,6 @@
   },
   {
     "id": 2858,
-    "entrezid": 880447,
     "description": "sensor kinase EraS",
     "aliases": "-",
     "obsolete": false,
@@ -37155,7 +34297,6 @@
   },
   {
     "id": 2859,
-    "entrezid": 880448,
     "description": "Zn-dependent metalloprotease",
     "aliases": "-",
     "obsolete": false,
@@ -37168,7 +34309,6 @@
   },
   {
     "id": 2860,
-    "entrezid": 880449,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37181,7 +34321,6 @@
   },
   {
     "id": 2861,
-    "entrezid": 880450,
     "description": "resistance-nodulation-cell division (RND) efflux membrane fusion protein",
     "aliases": "-",
     "obsolete": false,
@@ -37194,7 +34333,6 @@
   },
   {
     "id": 2862,
-    "entrezid": 880451,
     "description": "multifunctional non-homologous end joining protein LigD",
     "aliases": "-",
     "obsolete": false,
@@ -37207,7 +34345,6 @@
   },
   {
     "id": 2863,
-    "entrezid": 880452,
     "description": "cell division protein FtsB",
     "aliases": "-",
     "obsolete": false,
@@ -37220,7 +34357,6 @@
   },
   {
     "id": 2864,
-    "entrezid": 880453,
     "description": "enolase",
     "aliases": "-",
     "obsolete": false,
@@ -37233,7 +34369,6 @@
   },
   {
     "id": 2865,
-    "entrezid": 880454,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37246,7 +34381,6 @@
   },
   {
     "id": 2866,
-    "entrezid": 880455,
     "description": "phosphoribosylglycinamide formyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -37259,7 +34393,6 @@
   },
   {
     "id": 2867,
-    "entrezid": 880456,
     "description": "Na(+)-translocating NADH-quinone reductase subunit E",
     "aliases": "-",
     "obsolete": false,
@@ -37272,7 +34405,6 @@
   },
   {
     "id": 2868,
-    "entrezid": 880457,
     "description": "Na(+)-translocating NADH-quinone reductase subunit D",
     "aliases": "-",
     "obsolete": false,
@@ -37285,7 +34417,6 @@
   },
   {
     "id": 2869,
-    "entrezid": 880458,
     "description": "esterase",
     "aliases": "-",
     "obsolete": false,
@@ -37298,7 +34429,6 @@
   },
   {
     "id": 2870,
-    "entrezid": 880459,
     "description": "alcohol dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -37311,7 +34441,6 @@
   },
   {
     "id": 2871,
-    "entrezid": 880460,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37324,7 +34453,6 @@
   },
   {
     "id": 2872,
-    "entrezid": 880461,
     "description": "2-C-methyl-D-erythritol 4-phosphate cytidylyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -37337,7 +34465,6 @@
   },
   {
     "id": 2873,
-    "entrezid": 880462,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37350,7 +34477,6 @@
   },
   {
     "id": 2874,
-    "entrezid": 880463,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37363,7 +34489,6 @@
   },
   {
     "id": 2875,
-    "entrezid": 880464,
     "description": "1-deoxy-D-xylulose 5-phosphate reductoisomerase",
     "aliases": "-",
     "obsolete": false,
@@ -37376,7 +34501,6 @@
   },
   {
     "id": 2876,
-    "entrezid": 880465,
     "description": "phosphatidate cytidylyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -37389,7 +34513,6 @@
   },
   {
     "id": 2877,
-    "entrezid": 880466,
     "description": "glutathione-dependent formaldehyde neutralization regulator GfnR",
     "aliases": "-",
     "obsolete": false,
@@ -37402,7 +34525,6 @@
   },
   {
     "id": 2878,
-    "entrezid": 880467,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37415,7 +34537,6 @@
   },
   {
     "id": 2879,
-    "entrezid": 880468,
     "description": "thiosulfate sulfurtransferase",
     "aliases": "-",
     "obsolete": false,
@@ -37428,7 +34549,6 @@
   },
   {
     "id": 2880,
-    "entrezid": 880469,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -37441,7 +34561,6 @@
   },
   {
     "id": 2881,
-    "entrezid": 880470,
     "description": "protein BfiR",
     "aliases": "-",
     "obsolete": false,
@@ -37454,7 +34573,6 @@
   },
   {
     "id": 2882,
-    "entrezid": 880471,
     "description": "N-acetylglucosamine-6-phosphate deacetylase",
     "aliases": "-",
     "obsolete": false,
@@ -37467,7 +34585,6 @@
   },
   {
     "id": 2883,
-    "entrezid": 880472,
     "description": "aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -37480,7 +34597,6 @@
   },
   {
     "id": 2884,
-    "entrezid": 880473,
     "description": "DNA recombination protein RmuC",
     "aliases": "-",
     "obsolete": false,
@@ -37493,7 +34609,6 @@
   },
   {
     "id": 2885,
-    "entrezid": 880474,
     "description": "ribosomal large subunit pseudouridine synthase C",
     "aliases": "-",
     "obsolete": false,
@@ -37506,7 +34621,6 @@
   },
   {
     "id": 2886,
-    "entrezid": 880475,
     "description": "quinoprotein ethanol dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -37519,7 +34633,6 @@
   },
   {
     "id": 2887,
-    "entrezid": 880476,
     "description": "O-succinylhomoserine sulfhydrylase",
     "aliases": "-",
     "obsolete": false,
@@ -37532,7 +34645,6 @@
   },
   {
     "id": 2888,
-    "entrezid": 880477,
     "description": "amidophosphoribosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -37545,7 +34657,6 @@
   },
   {
     "id": 2889,
-    "entrezid": 880478,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37558,7 +34669,6 @@
   },
   {
     "id": 2890,
-    "entrezid": 880479,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -37571,7 +34681,6 @@
   },
   {
     "id": 2891,
-    "entrezid": 880480,
     "description": "coenzyme PQQ synthesis protein A",
     "aliases": "-",
     "obsolete": false,
@@ -37584,7 +34693,6 @@
   },
   {
     "id": 2892,
-    "entrezid": 880481,
     "description": "trans-2,3-dihydro-3-hydroxyanthranilate isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -37597,7 +34705,6 @@
   },
   {
     "id": 2893,
-    "entrezid": 880482,
     "description": "pyridoxamine 5'-phosphate oxidase",
     "aliases": "-",
     "obsolete": false,
@@ -37610,7 +34717,6 @@
   },
   {
     "id": 2894,
-    "entrezid": 880483,
     "description": "tRNA pseudouridine synthase D",
     "aliases": "-",
     "obsolete": false,
@@ -37623,7 +34729,6 @@
   },
   {
     "id": 2895,
-    "entrezid": 880484,
     "description": "2-C-methyl-D-erythritol 2,4-cyclodiphosphate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -37636,7 +34741,6 @@
   },
   {
     "id": 2896,
-    "entrezid": 880485,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -37649,7 +34753,6 @@
   },
   {
     "id": 2897,
-    "entrezid": 880486,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37662,7 +34765,6 @@
   },
   {
     "id": 2898,
-    "entrezid": 880487,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37675,7 +34777,6 @@
   },
   {
     "id": 2899,
-    "entrezid": 880488,
     "description": "4-amino-4-deoxychorismate lyase",
     "aliases": "-",
     "obsolete": false,
@@ -37688,7 +34789,6 @@
   },
   {
     "id": 2900,
-    "entrezid": 880489,
     "description": "acetyl-CoA carboxylase carboxyltransferase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -37701,7 +34801,6 @@
   },
   {
     "id": 2901,
-    "entrezid": 880490,
     "description": "DNA polymerase III subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -37714,7 +34813,6 @@
   },
   {
     "id": 2902,
-    "entrezid": 880491,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37727,7 +34825,6 @@
   },
   {
     "id": 2903,
-    "entrezid": 880492,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37740,7 +34837,6 @@
   },
   {
     "id": 2904,
-    "entrezid": 880493,
     "description": "acyl-[acyl-carrier-protein]--UDP-N-acetylglucosamine O-acyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -37753,7 +34849,6 @@
   },
   {
     "id": 2905,
-    "entrezid": 880494,
     "description": "3-hydroxyacyl-[acyl-carrier-protein] dehydratase FabZ",
     "aliases": "-",
     "obsolete": false,
@@ -37766,7 +34861,6 @@
   },
   {
     "id": 2906,
-    "entrezid": 880495,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -37779,7 +34873,6 @@
   },
   {
     "id": 2907,
-    "entrezid": 880496,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37792,7 +34885,6 @@
   },
   {
     "id": 2908,
-    "entrezid": 880497,
     "description": "amino acid permease",
     "aliases": "-",
     "obsolete": false,
@@ -37805,7 +34897,6 @@
   },
   {
     "id": 2909,
-    "entrezid": 880498,
     "description": "ribonuclease HII",
     "aliases": "-",
     "obsolete": false,
@@ -37818,7 +34909,6 @@
   },
   {
     "id": 2910,
-    "entrezid": 880499,
     "description": "N-acetyl-D-glucosamine phosphotransferase system transporter",
     "aliases": "-",
     "obsolete": false,
@@ -37831,7 +34921,6 @@
   },
   {
     "id": 2911,
-    "entrezid": 880500,
     "description": "N-acetyl-D-glucosamine phosphotransferase system transporter",
     "aliases": "-",
     "obsolete": false,
@@ -37844,7 +34933,6 @@
   },
   {
     "id": 2912,
-    "entrezid": 880501,
     "description": "branched-chain amino acid ABC transporter permease BraE",
     "aliases": "-",
     "obsolete": false,
@@ -37857,7 +34945,6 @@
   },
   {
     "id": 2913,
-    "entrezid": 880502,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37870,7 +34957,6 @@
   },
   {
     "id": 2914,
-    "entrezid": 880503,
     "description": "tetraacyldisaccharide 4'-kinase",
     "aliases": "-",
     "obsolete": false,
@@ -37883,7 +34969,6 @@
   },
   {
     "id": 2915,
-    "entrezid": 880504,
     "description": "phenazine biosynthesis protein PhzD",
     "aliases": "-",
     "obsolete": false,
@@ -37896,7 +34981,6 @@
   },
   {
     "id": 2916,
-    "entrezid": 880505,
     "description": "phenazine biosynthesis protein PhzE",
     "aliases": "-",
     "obsolete": false,
@@ -37909,7 +34993,6 @@
   },
   {
     "id": 2917,
-    "entrezid": 880506,
     "description": "outer membrane protein Opr86",
     "aliases": "-",
     "obsolete": false,
@@ -37922,7 +35005,6 @@
   },
   {
     "id": 2918,
-    "entrezid": 880507,
     "description": "zinc metalloprotease",
     "aliases": "-",
     "obsolete": false,
@@ -37935,7 +35017,6 @@
   },
   {
     "id": 2919,
-    "entrezid": 880508,
     "description": "carnitine dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -37948,7 +35029,6 @@
   },
   {
     "id": 2920,
-    "entrezid": 880509,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37961,7 +35041,6 @@
   },
   {
     "id": 2921,
-    "entrezid": 880510,
     "description": "30S ribosomal protein S16",
     "aliases": "-",
     "obsolete": false,
@@ -37974,7 +35053,6 @@
   },
   {
     "id": 2922,
-    "entrezid": 880511,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -37987,7 +35065,6 @@
   },
   {
     "id": 2923,
-    "entrezid": 880512,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38000,7 +35077,6 @@
   },
   {
     "id": 2924,
-    "entrezid": 880513,
     "description": "response regulator EraR",
     "aliases": "-",
     "obsolete": false,
@@ -38013,7 +35089,6 @@
   },
   {
     "id": 2925,
-    "entrezid": 880514,
     "description": "phenazine-specific methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -38026,7 +35101,6 @@
   },
   {
     "id": 2926,
-    "entrezid": 880515,
     "description": "phenazine biosynthesis protein",
     "aliases": "-",
     "obsolete": false,
@@ -38039,7 +35113,6 @@
   },
   {
     "id": 2927,
-    "entrezid": 880516,
     "description": "ribonuclease E",
     "aliases": "-",
     "obsolete": false,
@@ -38052,7 +35125,6 @@
   },
   {
     "id": 2928,
-    "entrezid": 880517,
     "description": "UDP-N-acetylenolpyruvoylglucosamine reductase",
     "aliases": "-",
     "obsolete": false,
@@ -38065,7 +35137,6 @@
   },
   {
     "id": 2929,
-    "entrezid": 880518,
     "description": "phenazine biosynthesis protein",
     "aliases": "-",
     "obsolete": false,
@@ -38078,7 +35149,6 @@
   },
   {
     "id": 2930,
-    "entrezid": 880519,
     "description": "phenazine biosynthesis protein PhzC",
     "aliases": "-",
     "obsolete": false,
@@ -38091,7 +35161,6 @@
   },
   {
     "id": 2931,
-    "entrezid": 880520,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38104,7 +35173,6 @@
   },
   {
     "id": 2932,
-    "entrezid": 880521,
     "description": "lipid-A-disaccharide synthase",
     "aliases": "-",
     "obsolete": false,
@@ -38117,7 +35185,6 @@
   },
   {
     "id": 2933,
-    "entrezid": 880522,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38130,7 +35197,6 @@
   },
   {
     "id": 2934,
-    "entrezid": 880523,
     "description": "3-ketoacyl-CoA thiolase",
     "aliases": "-",
     "obsolete": false,
@@ -38143,7 +35209,6 @@
   },
   {
     "id": 2935,
-    "entrezid": 880524,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38156,7 +35221,6 @@
   },
   {
     "id": 2936,
-    "entrezid": 880525,
     "description": "UDP-3-O-acylglucosamine N-acyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -38169,7 +35233,6 @@
   },
   {
     "id": 2937,
-    "entrezid": 880526,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38182,7 +35245,6 @@
   },
   {
     "id": 2938,
-    "entrezid": 880527,
     "description": "phosphate ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -38195,7 +35257,6 @@
   },
   {
     "id": 2939,
-    "entrezid": 880528,
     "description": "phosphate ABC transporter substrate-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -38208,7 +35269,6 @@
   },
   {
     "id": 2940,
-    "entrezid": 880529,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38221,7 +35281,6 @@
   },
   {
     "id": 2941,
-    "entrezid": 880530,
     "description": "membrane-bound lytic murein transglycosylase F",
     "aliases": "-",
     "obsolete": false,
@@ -38234,7 +35293,6 @@
   },
   {
     "id": 2942,
-    "entrezid": 880531,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38247,7 +35305,6 @@
   },
   {
     "id": 2943,
-    "entrezid": 880532,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -38260,7 +35317,6 @@
   },
   {
     "id": 2944,
-    "entrezid": 880533,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38273,7 +35329,6 @@
   },
   {
     "id": 2945,
-    "entrezid": 880534,
     "description": "glutaryl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -38286,7 +35341,6 @@
   },
   {
     "id": 2946,
-    "entrezid": 880535,
     "description": "inosine 5'-monophosphate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -38299,7 +35353,6 @@
   },
   {
     "id": 2947,
-    "entrezid": 880536,
     "description": "uridylate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -38312,7 +35365,6 @@
   },
   {
     "id": 2948,
-    "entrezid": 880537,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38325,7 +35377,6 @@
   },
   {
     "id": 2949,
-    "entrezid": 880538,
     "description": "cysteine desulfurase",
     "aliases": "-",
     "obsolete": false,
@@ -38338,7 +35389,6 @@
   },
   {
     "id": 2950,
-    "entrezid": 880539,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -38351,7 +35401,6 @@
   },
   {
     "id": 2951,
-    "entrezid": 880540,
     "description": "sugar ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -38364,7 +35413,6 @@
   },
   {
     "id": 2952,
-    "entrezid": 880541,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38377,7 +35425,6 @@
   },
   {
     "id": 2953,
-    "entrezid": 880542,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38390,7 +35437,6 @@
   },
   {
     "id": 2954,
-    "entrezid": 880543,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38403,7 +35449,6 @@
   },
   {
     "id": 2955,
-    "entrezid": 880544,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38416,7 +35461,6 @@
   },
   {
     "id": 2956,
-    "entrezid": 880545,
     "description": "ferrichrome receptor FiuA",
     "aliases": "-",
     "obsolete": false,
@@ -38429,7 +35473,6 @@
   },
   {
     "id": 2957,
-    "entrezid": 880546,
     "description": "CTP synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -38442,7 +35485,6 @@
   },
   {
     "id": 2958,
-    "entrezid": 880547,
     "description": "tRNA(Ile)-lysidine synthase",
     "aliases": "-",
     "obsolete": false,
@@ -38455,7 +35497,6 @@
   },
   {
     "id": 2959,
-    "entrezid": 880548,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38468,7 +35509,6 @@
   },
   {
     "id": 2960,
-    "entrezid": 880549,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38481,7 +35521,6 @@
   },
   {
     "id": 2961,
-    "entrezid": 880550,
     "description": "metallothionein",
     "aliases": "-",
     "obsolete": false,
@@ -38494,7 +35533,6 @@
   },
   {
     "id": 2962,
-    "entrezid": 880551,
     "description": "metallo-oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -38507,7 +35545,6 @@
   },
   {
     "id": 2963,
-    "entrezid": 880552,
     "description": "GMP synthase",
     "aliases": "-",
     "obsolete": false,
@@ -38520,7 +35557,6 @@
   },
   {
     "id": 2964,
-    "entrezid": 880553,
     "description": "ditrans,polycis-undecaprenyl-diphosphate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -38533,7 +35569,6 @@
   },
   {
     "id": 2965,
-    "entrezid": 880554,
     "description": "ribosome recycling factor",
     "aliases": "-",
     "obsolete": false,
@@ -38546,7 +35581,6 @@
   },
   {
     "id": 2966,
-    "entrezid": 880555,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -38559,7 +35593,6 @@
   },
   {
     "id": 2967,
-    "entrezid": 880556,
     "description": "multidrug efflux protein NorA",
     "aliases": "-",
     "obsolete": false,
@@ -38572,7 +35605,6 @@
   },
   {
     "id": 2968,
-    "entrezid": 880557,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38585,7 +35617,6 @@
   },
   {
     "id": 2969,
-    "entrezid": 880558,
     "description": "Na(+)-translocating NADH-quinone reductase subunit A",
     "aliases": "-",
     "obsolete": false,
@@ -38598,7 +35629,6 @@
   },
   {
     "id": 2970,
-    "entrezid": 880559,
     "description": "aromatic amino acid transporter AroP",
     "aliases": "-",
     "obsolete": false,
@@ -38611,7 +35641,6 @@
   },
   {
     "id": 2971,
-    "entrezid": 880560,
     "description": "aromatic amino acid transporter",
     "aliases": "-",
     "obsolete": false,
@@ -38624,7 +35653,6 @@
   },
   {
     "id": 2972,
-    "entrezid": 880561,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38637,7 +35665,6 @@
   },
   {
     "id": 2973,
-    "entrezid": 880562,
     "description": "7-cyano-7-deazaguanine reductase",
     "aliases": "-",
     "obsolete": false,
@@ -38650,7 +35677,6 @@
   },
   {
     "id": 2974,
-    "entrezid": 880563,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38663,7 +35689,6 @@
   },
   {
     "id": 2975,
-    "entrezid": 880564,
     "description": "methionine aminopeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -38676,7 +35701,6 @@
   },
   {
     "id": 2976,
-    "entrezid": 880565,
     "description": "bifunctional uridylyltransferase/uridylyl-removing protein",
     "aliases": "-",
     "obsolete": false,
@@ -38689,7 +35713,6 @@
   },
   {
     "id": 2977,
-    "entrezid": 880566,
     "description": "2,3-dihydroxybenzoate-AMP ligase",
     "aliases": "-",
     "obsolete": false,
@@ -38702,7 +35725,6 @@
   },
   {
     "id": 2978,
-    "entrezid": 880567,
     "description": "glutathione S-transferase",
     "aliases": "-",
     "obsolete": false,
@@ -38715,7 +35737,6 @@
   },
   {
     "id": 2979,
-    "entrezid": 880568,
     "description": "acetyl-CoA acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -38728,7 +35749,6 @@
   },
   {
     "id": 2980,
-    "entrezid": 880569,
     "description": "3-ketoacyl-ACP reductase",
     "aliases": "-",
     "obsolete": false,
@@ -38741,7 +35761,6 @@
   },
   {
     "id": 2981,
-    "entrezid": 880570,
     "description": "succinyldiaminopimelate transaminase",
     "aliases": "-",
     "obsolete": false,
@@ -38754,7 +35773,6 @@
   },
   {
     "id": 2982,
-    "entrezid": 880571,
     "description": "sodium/hydrogen antiporter",
     "aliases": "-",
     "obsolete": false,
@@ -38767,7 +35785,6 @@
   },
   {
     "id": 2983,
-    "entrezid": 880572,
     "description": "transporter protein AmiS",
     "aliases": "-",
     "obsolete": false,
@@ -38780,7 +35797,6 @@
   },
   {
     "id": 2984,
-    "entrezid": 880573,
     "description": "aliphatic amidase regulator",
     "aliases": "-",
     "obsolete": false,
@@ -38793,7 +35809,6 @@
   },
   {
     "id": 2985,
-    "entrezid": 880574,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38806,7 +35821,6 @@
   },
   {
     "id": 2986,
-    "entrezid": 880575,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38819,7 +35833,6 @@
   },
   {
     "id": 2987,
-    "entrezid": 880576,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38832,7 +35845,6 @@
   },
   {
     "id": 2988,
-    "entrezid": 880577,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38845,7 +35857,6 @@
   },
   {
     "id": 2989,
-    "entrezid": 880578,
     "description": "CDP-alcohol phosphatidyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -38858,7 +35869,6 @@
   },
   {
     "id": 2990,
-    "entrezid": 880579,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -38871,7 +35881,6 @@
   },
   {
     "id": 2991,
-    "entrezid": 880580,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38884,7 +35893,6 @@
   },
   {
     "id": 2992,
-    "entrezid": 880581,
     "description": "excinuclease ABC subunit C",
     "aliases": "-",
     "obsolete": false,
@@ -38897,7 +35905,6 @@
   },
   {
     "id": 2993,
-    "entrezid": 880582,
     "description": "response regulator GacA",
     "aliases": "-",
     "obsolete": false,
@@ -38910,7 +35917,6 @@
   },
   {
     "id": 2994,
-    "entrezid": 880583,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38923,7 +35929,6 @@
   },
   {
     "id": 2995,
-    "entrezid": 880584,
     "description": "2,3,4,5-tetrahydropyridine-2,6-dicarboxylate N-succinyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -38936,7 +35941,6 @@
   },
   {
     "id": 2996,
-    "entrezid": 880585,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38949,7 +35953,6 @@
   },
   {
     "id": 2997,
-    "entrezid": 880586,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38962,7 +35965,6 @@
   },
   {
     "id": 2998,
-    "entrezid": 880587,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38975,7 +35977,6 @@
   },
   {
     "id": 2999,
-    "entrezid": 880588,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -38988,7 +35989,6 @@
   },
   {
     "id": 3000,
-    "entrezid": 880589,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39001,7 +36001,6 @@
   },
   {
     "id": 3001,
-    "entrezid": 880590,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -39014,7 +36013,6 @@
   },
   {
     "id": 3002,
-    "entrezid": 880591,
     "description": "glycerol-3-phosphate acyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -39027,7 +36025,6 @@
   },
   {
     "id": 3003,
-    "entrezid": 880592,
     "description": "elongation factor Ts",
     "aliases": "-",
     "obsolete": false,
@@ -39040,7 +36037,6 @@
   },
   {
     "id": 3004,
-    "entrezid": 880593,
     "description": "30S ribosomal protein S2",
     "aliases": "-",
     "obsolete": false,
@@ -39053,7 +36049,6 @@
   },
   {
     "id": 3005,
-    "entrezid": 880594,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -39066,7 +36061,6 @@
   },
   {
     "id": 3006,
-    "entrezid": 880595,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39079,7 +36073,6 @@
   },
   {
     "id": 3007,
-    "entrezid": 880596,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39092,7 +36085,6 @@
   },
   {
     "id": 3008,
-    "entrezid": 880597,
     "description": "lipoprotein-releasing system ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -39105,7 +36097,6 @@
   },
   {
     "id": 3009,
-    "entrezid": 880598,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39118,7 +36109,6 @@
   },
   {
     "id": 3010,
-    "entrezid": 880599,
     "description": "acetylpolyamine aminohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -39131,7 +36121,6 @@
   },
   {
     "id": 3011,
-    "entrezid": 880600,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39144,7 +36133,6 @@
   },
   {
     "id": 3012,
-    "entrezid": 880601,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39157,7 +36145,6 @@
   },
   {
     "id": 3013,
-    "entrezid": 880602,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -39170,7 +36157,6 @@
   },
   {
     "id": 3014,
-    "entrezid": 880603,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39183,7 +36169,6 @@
   },
   {
     "id": 3015,
-    "entrezid": 880604,
     "description": "glutamine amidotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -39196,7 +36181,6 @@
   },
   {
     "id": 3016,
-    "entrezid": 880605,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39209,7 +36193,6 @@
   },
   {
     "id": 3017,
-    "entrezid": 880606,
     "description": "glycine dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -39222,7 +36205,6 @@
   },
   {
     "id": 3018,
-    "entrezid": 880607,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39235,7 +36217,6 @@
   },
   {
     "id": 3019,
-    "entrezid": 880608,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -39248,7 +36229,6 @@
   },
   {
     "id": 3020,
-    "entrezid": 880609,
     "description": "cysteine--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -39261,7 +36241,6 @@
   },
   {
     "id": 3021,
-    "entrezid": 880610,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -39274,7 +36253,6 @@
   },
   {
     "id": 3022,
-    "entrezid": 880611,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39287,7 +36265,6 @@
   },
   {
     "id": 3023,
-    "entrezid": 880612,
     "description": "type III export protein PscH",
     "aliases": "-",
     "obsolete": false,
@@ -39300,7 +36277,6 @@
   },
   {
     "id": 3024,
-    "entrezid": 880613,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39313,7 +36289,6 @@
   },
   {
     "id": 3025,
-    "entrezid": 880614,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39326,7 +36301,6 @@
   },
   {
     "id": 3026,
-    "entrezid": 880615,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39339,7 +36313,6 @@
   },
   {
     "id": 3027,
-    "entrezid": 880616,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39352,7 +36325,6 @@
   },
   {
     "id": 3028,
-    "entrezid": 880617,
     "description": "fimbrial subunit CupC1",
     "aliases": "-",
     "obsolete": false,
@@ -39365,7 +36337,6 @@
   },
   {
     "id": 3029,
-    "entrezid": 880618,
     "description": "aldehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -39378,7 +36349,6 @@
   },
   {
     "id": 3030,
-    "entrezid": 880619,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -39391,7 +36361,6 @@
   },
   {
     "id": 3031,
-    "entrezid": 880620,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39404,7 +36373,6 @@
   },
   {
     "id": 3032,
-    "entrezid": 880621,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39417,7 +36385,6 @@
   },
   {
     "id": 3033,
-    "entrezid": 880622,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39430,7 +36397,6 @@
   },
   {
     "id": 3034,
-    "entrezid": 880623,
     "description": "glutamine amidotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -39443,7 +36409,6 @@
   },
   {
     "id": 3035,
-    "entrezid": 880624,
     "description": "protease",
     "aliases": "-",
     "obsolete": false,
@@ -39456,7 +36421,6 @@
   },
   {
     "id": 3036,
-    "entrezid": 880625,
     "description": "3-oxoacyl-ACP synthase",
     "aliases": "-",
     "obsolete": false,
@@ -39469,7 +36433,6 @@
   },
   {
     "id": 3037,
-    "entrezid": 880626,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39482,7 +36445,6 @@
   },
   {
     "id": 3038,
-    "entrezid": 880627,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39495,7 +36457,6 @@
   },
   {
     "id": 3039,
-    "entrezid": 880628,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -39508,7 +36469,6 @@
   },
   {
     "id": 3040,
-    "entrezid": 880629,
     "description": "ribosomal protein S12 methylthiotransferase RimO",
     "aliases": "-",
     "obsolete": false,
@@ -39521,7 +36481,6 @@
   },
   {
     "id": 3041,
-    "entrezid": 880630,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39534,7 +36493,6 @@
   },
   {
     "id": 3042,
-    "entrezid": 880631,
     "description": "B12-dependent methionine synthase",
     "aliases": "-",
     "obsolete": false,
@@ -39547,7 +36505,6 @@
   },
   {
     "id": 3043,
-    "entrezid": 880632,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39560,7 +36517,6 @@
   },
   {
     "id": 3044,
-    "entrezid": 880633,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39573,7 +36529,6 @@
   },
   {
     "id": 3045,
-    "entrezid": 880634,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39586,7 +36541,6 @@
   },
   {
     "id": 3046,
-    "entrezid": 880635,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39599,7 +36553,6 @@
   },
   {
     "id": 3047,
-    "entrezid": 880636,
     "description": "bifunctional 5,10-methylene-tetrahydrofolate dehydrogenase/ 5,10-methylene-tetrahydrofolate cyclohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -39612,7 +36565,6 @@
   },
   {
     "id": 3048,
-    "entrezid": 880637,
     "description": "glycine cleavage system protein H",
     "aliases": "-",
     "obsolete": false,
@@ -39625,7 +36577,6 @@
   },
   {
     "id": 3049,
-    "entrezid": 880638,
     "description": "glycine cleavage system aminomethyltransferase T",
     "aliases": "-",
     "obsolete": false,
@@ -39638,7 +36589,6 @@
   },
   {
     "id": 3050,
-    "entrezid": 880639,
     "description": "bacteriophage protein",
     "aliases": "-",
     "obsolete": false,
@@ -39651,7 +36601,6 @@
   },
   {
     "id": 3051,
-    "entrezid": 880640,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39664,7 +36613,6 @@
   },
   {
     "id": 3052,
-    "entrezid": 880641,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39677,7 +36625,6 @@
   },
   {
     "id": 3053,
-    "entrezid": 880642,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39690,7 +36637,6 @@
   },
   {
     "id": 3054,
-    "entrezid": 880643,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39703,7 +36649,6 @@
   },
   {
     "id": 3055,
-    "entrezid": 880644,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39716,7 +36661,6 @@
   },
   {
     "id": 3056,
-    "entrezid": 880645,
     "description": "glutathione S-transferase",
     "aliases": "-",
     "obsolete": false,
@@ -39729,7 +36673,6 @@
   },
   {
     "id": 3057,
-    "entrezid": 880646,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -39742,7 +36685,6 @@
   },
   {
     "id": 3058,
-    "entrezid": 880647,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39755,7 +36697,6 @@
   },
   {
     "id": 3059,
-    "entrezid": 880648,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39768,7 +36709,6 @@
   },
   {
     "id": 3060,
-    "entrezid": 880649,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39781,7 +36721,6 @@
   },
   {
     "id": 3061,
-    "entrezid": 880650,
     "description": "quorum-sensing control repressor",
     "aliases": "-",
     "obsolete": false,
@@ -39794,7 +36733,6 @@
   },
   {
     "id": 3062,
-    "entrezid": 880651,
     "description": "HxcW pseudopilin",
     "aliases": "-",
     "obsolete": false,
@@ -39807,7 +36745,6 @@
   },
   {
     "id": 3063,
-    "entrezid": 880652,
     "description": "arginine/ornithine ABC transporter permease AotM",
     "aliases": "-",
     "obsolete": false,
@@ -39820,7 +36757,6 @@
   },
   {
     "id": 3064,
-    "entrezid": 880653,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39833,7 +36769,6 @@
   },
   {
     "id": 3065,
-    "entrezid": 880654,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39846,7 +36781,6 @@
   },
   {
     "id": 3066,
-    "entrezid": 880655,
     "description": "putrescine ABC transporter substrate-binding protein SpuD",
     "aliases": "-",
     "obsolete": false,
@@ -39859,7 +36793,6 @@
   },
   {
     "id": 3067,
-    "entrezid": 880656,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39872,7 +36805,6 @@
   },
   {
     "id": 3068,
-    "entrezid": 880657,
     "description": "choline sulfatase",
     "aliases": "-",
     "obsolete": false,
@@ -39885,7 +36817,6 @@
   },
   {
     "id": 3069,
-    "entrezid": 880658,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -39898,7 +36829,6 @@
   },
   {
     "id": 3070,
-    "entrezid": 880659,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39911,7 +36841,6 @@
   },
   {
     "id": 3071,
-    "entrezid": 880660,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39924,7 +36853,6 @@
   },
   {
     "id": 3072,
-    "entrezid": 880661,
     "description": "sn-glycerol-3-phosphate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -39937,7 +36865,6 @@
   },
   {
     "id": 3073,
-    "entrezid": 880662,
     "description": "CDP-6-deoxy-delta-3,4-glucoseen reductase",
     "aliases": "-",
     "obsolete": false,
@@ -39950,7 +36877,6 @@
   },
   {
     "id": 3074,
-    "entrezid": 880663,
     "description": "ABC-F family ATPase",
     "aliases": "-",
     "obsolete": false,
@@ -39963,7 +36889,6 @@
   },
   {
     "id": 3075,
-    "entrezid": 880664,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -39976,7 +36901,6 @@
   },
   {
     "id": 3076,
-    "entrezid": 880665,
     "description": "anthranilate phosphoribosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -39989,7 +36913,6 @@
   },
   {
     "id": 3077,
-    "entrezid": 880666,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40002,7 +36925,6 @@
   },
   {
     "id": 3078,
-    "entrezid": 880667,
     "description": "peptidyl-prolyl cis-trans isomerase B",
     "aliases": "-",
     "obsolete": false,
@@ -40015,7 +36937,6 @@
   },
   {
     "id": 3079,
-    "entrezid": 880668,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40028,7 +36949,6 @@
   },
   {
     "id": 3080,
-    "entrezid": 880669,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40041,7 +36961,6 @@
   },
   {
     "id": 3081,
-    "entrezid": 880670,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -40054,7 +36973,6 @@
   },
   {
     "id": 3082,
-    "entrezid": 880671,
     "description": "RNA methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -40067,7 +36985,6 @@
   },
   {
     "id": 3083,
-    "entrezid": 880672,
     "description": "sulfate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -40080,7 +36997,6 @@
   },
   {
     "id": 3084,
-    "entrezid": 880673,
     "description": "potassium transport system protein kup",
     "aliases": "-",
     "obsolete": false,
@@ -40093,7 +37009,6 @@
   },
   {
     "id": 3085,
-    "entrezid": 880674,
     "description": "methylcitrate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -40106,7 +37021,6 @@
   },
   {
     "id": 3086,
-    "entrezid": 880675,
     "description": "Fe/S biogenesis protein NfuA",
     "aliases": "-",
     "obsolete": false,
@@ -40119,7 +37033,6 @@
   },
   {
     "id": 3087,
-    "entrezid": 880676,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40132,7 +37045,6 @@
   },
   {
     "id": 3088,
-    "entrezid": 880677,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40145,7 +37057,6 @@
   },
   {
     "id": 3089,
-    "entrezid": 880678,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40158,7 +37069,6 @@
   },
   {
     "id": 3090,
-    "entrezid": 880679,
     "description": "branched-chain alpha-keto acid dehydrogenase complex lipoamide acyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -40171,7 +37081,6 @@
   },
   {
     "id": 3091,
-    "entrezid": 880680,
     "description": "ribose transporter RbsA",
     "aliases": "-",
     "obsolete": false,
@@ -40184,7 +37093,6 @@
   },
   {
     "id": 3092,
-    "entrezid": 880681,
     "description": "polyamine binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -40197,7 +37105,6 @@
   },
   {
     "id": 3093,
-    "entrezid": 880682,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40210,7 +37117,6 @@
   },
   {
     "id": 3094,
-    "entrezid": 880683,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40223,7 +37129,6 @@
   },
   {
     "id": 3095,
-    "entrezid": 880684,
     "description": "transcriptional regulator ToxR",
     "aliases": "-",
     "obsolete": false,
@@ -40236,7 +37141,6 @@
   },
   {
     "id": 3096,
-    "entrezid": 880685,
     "description": "oxygen-dependent quinone oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -40249,7 +37153,6 @@
   },
   {
     "id": 3097,
-    "entrezid": 880686,
     "description": "error-prone DNA polymerase",
     "aliases": "-",
     "obsolete": false,
@@ -40262,7 +37165,6 @@
   },
   {
     "id": 3098,
-    "entrezid": 880687,
     "description": "polyamine transporter PotH",
     "aliases": "-",
     "obsolete": false,
@@ -40275,7 +37177,6 @@
   },
   {
     "id": 3099,
-    "entrezid": 880688,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40288,7 +37189,6 @@
   },
   {
     "id": 3100,
-    "entrezid": 880689,
     "description": "anthranilate synthase component II",
     "aliases": "-",
     "obsolete": false,
@@ -40301,7 +37201,6 @@
   },
   {
     "id": 3101,
-    "entrezid": 880690,
     "description": "bacteriophage protein",
     "aliases": "-",
     "obsolete": false,
@@ -40314,7 +37213,6 @@
   },
   {
     "id": 3102,
-    "entrezid": 880691,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40327,7 +37225,6 @@
   },
   {
     "id": 3103,
-    "entrezid": 880692,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40340,7 +37237,6 @@
   },
   {
     "id": 3104,
-    "entrezid": 880693,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40353,7 +37249,6 @@
   },
   {
     "id": 3105,
-    "entrezid": 880694,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40366,7 +37261,6 @@
   },
   {
     "id": 3106,
-    "entrezid": 880695,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -40379,7 +37273,6 @@
   },
   {
     "id": 3107,
-    "entrezid": 880696,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40392,7 +37285,6 @@
   },
   {
     "id": 3108,
-    "entrezid": 880697,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40405,7 +37297,6 @@
   },
   {
     "id": 3109,
-    "entrezid": 880698,
     "description": "neutral ceramidase",
     "aliases": "-",
     "obsolete": false,
@@ -40418,7 +37309,6 @@
   },
   {
     "id": 3110,
-    "entrezid": 880699,
     "description": "N-carbamoylputrescine amidohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -40431,7 +37321,6 @@
   },
   {
     "id": 3111,
-    "entrezid": 880700,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -40444,7 +37333,6 @@
   },
   {
     "id": 3112,
-    "entrezid": 880701,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40457,7 +37345,6 @@
   },
   {
     "id": 3113,
-    "entrezid": 880702,
     "description": "morphogene protein BolA",
     "aliases": "-",
     "obsolete": false,
@@ -40470,7 +37357,6 @@
   },
   {
     "id": 3114,
-    "entrezid": 880703,
     "description": "N-formimino-L-glutamate deiminase",
     "aliases": "-",
     "obsolete": false,
@@ -40483,7 +37369,6 @@
   },
   {
     "id": 3115,
-    "entrezid": 880704,
     "description": "outer membrane lipoprotein Blc",
     "aliases": "-",
     "obsolete": false,
@@ -40496,7 +37381,6 @@
   },
   {
     "id": 3116,
-    "entrezid": 880705,
     "description": "sulfate transporter CysW",
     "aliases": "-",
     "obsolete": false,
@@ -40509,7 +37393,6 @@
   },
   {
     "id": 3117,
-    "entrezid": 880706,
     "description": "cytochrome C protein NapC",
     "aliases": "-",
     "obsolete": false,
@@ -40522,7 +37405,6 @@
   },
   {
     "id": 3118,
-    "entrezid": 880707,
     "description": "HxcU pseudopilin",
     "aliases": "-",
     "obsolete": false,
@@ -40535,7 +37417,6 @@
   },
   {
     "id": 3119,
-    "entrezid": 880708,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40548,7 +37429,6 @@
   },
   {
     "id": 3120,
-    "entrezid": 880709,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40561,7 +37441,6 @@
   },
   {
     "id": 3121,
-    "entrezid": 880710,
     "description": "16S rRNA pseudouridine(516) synthase",
     "aliases": "-",
     "obsolete": false,
@@ -40574,7 +37453,6 @@
   },
   {
     "id": 3122,
-    "entrezid": 880711,
     "description": "threonylcarbamoyl-AMP synthase",
     "aliases": "-",
     "obsolete": false,
@@ -40587,7 +37465,6 @@
   },
   {
     "id": 3123,
-    "entrezid": 880712,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40600,7 +37477,6 @@
   },
   {
     "id": 3124,
-    "entrezid": 880713,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -40613,7 +37489,6 @@
   },
   {
     "id": 3125,
-    "entrezid": 880714,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40626,7 +37501,6 @@
   },
   {
     "id": 3126,
-    "entrezid": 880715,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40639,7 +37513,6 @@
   },
   {
     "id": 3127,
-    "entrezid": 880716,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40652,7 +37525,6 @@
   },
   {
     "id": 3128,
-    "entrezid": 880717,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40665,7 +37537,6 @@
   },
   {
     "id": 3129,
-    "entrezid": 880718,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40678,7 +37549,6 @@
   },
   {
     "id": 3130,
-    "entrezid": 880719,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -40691,7 +37561,6 @@
   },
   {
     "id": 3131,
-    "entrezid": 880720,
     "description": "ferric-mycobactin receptor FemA",
     "aliases": "-",
     "obsolete": false,
@@ -40704,7 +37573,6 @@
   },
   {
     "id": 3132,
-    "entrezid": 880721,
     "description": "thioesterase PqsE",
     "aliases": "-",
     "obsolete": false,
@@ -40717,7 +37585,6 @@
   },
   {
     "id": 3133,
-    "entrezid": 880722,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40730,7 +37597,6 @@
   },
   {
     "id": 3134,
-    "entrezid": 880723,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40743,7 +37609,6 @@
   },
   {
     "id": 3135,
-    "entrezid": 880724,
     "description": "phosphoenolpyruvate synthase regulatory protein",
     "aliases": "-",
     "obsolete": false,
@@ -40756,7 +37621,6 @@
   },
   {
     "id": 3136,
-    "entrezid": 880725,
     "description": "L-lactate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -40769,7 +37633,6 @@
   },
   {
     "id": 3137,
-    "entrezid": 880726,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40782,7 +37645,6 @@
   },
   {
     "id": 3138,
-    "entrezid": 880727,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40795,7 +37657,6 @@
   },
   {
     "id": 3139,
-    "entrezid": 880728,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -40808,7 +37669,6 @@
   },
   {
     "id": 3140,
-    "entrezid": 880729,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40821,7 +37681,6 @@
   },
   {
     "id": 3141,
-    "entrezid": 880730,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40834,7 +37693,6 @@
   },
   {
     "id": 3142,
-    "entrezid": 880731,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40847,7 +37705,6 @@
   },
   {
     "id": 3143,
-    "entrezid": 880732,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -40860,7 +37717,6 @@
   },
   {
     "id": 3144,
-    "entrezid": 880733,
     "description": "4-hydroxythreonine-4-phosphate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -40873,7 +37729,6 @@
   },
   {
     "id": 3145,
-    "entrezid": 880734,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40886,7 +37741,6 @@
   },
   {
     "id": 3146,
-    "entrezid": 880735,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40899,7 +37753,6 @@
   },
   {
     "id": 3147,
-    "entrezid": 880736,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -40912,7 +37765,6 @@
   },
   {
     "id": 3148,
-    "entrezid": 880737,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40925,7 +37777,6 @@
   },
   {
     "id": 3149,
-    "entrezid": 880738,
     "description": "type III secretion system protein",
     "aliases": "-",
     "obsolete": false,
@@ -40938,7 +37789,6 @@
   },
   {
     "id": 3150,
-    "entrezid": 880739,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40951,7 +37801,6 @@
   },
   {
     "id": 3151,
-    "entrezid": 880740,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40964,7 +37813,6 @@
   },
   {
     "id": 3152,
-    "entrezid": 880741,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -40977,7 +37825,6 @@
   },
   {
     "id": 3153,
-    "entrezid": 880742,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -40990,7 +37837,6 @@
   },
   {
     "id": 3154,
-    "entrezid": 880743,
     "description": "3-oxoacyl-ACP synthase",
     "aliases": "-",
     "obsolete": false,
@@ -41003,7 +37849,6 @@
   },
   {
     "id": 3155,
-    "entrezid": 880744,
     "description": "cAMP-regulatory protein",
     "aliases": "-",
     "obsolete": false,
@@ -41016,7 +37861,6 @@
   },
   {
     "id": 3156,
-    "entrezid": 880745,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41029,7 +37873,6 @@
   },
   {
     "id": 3157,
-    "entrezid": 880746,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41042,7 +37885,6 @@
   },
   {
     "id": 3158,
-    "entrezid": 880747,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41055,7 +37897,6 @@
   },
   {
     "id": 3159,
-    "entrezid": 880748,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41068,7 +37909,6 @@
   },
   {
     "id": 3160,
-    "entrezid": 880749,
     "description": "CdhR family transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -41081,7 +37921,6 @@
   },
   {
     "id": 3161,
-    "entrezid": 880750,
     "description": "acetylornithine deacetylase",
     "aliases": "-",
     "obsolete": false,
@@ -41094,7 +37933,6 @@
   },
   {
     "id": 3162,
-    "entrezid": 880751,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41107,7 +37945,6 @@
   },
   {
     "id": 3163,
-    "entrezid": 880752,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41120,7 +37957,6 @@
   },
   {
     "id": 3164,
-    "entrezid": 880753,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41133,7 +37969,6 @@
   },
   {
     "id": 3165,
-    "entrezid": 880754,
     "description": "amidase",
     "aliases": "-",
     "obsolete": false,
@@ -41146,7 +37981,6 @@
   },
   {
     "id": 3166,
-    "entrezid": 880755,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41159,7 +37993,6 @@
   },
   {
     "id": 3167,
-    "entrezid": 880756,
     "description": "organic solvent tolerance protein OstA",
     "aliases": "-",
     "obsolete": false,
@@ -41172,7 +38005,6 @@
   },
   {
     "id": 3168,
-    "entrezid": 880757,
     "description": "bacteriophage protein",
     "aliases": "-",
     "obsolete": false,
@@ -41185,7 +38017,6 @@
   },
   {
     "id": 3169,
-    "entrezid": 880758,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41198,7 +38029,6 @@
   },
   {
     "id": 3170,
-    "entrezid": 880759,
     "description": "2-nonaprenyl-3-methyl-6-methoxy-1,4-benzoquinol hydroxylase",
     "aliases": "-",
     "obsolete": false,
@@ -41211,7 +38041,6 @@
   },
   {
     "id": 3171,
-    "entrezid": 880760,
     "description": "anthranilate--CoA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -41224,7 +38053,6 @@
   },
   {
     "id": 3172,
-    "entrezid": 880761,
     "description": "deoxyguanosinetriphosphate triphosphohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -41237,7 +38065,6 @@
   },
   {
     "id": 3173,
-    "entrezid": 880762,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41250,7 +38077,6 @@
   },
   {
     "id": 3174,
-    "entrezid": 880763,
     "description": "transglycosylase",
     "aliases": "-",
     "obsolete": false,
@@ -41263,7 +38089,6 @@
   },
   {
     "id": 3175,
-    "entrezid": 880764,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41276,7 +38101,6 @@
   },
   {
     "id": 3176,
-    "entrezid": 880765,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41289,7 +38113,6 @@
   },
   {
     "id": 3177,
-    "entrezid": 880766,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -41302,7 +38125,6 @@
   },
   {
     "id": 3178,
-    "entrezid": 880767,
     "description": "carbonic anhydrase",
     "aliases": "-",
     "obsolete": false,
@@ -41315,7 +38137,6 @@
   },
   {
     "id": 3179,
-    "entrezid": 880768,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -41328,7 +38149,6 @@
   },
   {
     "id": 3180,
-    "entrezid": 880769,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -41341,7 +38161,6 @@
   },
   {
     "id": 3181,
-    "entrezid": 880770,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41354,7 +38173,6 @@
   },
   {
     "id": 3182,
-    "entrezid": 880771,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -41367,7 +38185,6 @@
   },
   {
     "id": 3183,
-    "entrezid": 880772,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41380,7 +38197,6 @@
   },
   {
     "id": 3184,
-    "entrezid": 880773,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41393,7 +38209,6 @@
   },
   {
     "id": 3185,
-    "entrezid": 880774,
     "description": "transporter ExbB",
     "aliases": "-",
     "obsolete": false,
@@ -41406,7 +38221,6 @@
   },
   {
     "id": 3186,
-    "entrezid": 880775,
     "description": "dihydroneopterin aldolase",
     "aliases": "-",
     "obsolete": false,
@@ -41419,7 +38233,6 @@
   },
   {
     "id": 3187,
-    "entrezid": 880776,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -41432,7 +38245,6 @@
   },
   {
     "id": 3188,
-    "entrezid": 880777,
     "description": "phage coat protein A",
     "aliases": "-",
     "obsolete": false,
@@ -41445,7 +38257,6 @@
   },
   {
     "id": 3189,
-    "entrezid": 880778,
     "description": "phage coat protein B",
     "aliases": "-",
     "obsolete": false,
@@ -41458,7 +38269,6 @@
   },
   {
     "id": 3190,
-    "entrezid": 880779,
     "description": "ribonuclease activity regulator protein RraA",
     "aliases": "-",
     "obsolete": false,
@@ -41471,7 +38281,6 @@
   },
   {
     "id": 3191,
-    "entrezid": 880780,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41484,7 +38293,6 @@
   },
   {
     "id": 3192,
-    "entrezid": 880781,
     "description": "guanidinopropionase",
     "aliases": "-",
     "obsolete": false,
@@ -41497,7 +38305,6 @@
   },
   {
     "id": 3193,
-    "entrezid": 880782,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41510,7 +38317,6 @@
   },
   {
     "id": 3194,
-    "entrezid": 880783,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41523,7 +38329,6 @@
   },
   {
     "id": 3195,
-    "entrezid": 880784,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41536,7 +38341,6 @@
   },
   {
     "id": 3196,
-    "entrezid": 880785,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41549,7 +38353,6 @@
   },
   {
     "id": 3197,
-    "entrezid": 880786,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41562,7 +38365,6 @@
   },
   {
     "id": 3198,
-    "entrezid": 880787,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -41575,7 +38377,6 @@
   },
   {
     "id": 3199,
-    "entrezid": 880788,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41588,7 +38389,6 @@
   },
   {
     "id": 3200,
-    "entrezid": 880789,
     "description": "transporter ExbD",
     "aliases": "-",
     "obsolete": false,
@@ -41601,7 +38401,6 @@
   },
   {
     "id": 3201,
-    "entrezid": 880790,
     "description": "alkaline phosphatase L",
     "aliases": "-",
     "obsolete": false,
@@ -41614,7 +38413,6 @@
   },
   {
     "id": 3202,
-    "entrezid": 880791,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41627,7 +38425,6 @@
   },
   {
     "id": 3203,
-    "entrezid": 880792,
     "description": "fructose-1,6-bisphosphate aldolase",
     "aliases": "-",
     "obsolete": false,
@@ -41640,7 +38437,6 @@
   },
   {
     "id": 3204,
-    "entrezid": 880793,
     "description": "glucose-sensitive porin",
     "aliases": "-",
     "obsolete": false,
@@ -41653,7 +38449,6 @@
   },
   {
     "id": 3205,
-    "entrezid": 880794,
     "description": "methylated-DNA--protein-cysteine methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -41666,7 +38461,6 @@
   },
   {
     "id": 3206,
-    "entrezid": 880795,
     "description": "ribose ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -41679,7 +38473,6 @@
   },
   {
     "id": 3207,
-    "entrezid": 880796,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -41692,7 +38485,6 @@
   },
   {
     "id": 3208,
-    "entrezid": 880797,
     "description": "ABC transporter ATP-binding protein/permease",
     "aliases": "-",
     "obsolete": false,
@@ -41705,7 +38497,6 @@
   },
   {
     "id": 3209,
-    "entrezid": 880798,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41718,7 +38509,6 @@
   },
   {
     "id": 3210,
-    "entrezid": 880799,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41731,7 +38521,6 @@
   },
   {
     "id": 3211,
-    "entrezid": 880800,
     "description": "cis/trans isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -41744,7 +38533,6 @@
   },
   {
     "id": 3212,
-    "entrezid": 880801,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41757,7 +38545,6 @@
   },
   {
     "id": 3213,
-    "entrezid": 880802,
     "description": "sulfate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -41770,7 +38557,6 @@
   },
   {
     "id": 3214,
-    "entrezid": 880803,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41783,7 +38569,6 @@
   },
   {
     "id": 3215,
-    "entrezid": 880804,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -41796,7 +38581,6 @@
   },
   {
     "id": 3216,
-    "entrezid": 880805,
     "description": "type II secretion system protein",
     "aliases": "-",
     "obsolete": false,
@@ -41809,7 +38593,6 @@
   },
   {
     "id": 3217,
-    "entrezid": 880806,
     "description": "alginate regulatory protein AlgP",
     "aliases": "-",
     "obsolete": false,
@@ -41822,7 +38605,6 @@
   },
   {
     "id": 3218,
-    "entrezid": 880807,
     "description": "FkbP-type peptidyl-prolyl cis-trans isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -41835,7 +38617,6 @@
   },
   {
     "id": 3219,
-    "entrezid": 880808,
     "description": "type II secretion system protein HxcR",
     "aliases": "-",
     "obsolete": false,
@@ -41848,7 +38629,6 @@
   },
   {
     "id": 3220,
-    "entrezid": 880809,
     "description": "type III export protein PscK",
     "aliases": "-",
     "obsolete": false,
@@ -41861,7 +38641,6 @@
   },
   {
     "id": 3221,
-    "entrezid": 880810,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41874,7 +38653,6 @@
   },
   {
     "id": 3222,
-    "entrezid": 880811,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -41887,7 +38665,6 @@
   },
   {
     "id": 3223,
-    "entrezid": 880812,
     "description": "HxcV pseudopilin",
     "aliases": "-",
     "obsolete": false,
@@ -41900,7 +38677,6 @@
   },
   {
     "id": 3224,
-    "entrezid": 880813,
     "description": "type II secretion system protein",
     "aliases": "-",
     "obsolete": false,
@@ -41913,7 +38689,6 @@
   },
   {
     "id": 3225,
-    "entrezid": 880814,
     "description": "glycerol-3-phosphate acyltransferase PlsY",
     "aliases": "-",
     "obsolete": false,
@@ -41926,7 +38701,6 @@
   },
   {
     "id": 3226,
-    "entrezid": 880815,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -41939,7 +38713,6 @@
   },
   {
     "id": 3227,
-    "entrezid": 880816,
     "description": "type II secretion system protein",
     "aliases": "-",
     "obsolete": false,
@@ -41952,7 +38725,6 @@
   },
   {
     "id": 3228,
-    "entrezid": 880817,
     "description": "tyrosine--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -41965,7 +38737,6 @@
   },
   {
     "id": 3229,
-    "entrezid": 880818,
     "description": "HxcX atypical pseudopilin",
     "aliases": "-",
     "obsolete": false,
@@ -41978,7 +38749,6 @@
   },
   {
     "id": 3230,
-    "entrezid": 880819,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -41991,7 +38761,6 @@
   },
   {
     "id": 3231,
-    "entrezid": 880820,
     "description": "heme oxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -42004,7 +38773,6 @@
   },
   {
     "id": 3232,
-    "entrezid": 880821,
     "description": "type II secretion system protein",
     "aliases": "-",
     "obsolete": false,
@@ -42017,7 +38785,6 @@
   },
   {
     "id": 3233,
-    "entrezid": 880822,
     "description": "non-heme catalase KatN",
     "aliases": "-",
     "obsolete": false,
@@ -42030,7 +38797,6 @@
   },
   {
     "id": 3234,
-    "entrezid": 880823,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42043,7 +38809,6 @@
   },
   {
     "id": 3235,
-    "entrezid": 880824,
     "description": "sarcosine oxidase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -42056,7 +38821,6 @@
   },
   {
     "id": 3236,
-    "entrezid": 880825,
     "description": "sarcosine oxidase subunit gamma",
     "aliases": "-",
     "obsolete": false,
@@ -42069,7 +38833,6 @@
   },
   {
     "id": 3237,
-    "entrezid": 880826,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42082,7 +38845,6 @@
   },
   {
     "id": 3238,
-    "entrezid": 880827,
     "description": "pterin-4-alpha-carbinolamine dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -42095,7 +38857,6 @@
   },
   {
     "id": 3239,
-    "entrezid": 880828,
     "description": "biofilm formation protein PslL",
     "aliases": "-",
     "obsolete": false,
@@ -42108,7 +38869,6 @@
   },
   {
     "id": 3240,
-    "entrezid": 880829,
     "description": "ribokinase",
     "aliases": "-",
     "obsolete": false,
@@ -42121,7 +38881,6 @@
   },
   {
     "id": 3241,
-    "entrezid": 880830,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42134,7 +38893,6 @@
   },
   {
     "id": 3242,
-    "entrezid": 880831,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42147,7 +38905,6 @@
   },
   {
     "id": 3243,
-    "entrezid": 880832,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42160,7 +38917,6 @@
   },
   {
     "id": 3244,
-    "entrezid": 880833,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -42173,7 +38929,6 @@
   },
   {
     "id": 3245,
-    "entrezid": 880834,
     "description": "bis(5'-nucleosyl)-tetraphosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -42186,7 +38941,6 @@
   },
   {
     "id": 3246,
-    "entrezid": 880835,
     "description": "glutamine synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -42199,7 +38953,6 @@
   },
   {
     "id": 3247,
-    "entrezid": 880836,
     "description": "proline utilization regulator",
     "aliases": "-",
     "obsolete": false,
@@ -42212,7 +38965,6 @@
   },
   {
     "id": 3248,
-    "entrezid": 880837,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -42225,7 +38977,6 @@
   },
   {
     "id": 3249,
-    "entrezid": 880838,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42238,7 +38989,6 @@
   },
   {
     "id": 3250,
-    "entrezid": 880839,
     "description": "aromatic amino acid aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -42251,7 +39001,6 @@
   },
   {
     "id": 3251,
-    "entrezid": 880840,
     "description": "glutamine synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -42264,7 +39013,6 @@
   },
   {
     "id": 3252,
-    "entrezid": 880841,
     "description": "iron ABC transporter substrate-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -42277,7 +39025,6 @@
   },
   {
     "id": 3253,
-    "entrezid": 880842,
     "description": "iron ABC transporter substrate-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -42290,7 +39037,6 @@
   },
   {
     "id": 3254,
-    "entrezid": 880843,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -42303,7 +39049,6 @@
   },
   {
     "id": 3255,
-    "entrezid": 880844,
     "description": "gamma-aminobutyrate permease",
     "aliases": "-",
     "obsolete": false,
@@ -42316,7 +39061,6 @@
   },
   {
     "id": 3256,
-    "entrezid": 880845,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -42329,7 +39073,6 @@
   },
   {
     "id": 3257,
-    "entrezid": 880846,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42342,7 +39085,6 @@
   },
   {
     "id": 3258,
-    "entrezid": 880847,
     "description": "ribosomal RNA small subunit methyltransferase A",
     "aliases": "-",
     "obsolete": false,
@@ -42355,7 +39097,6 @@
   },
   {
     "id": 3259,
-    "entrezid": 880848,
     "description": "C4-dicarboxylate transport protein",
     "aliases": "-",
     "obsolete": false,
@@ -42368,7 +39109,6 @@
   },
   {
     "id": 3260,
-    "entrezid": 880849,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42381,7 +39121,6 @@
   },
   {
     "id": 3261,
-    "entrezid": 880850,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -42394,7 +39133,6 @@
   },
   {
     "id": 3262,
-    "entrezid": 880851,
     "description": "protein AmpDh2",
     "aliases": "-",
     "obsolete": false,
@@ -42407,7 +39145,6 @@
   },
   {
     "id": 3263,
-    "entrezid": 880852,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42420,7 +39157,6 @@
   },
   {
     "id": 3264,
-    "entrezid": 880853,
     "description": "3-octaprenyl-4-hydroxybenzoate carboxy-lyase",
     "aliases": "-",
     "obsolete": false,
@@ -42433,7 +39169,6 @@
   },
   {
     "id": 3265,
-    "entrezid": 880854,
     "description": "O-antigen acetylase",
     "aliases": "-",
     "obsolete": false,
@@ -42446,7 +39181,6 @@
   },
   {
     "id": 3266,
-    "entrezid": 880855,
     "description": "transcription termination factor Rho",
     "aliases": "-",
     "obsolete": false,
@@ -42459,7 +39193,6 @@
   },
   {
     "id": 3267,
-    "entrezid": 880856,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42472,7 +39205,6 @@
   },
   {
     "id": 3268,
-    "entrezid": 880857,
     "description": "transcriptional regulator AguR",
     "aliases": "-",
     "obsolete": false,
@@ -42485,7 +39217,6 @@
   },
   {
     "id": 3269,
-    "entrezid": 880858,
     "description": "thiamine-phosphate pyrophosphorylase",
     "aliases": "-",
     "obsolete": false,
@@ -42498,7 +39229,6 @@
   },
   {
     "id": 3270,
-    "entrezid": 880859,
     "description": "glutamate-1-semialdehyde aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -42511,7 +39241,6 @@
   },
   {
     "id": 3271,
-    "entrezid": 880860,
     "description": "flavin-containing monooxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -42524,7 +39253,6 @@
   },
   {
     "id": 3272,
-    "entrezid": 880861,
     "description": "protein phosphatase CheZ",
     "aliases": "-",
     "obsolete": false,
@@ -42537,7 +39265,6 @@
   },
   {
     "id": 3273,
-    "entrezid": 880862,
     "description": "fimbrial subunit CupA1",
     "aliases": "-",
     "obsolete": false,
@@ -42550,7 +39277,6 @@
   },
   {
     "id": 3274,
-    "entrezid": 880863,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -42563,7 +39289,6 @@
   },
   {
     "id": 3275,
-    "entrezid": 880864,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -42576,7 +39301,6 @@
   },
   {
     "id": 3276,
-    "entrezid": 880865,
     "description": "chaperone CupA5",
     "aliases": "-",
     "obsolete": false,
@@ -42589,7 +39313,6 @@
   },
   {
     "id": 3277,
-    "entrezid": 880866,
     "description": "secreted protein Hcp",
     "aliases": "-",
     "obsolete": false,
@@ -42602,7 +39325,6 @@
   },
   {
     "id": 3278,
-    "entrezid": 880867,
     "description": "translocator protein PopB",
     "aliases": "-",
     "obsolete": false,
@@ -42615,7 +39337,6 @@
   },
   {
     "id": 3279,
-    "entrezid": 880868,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -42628,7 +39349,6 @@
   },
   {
     "id": 3280,
-    "entrezid": 880869,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -42641,7 +39361,6 @@
   },
   {
     "id": 3281,
-    "entrezid": 880870,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42654,7 +39373,6 @@
   },
   {
     "id": 3282,
-    "entrezid": 880871,
     "description": "sugar efflux transporter",
     "aliases": "-",
     "obsolete": false,
@@ -42667,7 +39385,6 @@
   },
   {
     "id": 3283,
-    "entrezid": 880872,
     "description": "spermidine acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -42680,7 +39397,6 @@
   },
   {
     "id": 3284,
-    "entrezid": 880873,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42693,7 +39409,6 @@
   },
   {
     "id": 3285,
-    "entrezid": 880874,
     "description": "flagellar assembly protein FliH",
     "aliases": "-",
     "obsolete": false,
@@ -42706,7 +39421,6 @@
   },
   {
     "id": 3286,
-    "entrezid": 880875,
     "description": "3-oxopropanoate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -42719,7 +39433,6 @@
   },
   {
     "id": 3287,
-    "entrezid": 880876,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42732,7 +39445,6 @@
   },
   {
     "id": 3288,
-    "entrezid": 880877,
     "description": "GTPase ObgE",
     "aliases": "-",
     "obsolete": false,
@@ -42745,7 +39457,6 @@
   },
   {
     "id": 3289,
-    "entrezid": 880878,
     "description": "50S ribosomal protein L27",
     "aliases": "-",
     "obsolete": false,
@@ -42758,7 +39469,6 @@
   },
   {
     "id": 3290,
-    "entrezid": 880879,
     "description": "glycerol metabolism activator",
     "aliases": "-",
     "obsolete": false,
@@ -42771,7 +39481,6 @@
   },
   {
     "id": 3291,
-    "entrezid": 880880,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42784,7 +39493,6 @@
   },
   {
     "id": 3292,
-    "entrezid": 880881,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -42797,7 +39505,6 @@
   },
   {
     "id": 3293,
-    "entrezid": 880882,
     "description": "sensor/response regulator hybrid protein",
     "aliases": "-",
     "obsolete": false,
@@ -42810,7 +39517,6 @@
   },
   {
     "id": 3294,
-    "entrezid": 880883,
     "description": "sulfate transporter CysT",
     "aliases": "-",
     "obsolete": false,
@@ -42823,7 +39529,6 @@
   },
   {
     "id": 3295,
-    "entrezid": 880884,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42836,7 +39541,6 @@
   },
   {
     "id": 3296,
-    "entrezid": 880885,
     "description": "peptidyl-prolyl cis-trans isomerase SlyD",
     "aliases": "-",
     "obsolete": false,
@@ -42849,7 +39553,6 @@
   },
   {
     "id": 3297,
-    "entrezid": 880886,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42862,7 +39565,6 @@
   },
   {
     "id": 3298,
-    "entrezid": 880887,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42875,7 +39577,6 @@
   },
   {
     "id": 3299,
-    "entrezid": 880888,
     "description": "acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -42888,7 +39589,6 @@
   },
   {
     "id": 3300,
-    "entrezid": 880889,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -42901,7 +39601,6 @@
   },
   {
     "id": 3301,
-    "entrezid": 880890,
     "description": "urocanate hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -42914,7 +39613,6 @@
   },
   {
     "id": 3302,
-    "entrezid": 880891,
     "description": "50S ribosomal protein L28",
     "aliases": "-",
     "obsolete": false,
@@ -42927,7 +39625,6 @@
   },
   {
     "id": 3303,
-    "entrezid": 880892,
     "description": "dipeptide ABC transporter substrate-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -42940,7 +39637,6 @@
   },
   {
     "id": 3304,
-    "entrezid": 880893,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42953,7 +39649,6 @@
   },
   {
     "id": 3305,
-    "entrezid": 880894,
     "description": "shikimate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -42966,7 +39661,6 @@
   },
   {
     "id": 3306,
-    "entrezid": 880895,
     "description": "RNA polymerase sigma factor",
     "aliases": "-",
     "obsolete": false,
@@ -42979,7 +39673,6 @@
   },
   {
     "id": 3307,
-    "entrezid": 880896,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -42992,7 +39685,6 @@
   },
   {
     "id": 3308,
-    "entrezid": 880898,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43005,7 +39697,6 @@
   },
   {
     "id": 3309,
-    "entrezid": 880899,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43018,7 +39709,6 @@
   },
   {
     "id": 3310,
-    "entrezid": 880900,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43031,7 +39721,6 @@
   },
   {
     "id": 3311,
-    "entrezid": 880901,
     "description": "coproporphyrinogen III oxidase",
     "aliases": "-",
     "obsolete": false,
@@ -43044,7 +39733,6 @@
   },
   {
     "id": 3312,
-    "entrezid": 880902,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43057,7 +39745,6 @@
   },
   {
     "id": 3313,
-    "entrezid": 880903,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43070,7 +39757,6 @@
   },
   {
     "id": 3314,
-    "entrezid": 880904,
     "description": "phospholipase C",
     "aliases": "-",
     "obsolete": false,
@@ -43083,7 +39769,6 @@
   },
   {
     "id": 3315,
-    "entrezid": 880905,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43096,7 +39781,6 @@
   },
   {
     "id": 3316,
-    "entrezid": 880906,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43109,7 +39793,6 @@
   },
   {
     "id": 3317,
-    "entrezid": 880907,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43122,7 +39805,6 @@
   },
   {
     "id": 3318,
-    "entrezid": 880908,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43135,7 +39817,6 @@
   },
   {
     "id": 3319,
-    "entrezid": 880909,
     "description": "gamma-glutamyl kinase",
     "aliases": "-",
     "obsolete": false,
@@ -43148,7 +39829,6 @@
   },
   {
     "id": 3320,
-    "entrezid": 880910,
     "description": "class III (anaerobic) ribonucleoside-triphosphate reductase activating protein NrdG",
     "aliases": "-",
     "obsolete": false,
@@ -43161,7 +39841,6 @@
   },
   {
     "id": 3321,
-    "entrezid": 880911,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43174,7 +39853,6 @@
   },
   {
     "id": 3322,
-    "entrezid": 880912,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -43187,7 +39865,6 @@
   },
   {
     "id": 3323,
-    "entrezid": 880913,
     "description": "flagellar motor protein MotD",
     "aliases": "-",
     "obsolete": false,
@@ -43200,7 +39877,6 @@
   },
   {
     "id": 3324,
-    "entrezid": 880914,
     "description": "NAD(P)H quinone oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -43213,7 +39889,6 @@
   },
   {
     "id": 3325,
-    "entrezid": 880915,
     "description": "arginine:pyruvate transaminase AruH",
     "aliases": "-",
     "obsolete": false,
@@ -43226,7 +39901,6 @@
   },
   {
     "id": 3326,
-    "entrezid": 880916,
     "description": "protein ApaG",
     "aliases": "-",
     "obsolete": false,
@@ -43239,7 +39913,6 @@
   },
   {
     "id": 3327,
-    "entrezid": 880917,
     "description": "5-aminovalerate aminotransferase DavT",
     "aliases": "-",
     "obsolete": false,
@@ -43252,7 +39925,6 @@
   },
   {
     "id": 3328,
-    "entrezid": 880918,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43265,7 +39937,6 @@
   },
   {
     "id": 3329,
-    "entrezid": 880919,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43278,7 +39949,6 @@
   },
   {
     "id": 3330,
-    "entrezid": 880920,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43291,7 +39961,6 @@
   },
   {
     "id": 3331,
-    "entrezid": 880921,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43304,7 +39973,6 @@
   },
   {
     "id": 3332,
-    "entrezid": 880922,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -43317,7 +39985,6 @@
   },
   {
     "id": 3333,
-    "entrezid": 880923,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43330,7 +39997,6 @@
   },
   {
     "id": 3334,
-    "entrezid": 880924,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43343,7 +40009,6 @@
   },
   {
     "id": 3335,
-    "entrezid": 880925,
     "description": "biofilm formation protein PslB",
     "aliases": "-",
     "obsolete": false,
@@ -43356,7 +40021,6 @@
   },
   {
     "id": 3336,
-    "entrezid": 880926,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43369,7 +40033,6 @@
   },
   {
     "id": 3337,
-    "entrezid": 880927,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43382,7 +40045,6 @@
   },
   {
     "id": 3338,
-    "entrezid": 880928,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -43395,7 +40057,6 @@
   },
   {
     "id": 3339,
-    "entrezid": 880929,
     "description": "binding-protein-dependent maltose/mannitol transport protein",
     "aliases": "-",
     "obsolete": false,
@@ -43408,7 +40069,6 @@
   },
   {
     "id": 3340,
-    "entrezid": 880930,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43421,7 +40081,6 @@
   },
   {
     "id": 3341,
-    "entrezid": 880931,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43434,7 +40093,6 @@
   },
   {
     "id": 3342,
-    "entrezid": 880932,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43447,7 +40105,6 @@
   },
   {
     "id": 3343,
-    "entrezid": 880933,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43460,7 +40117,6 @@
   },
   {
     "id": 3344,
-    "entrezid": 880934,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -43473,7 +40129,6 @@
   },
   {
     "id": 3345,
-    "entrezid": 880935,
     "description": "flagellar basal body rod protein FlgG",
     "aliases": "-",
     "obsolete": false,
@@ -43486,7 +40141,6 @@
   },
   {
     "id": 3346,
-    "entrezid": 880936,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -43499,7 +40153,6 @@
   },
   {
     "id": 3347,
-    "entrezid": 880937,
     "description": "ATP-dependent DNA helicase RecG",
     "aliases": "-",
     "obsolete": false,
@@ -43512,7 +40165,6 @@
   },
   {
     "id": 3348,
-    "entrezid": 880938,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43525,7 +40177,6 @@
   },
   {
     "id": 3349,
-    "entrezid": 880939,
     "description": "flagellar glycosyl transferase FgtA",
     "aliases": "-",
     "obsolete": false,
@@ -43538,7 +40189,6 @@
   },
   {
     "id": 3350,
-    "entrezid": 880940,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -43551,7 +40201,6 @@
   },
   {
     "id": 3351,
-    "entrezid": 880941,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43564,7 +40213,6 @@
   },
   {
     "id": 3352,
-    "entrezid": 880942,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -43577,7 +40225,6 @@
   },
   {
     "id": 3353,
-    "entrezid": 880943,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -43590,7 +40237,6 @@
   },
   {
     "id": 3354,
-    "entrezid": 880944,
     "description": "cytochrome b",
     "aliases": "-",
     "obsolete": false,
@@ -43603,7 +40249,6 @@
   },
   {
     "id": 3355,
-    "entrezid": 880945,
     "description": "iron-sulfur protein",
     "aliases": "-",
     "obsolete": false,
@@ -43616,7 +40261,6 @@
   },
   {
     "id": 3356,
-    "entrezid": 880946,
     "description": "octaprenyl-diphosphate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -43629,7 +40273,6 @@
   },
   {
     "id": 3357,
-    "entrezid": 880947,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43642,7 +40285,6 @@
   },
   {
     "id": 3358,
-    "entrezid": 880948,
     "description": "heme exporter protein CcmB",
     "aliases": "-",
     "obsolete": false,
@@ -43655,7 +40297,6 @@
   },
   {
     "id": 3359,
-    "entrezid": 880949,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43668,7 +40309,6 @@
   },
   {
     "id": 3360,
-    "entrezid": 880950,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43681,7 +40321,6 @@
   },
   {
     "id": 3361,
-    "entrezid": 880951,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -43694,7 +40333,6 @@
   },
   {
     "id": 3362,
-    "entrezid": 880952,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43707,7 +40345,6 @@
   },
   {
     "id": 3363,
-    "entrezid": 880953,
     "description": "4-alpha-glucanotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -43720,7 +40357,6 @@
   },
   {
     "id": 3364,
-    "entrezid": 880954,
     "description": "heme exporter protein CcmD",
     "aliases": "-",
     "obsolete": false,
@@ -43733,7 +40369,6 @@
   },
   {
     "id": 3365,
-    "entrezid": 880955,
     "description": "cytochrome C",
     "aliases": "-",
     "obsolete": false,
@@ -43746,7 +40381,6 @@
   },
   {
     "id": 3366,
-    "entrezid": 880956,
     "description": "peptidyl-prolyl cis-trans isomerase FklB",
     "aliases": "-",
     "obsolete": false,
@@ -43759,7 +40393,6 @@
   },
   {
     "id": 3367,
-    "entrezid": 880957,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43772,7 +40405,6 @@
   },
   {
     "id": 3368,
-    "entrezid": 880958,
     "description": "tryptophan--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -43785,7 +40417,6 @@
   },
   {
     "id": 3369,
-    "entrezid": 880959,
     "description": "multidrug resistance protein PmpM",
     "aliases": "-",
     "obsolete": false,
@@ -43798,7 +40429,6 @@
   },
   {
     "id": 3370,
-    "entrezid": 880960,
     "description": "allantoate amidohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -43811,7 +40441,6 @@
   },
   {
     "id": 3371,
-    "entrezid": 880961,
     "description": "shikimate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -43824,7 +40453,6 @@
   },
   {
     "id": 3372,
-    "entrezid": 880962,
     "description": "type 4 fimbrial biogenesis outer membrane protein PilQ",
     "aliases": "-",
     "obsolete": false,
@@ -43837,7 +40465,6 @@
   },
   {
     "id": 3373,
-    "entrezid": 880963,
     "description": "malto-oligosyltrehalose synthase",
     "aliases": "-",
     "obsolete": false,
@@ -43850,7 +40477,6 @@
   },
   {
     "id": 3374,
-    "entrezid": 880964,
     "description": "ECF subfamily sigma-70 factor",
     "aliases": "-",
     "obsolete": false,
@@ -43863,7 +40489,6 @@
   },
   {
     "id": 3375,
-    "entrezid": 880965,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43876,7 +40501,6 @@
   },
   {
     "id": 3376,
-    "entrezid": 880966,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43889,7 +40513,6 @@
   },
   {
     "id": 3377,
-    "entrezid": 880967,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43902,7 +40525,6 @@
   },
   {
     "id": 3378,
-    "entrezid": 880968,
     "description": "ATP phosphoribosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -43915,7 +40537,6 @@
   },
   {
     "id": 3379,
-    "entrezid": 880969,
     "description": "UDP-N-acetylglucosamine 1-carboxyvinyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -43928,7 +40549,6 @@
   },
   {
     "id": 3380,
-    "entrezid": 880970,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43941,7 +40561,6 @@
   },
   {
     "id": 3381,
-    "entrezid": 880971,
     "description": "murein hydrolase B",
     "aliases": "-",
     "obsolete": false,
@@ -43954,7 +40573,6 @@
   },
   {
     "id": 3382,
-    "entrezid": 880972,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43967,7 +40585,6 @@
   },
   {
     "id": 3383,
-    "entrezid": 880973,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -43980,7 +40597,6 @@
   },
   {
     "id": 3384,
-    "entrezid": 880974,
     "description": "ATP-dependent protease",
     "aliases": "-",
     "obsolete": false,
@@ -43993,7 +40609,6 @@
   },
   {
     "id": 3385,
-    "entrezid": 880975,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44006,7 +40621,6 @@
   },
   {
     "id": 3386,
-    "entrezid": 880976,
     "description": "AlgW protein",
     "aliases": "-",
     "obsolete": false,
@@ -44019,7 +40633,6 @@
   },
   {
     "id": 3387,
-    "entrezid": 880977,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44032,7 +40645,6 @@
   },
   {
     "id": 3388,
-    "entrezid": 880978,
     "description": "cytochrome c biogenesis ATP-binding export protein CcmA",
     "aliases": "-",
     "obsolete": false,
@@ -44045,7 +40657,6 @@
   },
   {
     "id": 3389,
-    "entrezid": 880979,
     "description": "bifunctional sulfate adenylyltransferase subunit 1/adenylylsulfate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -44058,7 +40669,6 @@
   },
   {
     "id": 3390,
-    "entrezid": 880980,
     "description": "sulfate adenylyltransferase subunit 2",
     "aliases": "-",
     "obsolete": false,
@@ -44071,7 +40681,6 @@
   },
   {
     "id": 3391,
-    "entrezid": 880981,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44084,7 +40693,6 @@
   },
   {
     "id": 3392,
-    "entrezid": 880982,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44097,7 +40705,6 @@
   },
   {
     "id": 3393,
-    "entrezid": 880983,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44110,7 +40717,6 @@
   },
   {
     "id": 3394,
-    "entrezid": 880984,
     "description": "type 4 fimbrial biogenesis protein PilP",
     "aliases": "-",
     "obsolete": false,
@@ -44123,7 +40729,6 @@
   },
   {
     "id": 3395,
-    "entrezid": 880985,
     "description": "type 4 fimbrial biogenesis protein PilO",
     "aliases": "-",
     "obsolete": false,
@@ -44136,7 +40741,6 @@
   },
   {
     "id": 3396,
-    "entrezid": 880986,
     "description": "glycosyl hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -44149,7 +40753,6 @@
   },
   {
     "id": 3397,
-    "entrezid": 880987,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44162,7 +40765,6 @@
   },
   {
     "id": 3398,
-    "entrezid": 880988,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44175,7 +40777,6 @@
   },
   {
     "id": 3399,
-    "entrezid": 880989,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44188,7 +40789,6 @@
   },
   {
     "id": 3400,
-    "entrezid": 880990,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44201,7 +40801,6 @@
   },
   {
     "id": 3401,
-    "entrezid": 880991,
     "description": "histidinol-phosphate aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -44214,7 +40813,6 @@
   },
   {
     "id": 3402,
-    "entrezid": 880992,
     "description": "histidinol dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -44227,7 +40825,6 @@
   },
   {
     "id": 3403,
-    "entrezid": 880993,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44240,7 +40837,6 @@
   },
   {
     "id": 3404,
-    "entrezid": 880994,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44253,7 +40849,6 @@
   },
   {
     "id": 3405,
-    "entrezid": 880995,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44266,7 +40861,6 @@
   },
   {
     "id": 3406,
-    "entrezid": 880996,
     "description": "transcriptional regulator RtcR",
     "aliases": "-",
     "obsolete": false,
@@ -44279,7 +40873,6 @@
   },
   {
     "id": 3407,
-    "entrezid": 880997,
     "description": "nitrogen regulatory IIA protein",
     "aliases": "-",
     "obsolete": false,
@@ -44292,7 +40885,6 @@
   },
   {
     "id": 3408,
-    "entrezid": 880998,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44305,7 +40897,6 @@
   },
   {
     "id": 3409,
-    "entrezid": 880999,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -44318,7 +40909,6 @@
   },
   {
     "id": 3410,
-    "entrezid": 881000,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -44331,7 +40921,6 @@
   },
   {
     "id": 3411,
-    "entrezid": 881001,
     "description": "arabinose-5-phosphate isomerase KdsD",
     "aliases": "-",
     "obsolete": false,
@@ -44344,7 +40933,6 @@
   },
   {
     "id": 3412,
-    "entrezid": 881002,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44357,7 +40945,6 @@
   },
   {
     "id": 3413,
-    "entrezid": 881003,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44370,7 +40957,6 @@
   },
   {
     "id": 3414,
-    "entrezid": 881004,
     "description": "cytochrome c-type biogenesis protein CcmF",
     "aliases": "-",
     "obsolete": false,
@@ -44383,7 +40969,6 @@
   },
   {
     "id": 3415,
-    "entrezid": 881005,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44396,7 +40981,6 @@
   },
   {
     "id": 3416,
-    "entrezid": 881006,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44409,7 +40993,6 @@
   },
   {
     "id": 3417,
-    "entrezid": 881007,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44422,7 +41005,6 @@
   },
   {
     "id": 3418,
-    "entrezid": 881008,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -44435,7 +41017,6 @@
   },
   {
     "id": 3419,
-    "entrezid": 881009,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44448,7 +41029,6 @@
   },
   {
     "id": 3420,
-    "entrezid": 881010,
     "description": "RNA 3'-terminal-phosphate cyclase",
     "aliases": "-",
     "obsolete": false,
@@ -44461,7 +41041,6 @@
   },
   {
     "id": 3421,
-    "entrezid": 881011,
     "description": "phosphoryl carrier protein",
     "aliases": "-",
     "obsolete": false,
@@ -44474,7 +41053,6 @@
   },
   {
     "id": 3422,
-    "entrezid": 881012,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44487,7 +41065,6 @@
   },
   {
     "id": 3423,
-    "entrezid": 881013,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44500,7 +41077,6 @@
   },
   {
     "id": 3424,
-    "entrezid": 881014,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -44513,7 +41089,6 @@
   },
   {
     "id": 3425,
-    "entrezid": 881015,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44526,7 +41101,6 @@
   },
   {
     "id": 3426,
-    "entrezid": 881016,
     "description": "monovalent cation/H+ antiporter subunit G",
     "aliases": "-",
     "obsolete": false,
@@ -44539,7 +41113,6 @@
   },
   {
     "id": 3427,
-    "entrezid": 881017,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44552,7 +41125,6 @@
   },
   {
     "id": 3428,
-    "entrezid": 881018,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -44565,7 +41137,6 @@
   },
   {
     "id": 3429,
-    "entrezid": 881019,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44578,7 +41149,6 @@
   },
   {
     "id": 3430,
-    "entrezid": 881020,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44591,7 +41161,6 @@
   },
   {
     "id": 3431,
-    "entrezid": 881021,
     "description": "cytochrome C551 peroxidase",
     "aliases": "-",
     "obsolete": false,
@@ -44604,7 +41173,6 @@
   },
   {
     "id": 3432,
-    "entrezid": 881022,
     "description": "RNA polymerase factor sigma-54",
     "aliases": "-",
     "obsolete": false,
@@ -44617,7 +41185,6 @@
   },
   {
     "id": 3433,
-    "entrezid": 881023,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44630,7 +41197,6 @@
   },
   {
     "id": 3434,
-    "entrezid": 881024,
     "description": "cytochrome c-type biogenesis protein CcmE",
     "aliases": "-",
     "obsolete": false,
@@ -44643,7 +41209,6 @@
   },
   {
     "id": 3435,
-    "entrezid": 881025,
     "description": "type 4 fimbrial biogenesis protein PilN",
     "aliases": "-",
     "obsolete": false,
@@ -44656,7 +41221,6 @@
   },
   {
     "id": 3436,
-    "entrezid": 881026,
     "description": "glycogen synthase",
     "aliases": "-",
     "obsolete": false,
@@ -44669,7 +41233,6 @@
   },
   {
     "id": 3437,
-    "entrezid": 881027,
     "description": "glutamate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -44682,7 +41245,6 @@
   },
   {
     "id": 3438,
-    "entrezid": 881028,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44695,7 +41257,6 @@
   },
   {
     "id": 3439,
-    "entrezid": 881029,
     "description": "cytochrome c-type biogenesis protein CcmH",
     "aliases": "-",
     "obsolete": false,
@@ -44708,7 +41269,6 @@
   },
   {
     "id": 3440,
-    "entrezid": 881030,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44721,7 +41281,6 @@
   },
   {
     "id": 3441,
-    "entrezid": 881031,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44734,7 +41293,6 @@
   },
   {
     "id": 3442,
-    "entrezid": 881032,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -44747,7 +41305,6 @@
   },
   {
     "id": 3443,
-    "entrezid": 881033,
     "description": "fumarate hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -44760,7 +41317,6 @@
   },
   {
     "id": 3444,
-    "entrezid": 881034,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44773,7 +41329,6 @@
   },
   {
     "id": 3445,
-    "entrezid": 881035,
     "description": "protein activator",
     "aliases": "-",
     "obsolete": false,
@@ -44786,7 +41341,6 @@
   },
   {
     "id": 3446,
-    "entrezid": 881036,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44799,7 +41353,6 @@
   },
   {
     "id": 3447,
-    "entrezid": 881037,
     "description": "PmbA protein",
     "aliases": "-",
     "obsolete": false,
@@ -44812,7 +41365,6 @@
   },
   {
     "id": 3448,
-    "entrezid": 881038,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44825,7 +41377,6 @@
   },
   {
     "id": 3449,
-    "entrezid": 881039,
     "description": "nucleoside triphosphate pyrophosphohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -44838,7 +41389,6 @@
   },
   {
     "id": 3450,
-    "entrezid": 881040,
     "description": "superoxide dismutase",
     "aliases": "-",
     "obsolete": false,
@@ -44851,7 +41401,6 @@
   },
   {
     "id": 3451,
-    "entrezid": 881041,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44864,7 +41413,6 @@
   },
   {
     "id": 3452,
-    "entrezid": 881042,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44877,7 +41425,6 @@
   },
   {
     "id": 3453,
-    "entrezid": 881043,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44890,7 +41437,6 @@
   },
   {
     "id": 3454,
-    "entrezid": 881044,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44903,7 +41449,6 @@
   },
   {
     "id": 3455,
-    "entrezid": 881045,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44916,7 +41461,6 @@
   },
   {
     "id": 3456,
-    "entrezid": 881046,
     "description": "cytoplasmic axial filament protein",
     "aliases": "-",
     "obsolete": false,
@@ -44929,7 +41473,6 @@
   },
   {
     "id": 3457,
-    "entrezid": 881047,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44942,7 +41485,6 @@
   },
   {
     "id": 3458,
-    "entrezid": 881048,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44955,7 +41497,6 @@
   },
   {
     "id": 3459,
-    "entrezid": 881049,
     "description": "ATP-dependent protease peptidase subunit",
     "aliases": "-",
     "obsolete": false,
@@ -44968,7 +41509,6 @@
   },
   {
     "id": 3460,
-    "entrezid": 881050,
     "description": "ATP-dependent protease ATP-binding subunit HslU",
     "aliases": "-",
     "obsolete": false,
@@ -44981,7 +41521,6 @@
   },
   {
     "id": 3461,
-    "entrezid": 881051,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -44994,7 +41533,6 @@
   },
   {
     "id": 3462,
-    "entrezid": 881052,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -45007,7 +41545,6 @@
   },
   {
     "id": 3463,
-    "entrezid": 881053,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -45020,7 +41557,6 @@
   },
   {
     "id": 3464,
-    "entrezid": 881054,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45033,7 +41569,6 @@
   },
   {
     "id": 3465,
-    "entrezid": 881055,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45046,7 +41581,6 @@
   },
   {
     "id": 3466,
-    "entrezid": 881056,
     "description": "DNA-binding response regulator RoxR",
     "aliases": "-",
     "obsolete": false,
@@ -45059,7 +41593,6 @@
   },
   {
     "id": 3467,
-    "entrezid": 881057,
     "description": "sensor histidine kinase RoxS",
     "aliases": "-",
     "obsolete": false,
@@ -45072,7 +41605,6 @@
   },
   {
     "id": 3468,
-    "entrezid": 881058,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45085,7 +41617,6 @@
   },
   {
     "id": 3469,
-    "entrezid": 881059,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -45098,7 +41629,6 @@
   },
   {
     "id": 3470,
-    "entrezid": 881060,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -45111,7 +41641,6 @@
   },
   {
     "id": 3471,
-    "entrezid": 881061,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -45124,7 +41653,6 @@
   },
   {
     "id": 3472,
-    "entrezid": 881062,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -45137,7 +41665,6 @@
   },
   {
     "id": 3473,
-    "entrezid": 881063,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45150,7 +41677,6 @@
   },
   {
     "id": 3474,
-    "entrezid": 881064,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45163,7 +41689,6 @@
   },
   {
     "id": 3475,
-    "entrezid": 881065,
     "description": "cytochrome c-type biogenesis protein CcmG",
     "aliases": "-",
     "obsolete": false,
@@ -45176,7 +41701,6 @@
   },
   {
     "id": 3476,
-    "entrezid": 881066,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45189,7 +41713,6 @@
   },
   {
     "id": 3477,
-    "entrezid": 881067,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -45202,7 +41725,6 @@
   },
   {
     "id": 3478,
-    "entrezid": 881068,
     "description": "phosphate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -45215,7 +41737,6 @@
   },
   {
     "id": 3479,
-    "entrezid": 881069,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45228,7 +41749,6 @@
   },
   {
     "id": 3480,
-    "entrezid": 881070,
     "description": "multidrug efflux outer membrane protein OprJ",
     "aliases": "-",
     "obsolete": false,
@@ -45241,7 +41761,6 @@
   },
   {
     "id": 3481,
-    "entrezid": 881071,
     "description": "resistance-nodulation-cell division (RND) multidrug efflux transporter MexD",
     "aliases": "-",
     "obsolete": false,
@@ -45254,7 +41773,6 @@
   },
   {
     "id": 3482,
-    "entrezid": 881072,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45267,7 +41785,6 @@
   },
   {
     "id": 3483,
-    "entrezid": 881073,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45280,7 +41797,6 @@
   },
   {
     "id": 3484,
-    "entrezid": 881074,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45293,7 +41809,6 @@
   },
   {
     "id": 3485,
-    "entrezid": 881075,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45306,7 +41821,6 @@
   },
   {
     "id": 3486,
-    "entrezid": 881076,
     "description": "poly(3-hydroxyalkanoic acid) synthase",
     "aliases": "-",
     "obsolete": false,
@@ -45319,7 +41833,6 @@
   },
   {
     "id": 3487,
-    "entrezid": 881077,
     "description": "ECF subfamily sigma-70 factor",
     "aliases": "-",
     "obsolete": false,
@@ -45332,7 +41845,6 @@
   },
   {
     "id": 3488,
-    "entrezid": 881078,
     "description": "resistance-nodulation-cell division (RND) multidrug efflux membrane fusion protein MexC",
     "aliases": "-",
     "obsolete": false,
@@ -45345,7 +41857,6 @@
   },
   {
     "id": 3489,
-    "entrezid": 881079,
     "description": "transcriptional regulator NfxB",
     "aliases": "-",
     "obsolete": false,
@@ -45358,7 +41869,6 @@
   },
   {
     "id": 3490,
-    "entrezid": 881080,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -45371,7 +41881,6 @@
   },
   {
     "id": 3491,
-    "entrezid": 881081,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -45384,7 +41893,6 @@
   },
   {
     "id": 3492,
-    "entrezid": 881082,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -45397,7 +41905,6 @@
   },
   {
     "id": 3493,
-    "entrezid": 881083,
     "description": "metallopeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -45410,7 +41917,6 @@
   },
   {
     "id": 3494,
-    "entrezid": 881084,
     "description": "motility regulator",
     "aliases": "-",
     "obsolete": false,
@@ -45423,7 +41929,6 @@
   },
   {
     "id": 3495,
-    "entrezid": 881085,
     "description": "serine hydroxymethyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -45436,7 +41941,6 @@
   },
   {
     "id": 3496,
-    "entrezid": 881086,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45449,7 +41953,6 @@
   },
   {
     "id": 3497,
-    "entrezid": 881087,
     "description": "heme exporter protein CcmC",
     "aliases": "-",
     "obsolete": false,
@@ -45462,7 +41965,6 @@
   },
   {
     "id": 3498,
-    "entrezid": 881088,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45475,7 +41977,6 @@
   },
   {
     "id": 3499,
-    "entrezid": 881089,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45488,7 +41989,6 @@
   },
   {
     "id": 3500,
-    "entrezid": 881090,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45501,7 +42001,6 @@
   },
   {
     "id": 3501,
-    "entrezid": 881091,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45514,7 +42013,6 @@
   },
   {
     "id": 3502,
-    "entrezid": 881092,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45527,7 +42025,6 @@
   },
   {
     "id": 3503,
-    "entrezid": 881093,
     "description": "outer membrane receptor FepA",
     "aliases": "-",
     "obsolete": false,
@@ -45540,7 +42037,6 @@
   },
   {
     "id": 3504,
-    "entrezid": 881094,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -45553,7 +42049,6 @@
   },
   {
     "id": 3505,
-    "entrezid": 881095,
     "description": "glycine-glutamate dipeptide porin OpdP",
     "aliases": "-",
     "obsolete": false,
@@ -45566,7 +42061,6 @@
   },
   {
     "id": 3506,
-    "entrezid": 881096,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -45579,7 +42073,6 @@
   },
   {
     "id": 3507,
-    "entrezid": 881097,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45592,7 +42085,6 @@
   },
   {
     "id": 3508,
-    "entrezid": 881098,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45605,7 +42097,6 @@
   },
   {
     "id": 3509,
-    "entrezid": 881099,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45618,7 +42109,6 @@
   },
   {
     "id": 3510,
-    "entrezid": 881100,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -45631,7 +42121,6 @@
   },
   {
     "id": 3511,
-    "entrezid": 881101,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45644,7 +42133,6 @@
   },
   {
     "id": 3512,
-    "entrezid": 881102,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45657,7 +42145,6 @@
   },
   {
     "id": 3513,
-    "entrezid": 881103,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45670,7 +42157,6 @@
   },
   {
     "id": 3514,
-    "entrezid": 881104,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45683,7 +42169,6 @@
   },
   {
     "id": 3515,
-    "entrezid": 881105,
     "description": "N-acetyl-anhydromuranmyl-L-alanine amidase",
     "aliases": "-",
     "obsolete": false,
@@ -45696,7 +42181,6 @@
   },
   {
     "id": 3516,
-    "entrezid": 881106,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45709,7 +42193,6 @@
   },
   {
     "id": 3517,
-    "entrezid": 881107,
     "description": "DNA repair protein RadA",
     "aliases": "-",
     "obsolete": false,
@@ -45722,7 +42205,6 @@
   },
   {
     "id": 3518,
-    "entrezid": 881108,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45735,7 +42217,6 @@
   },
   {
     "id": 3519,
-    "entrezid": 881109,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45748,7 +42229,6 @@
   },
   {
     "id": 3520,
-    "entrezid": 881110,
     "description": "monovalent cation/H+ antiporter subunit E",
     "aliases": "-",
     "obsolete": false,
@@ -45761,7 +42241,6 @@
   },
   {
     "id": 3521,
-    "entrezid": 881111,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -45774,7 +42253,6 @@
   },
   {
     "id": 3522,
-    "entrezid": 881112,
     "description": "iron transport outer membrane receptor",
     "aliases": "-",
     "obsolete": false,
@@ -45787,7 +42265,6 @@
   },
   {
     "id": 3523,
-    "entrezid": 881113,
     "description": "acyl-CoA thioesterase",
     "aliases": "-",
     "obsolete": false,
@@ -45800,7 +42277,6 @@
   },
   {
     "id": 3524,
-    "entrezid": 881114,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45813,7 +42289,6 @@
   },
   {
     "id": 3525,
-    "entrezid": 881115,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45826,7 +42301,6 @@
   },
   {
     "id": 3526,
-    "entrezid": 881116,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45839,7 +42313,6 @@
   },
   {
     "id": 3527,
-    "entrezid": 881117,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45852,7 +42325,6 @@
   },
   {
     "id": 3528,
-    "entrezid": 881118,
     "description": "ornithine decarboxylase",
     "aliases": "-",
     "obsolete": false,
@@ -45865,7 +42337,6 @@
   },
   {
     "id": 3529,
-    "entrezid": 881119,
     "description": "chemotaxis transducer",
     "aliases": "-",
     "obsolete": false,
@@ -45878,7 +42349,6 @@
   },
   {
     "id": 3530,
-    "entrezid": 881120,
     "description": "catalase",
     "aliases": "-",
     "obsolete": false,
@@ -45891,7 +42361,6 @@
   },
   {
     "id": 3531,
-    "entrezid": 881121,
     "description": "hydroxylase",
     "aliases": "-",
     "obsolete": false,
@@ -45904,7 +42373,6 @@
   },
   {
     "id": 3532,
-    "entrezid": 881122,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45917,7 +42385,6 @@
   },
   {
     "id": 3533,
-    "entrezid": 881123,
     "description": "acyl-CoA thioesterase",
     "aliases": "-",
     "obsolete": false,
@@ -45930,7 +42397,6 @@
   },
   {
     "id": 3534,
-    "entrezid": 881124,
     "description": "choline dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -45943,7 +42409,6 @@
   },
   {
     "id": 3535,
-    "entrezid": 881125,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -45956,7 +42421,6 @@
   },
   {
     "id": 3536,
-    "entrezid": 881126,
     "description": "3-oxoacyl-ACP synthase",
     "aliases": "-",
     "obsolete": false,
@@ -45969,7 +42433,6 @@
   },
   {
     "id": 3537,
-    "entrezid": 881127,
     "description": "large-conductance mechanosensitive channel",
     "aliases": "-",
     "obsolete": false,
@@ -45982,7 +42445,6 @@
   },
   {
     "id": 3538,
-    "entrezid": 881128,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -45995,7 +42457,6 @@
   },
   {
     "id": 3539,
-    "entrezid": 881129,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46008,7 +42469,6 @@
   },
   {
     "id": 3540,
-    "entrezid": 881130,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46021,7 +42481,6 @@
   },
   {
     "id": 3541,
-    "entrezid": 881131,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -46034,7 +42493,6 @@
   },
   {
     "id": 3542,
-    "entrezid": 881132,
     "description": "erythronate-4-phosphate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -46047,7 +42505,6 @@
   },
   {
     "id": 3543,
-    "entrezid": 881133,
     "description": "C4-dicarboxylate-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -46060,7 +42517,6 @@
   },
   {
     "id": 3544,
-    "entrezid": 881134,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46073,7 +42529,6 @@
   },
   {
     "id": 3545,
-    "entrezid": 881135,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46086,7 +42541,6 @@
   },
   {
     "id": 3546,
-    "entrezid": 881136,
     "description": "rod shape-determining protein MreD",
     "aliases": "-",
     "obsolete": false,
@@ -46099,7 +42553,6 @@
   },
   {
     "id": 3547,
-    "entrezid": 881137,
     "description": "protein GbdR",
     "aliases": "-",
     "obsolete": false,
@@ -46112,7 +42565,6 @@
   },
   {
     "id": 3548,
-    "entrezid": 881138,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46125,7 +42577,6 @@
   },
   {
     "id": 3549,
-    "entrezid": 881139,
     "description": "monovalent cation/H+ antiporter subunit F",
     "aliases": "-",
     "obsolete": false,
@@ -46138,7 +42589,6 @@
   },
   {
     "id": 3550,
-    "entrezid": 881140,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46151,7 +42601,6 @@
   },
   {
     "id": 3551,
-    "entrezid": 881141,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46164,7 +42613,6 @@
   },
   {
     "id": 3552,
-    "entrezid": 881142,
     "description": "malic enzyme",
     "aliases": "-",
     "obsolete": false,
@@ -46177,7 +42625,6 @@
   },
   {
     "id": 3553,
-    "entrezid": 881143,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46190,7 +42637,6 @@
   },
   {
     "id": 3554,
-    "entrezid": 881144,
     "description": "nuclease",
     "aliases": "-",
     "obsolete": false,
@@ -46203,7 +42649,6 @@
   },
   {
     "id": 3555,
-    "entrezid": 881145,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46216,7 +42661,6 @@
   },
   {
     "id": 3556,
-    "entrezid": 881146,
     "description": "cytochrome C",
     "aliases": "-",
     "obsolete": false,
@@ -46229,7 +42673,6 @@
   },
   {
     "id": 3557,
-    "entrezid": 881147,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46242,7 +42685,6 @@
   },
   {
     "id": 3558,
-    "entrezid": 881148,
     "description": "50S ribosomal protein L21",
     "aliases": "-",
     "obsolete": false,
@@ -46255,7 +42697,6 @@
   },
   {
     "id": 3559,
-    "entrezid": 881149,
     "description": "50S ribosomal protein L31",
     "aliases": "-",
     "obsolete": false,
@@ -46268,7 +42709,6 @@
   },
   {
     "id": 3560,
-    "entrezid": 881150,
     "description": "primosome assembly protein PriA",
     "aliases": "-",
     "obsolete": false,
@@ -46281,7 +42721,6 @@
   },
   {
     "id": 3561,
-    "entrezid": 881151,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46294,7 +42733,6 @@
   },
   {
     "id": 3562,
-    "entrezid": 881152,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46307,7 +42745,6 @@
   },
   {
     "id": 3563,
-    "entrezid": 881153,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -46320,7 +42757,6 @@
   },
   {
     "id": 3564,
-    "entrezid": 881154,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46333,7 +42769,6 @@
   },
   {
     "id": 3565,
-    "entrezid": 881155,
     "description": "lipopolysaccharide biosynthetic protein LpxO",
     "aliases": "-",
     "obsolete": false,
@@ -46346,7 +42781,6 @@
   },
   {
     "id": 3566,
-    "entrezid": 881156,
     "description": "bifunctional isocitrate dehydrogenase kinase/phosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -46359,7 +42793,6 @@
   },
   {
     "id": 3567,
-    "entrezid": 881157,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46372,7 +42805,6 @@
   },
   {
     "id": 3568,
-    "entrezid": 881158,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -46385,7 +42817,6 @@
   },
   {
     "id": 3569,
-    "entrezid": 881159,
     "description": "peptide ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -46398,7 +42829,6 @@
   },
   {
     "id": 3570,
-    "entrezid": 881160,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46411,7 +42841,6 @@
   },
   {
     "id": 3571,
-    "entrezid": 881161,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -46424,7 +42853,6 @@
   },
   {
     "id": 3572,
-    "entrezid": 881162,
     "description": "type 4 fimbrial biogenesis protein PilM",
     "aliases": "-",
     "obsolete": false,
@@ -46437,7 +42865,6 @@
   },
   {
     "id": 3573,
-    "entrezid": 881163,
     "description": "penicillin-binding protein 1A",
     "aliases": "-",
     "obsolete": false,
@@ -46450,7 +42877,6 @@
   },
   {
     "id": 3574,
-    "entrezid": 881164,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46463,7 +42889,6 @@
   },
   {
     "id": 3575,
-    "entrezid": 881165,
     "description": "rod shape-determining protein MreB",
     "aliases": "-",
     "obsolete": false,
@@ -46476,7 +42901,6 @@
   },
   {
     "id": 3576,
-    "entrezid": 881166,
     "description": "aspartyl/glutamyl-tRNA amidotransferase subunit C",
     "aliases": "-",
     "obsolete": false,
@@ -46489,7 +42913,6 @@
   },
   {
     "id": 3577,
-    "entrezid": 881167,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46502,7 +42925,6 @@
   },
   {
     "id": 3578,
-    "entrezid": 881168,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -46515,7 +42937,6 @@
   },
   {
     "id": 3579,
-    "entrezid": 881169,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46528,7 +42949,6 @@
   },
   {
     "id": 3580,
-    "entrezid": 881170,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -46541,7 +42961,6 @@
   },
   {
     "id": 3581,
-    "entrezid": 881171,
     "description": "poly(3-hydroxyalkanoic acid) depolymerase",
     "aliases": "-",
     "obsolete": false,
@@ -46554,7 +42973,6 @@
   },
   {
     "id": 3582,
-    "entrezid": 881172,
     "description": "rod shape-determining protein MreC",
     "aliases": "-",
     "obsolete": false,
@@ -46567,7 +42985,6 @@
   },
   {
     "id": 3583,
-    "entrezid": 881173,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46580,7 +42997,6 @@
   },
   {
     "id": 3584,
-    "entrezid": 881174,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46593,7 +43009,6 @@
   },
   {
     "id": 3585,
-    "entrezid": 881175,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46606,7 +43021,6 @@
   },
   {
     "id": 3586,
-    "entrezid": 881176,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -46619,7 +43033,6 @@
   },
   {
     "id": 3587,
-    "entrezid": 881177,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -46632,7 +43045,6 @@
   },
   {
     "id": 3588,
-    "entrezid": 881178,
     "description": "monovalent cation/H+ antiporter subunit C",
     "aliases": "-",
     "obsolete": false,
@@ -46645,7 +43057,6 @@
   },
   {
     "id": 3589,
-    "entrezid": 881179,
     "description": "enoyl-CoA hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -46658,7 +43069,6 @@
   },
   {
     "id": 3590,
-    "entrezid": 881180,
     "description": "aspartyl/glutamyl-tRNA amidotransferase subunit A",
     "aliases": "-",
     "obsolete": false,
@@ -46671,7 +43081,6 @@
   },
   {
     "id": 3591,
-    "entrezid": 881181,
     "description": "aspartyl/glutamyl-tRNA amidotransferase subunit B",
     "aliases": "-",
     "obsolete": false,
@@ -46684,7 +43093,6 @@
   },
   {
     "id": 3592,
-    "entrezid": 881182,
     "description": "glycerate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -46697,7 +43105,6 @@
   },
   {
     "id": 3593,
-    "entrezid": 881183,
     "description": "16S rRNA methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -46710,7 +43117,6 @@
   },
   {
     "id": 3594,
-    "entrezid": 881184,
     "description": "multidrug resistance efflux pump",
     "aliases": "-",
     "obsolete": false,
@@ -46723,7 +43129,6 @@
   },
   {
     "id": 3595,
-    "entrezid": 881185,
     "description": "poly(3-hydroxyalkanoic acid) synthase",
     "aliases": "-",
     "obsolete": false,
@@ -46736,7 +43141,6 @@
   },
   {
     "id": 3596,
-    "entrezid": 881186,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -46749,7 +43153,6 @@
   },
   {
     "id": 3597,
-    "entrezid": 881187,
     "description": "polyhydroxyalkanoate synthesis protein PhaF",
     "aliases": "-",
     "obsolete": false,
@@ -46762,7 +43165,6 @@
   },
   {
     "id": 3598,
-    "entrezid": 881188,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46775,7 +43177,6 @@
   },
   {
     "id": 3599,
-    "entrezid": 881189,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46788,7 +43189,6 @@
   },
   {
     "id": 3600,
-    "entrezid": 881190,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46801,7 +43201,6 @@
   },
   {
     "id": 3601,
-    "entrezid": 881191,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46814,7 +43213,6 @@
   },
   {
     "id": 3602,
-    "entrezid": 881192,
     "description": "lysine-specific permease",
     "aliases": "-",
     "obsolete": false,
@@ -46827,7 +43225,6 @@
   },
   {
     "id": 3603,
-    "entrezid": 881193,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46840,7 +43237,6 @@
   },
   {
     "id": 3604,
-    "entrezid": 881194,
     "description": "arginine--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -46853,7 +43249,6 @@
   },
   {
     "id": 3605,
-    "entrezid": 881195,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46866,7 +43261,6 @@
   },
   {
     "id": 3606,
-    "entrezid": 881196,
     "description": "phosphoheptose isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -46879,7 +43273,6 @@
   },
   {
     "id": 3607,
-    "entrezid": 881197,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46892,7 +43285,6 @@
   },
   {
     "id": 3608,
-    "entrezid": 881198,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46905,7 +43297,6 @@
   },
   {
     "id": 3609,
-    "entrezid": 881199,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46918,7 +43309,6 @@
   },
   {
     "id": 3610,
-    "entrezid": 881200,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46931,7 +43321,6 @@
   },
   {
     "id": 3611,
-    "entrezid": 881201,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46944,7 +43333,6 @@
   },
   {
     "id": 3612,
-    "entrezid": 881202,
     "description": "uroporphyrinogen decarboxylase",
     "aliases": "-",
     "obsolete": false,
@@ -46957,7 +43345,6 @@
   },
   {
     "id": 3613,
-    "entrezid": 881203,
     "description": "multidrug efflux pump outer membrane protein",
     "aliases": "-",
     "obsolete": false,
@@ -46970,7 +43357,6 @@
   },
   {
     "id": 3614,
-    "entrezid": 881204,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -46983,7 +43369,6 @@
   },
   {
     "id": 3615,
-    "entrezid": 881205,
     "description": "O-acetylhomoserine aminocarboxypropyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -46996,7 +43381,6 @@
   },
   {
     "id": 3616,
-    "entrezid": 881206,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47009,7 +43393,6 @@
   },
   {
     "id": 3617,
-    "entrezid": 881207,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47022,7 +43405,6 @@
   },
   {
     "id": 3618,
-    "entrezid": 881208,
     "description": "chemotaxis transducer",
     "aliases": "-",
     "obsolete": false,
@@ -47035,7 +43417,6 @@
   },
   {
     "id": 3619,
-    "entrezid": 881209,
     "description": "stringent starvation protein A",
     "aliases": "-",
     "obsolete": false,
@@ -47048,7 +43429,6 @@
   },
   {
     "id": 3620,
-    "entrezid": 881210,
     "description": "cytochrome C1",
     "aliases": "-",
     "obsolete": false,
@@ -47061,7 +43441,6 @@
   },
   {
     "id": 3621,
-    "entrezid": 881211,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47074,7 +43453,6 @@
   },
   {
     "id": 3622,
-    "entrezid": 881212,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -47087,7 +43465,6 @@
   },
   {
     "id": 3623,
-    "entrezid": 881213,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -47100,7 +43477,6 @@
   },
   {
     "id": 3624,
-    "entrezid": 881214,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -47113,7 +43489,6 @@
   },
   {
     "id": 3625,
-    "entrezid": 881215,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47126,7 +43501,6 @@
   },
   {
     "id": 3626,
-    "entrezid": 881216,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47139,7 +43513,6 @@
   },
   {
     "id": 3627,
-    "entrezid": 881217,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47152,7 +43525,6 @@
   },
   {
     "id": 3628,
-    "entrezid": 881218,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47165,7 +43537,6 @@
   },
   {
     "id": 3629,
-    "entrezid": 881219,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47178,7 +43549,6 @@
   },
   {
     "id": 3630,
-    "entrezid": 881220,
     "description": "monovalent cation/H+ antiporter subunit D",
     "aliases": "-",
     "obsolete": false,
@@ -47191,7 +43561,6 @@
   },
   {
     "id": 3631,
-    "entrezid": 881221,
     "description": "glutamate synthase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -47204,7 +43573,6 @@
   },
   {
     "id": 3632,
-    "entrezid": 881222,
     "description": "glutamate synthase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -47217,7 +43585,6 @@
   },
   {
     "id": 3633,
-    "entrezid": 881223,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47230,7 +43597,6 @@
   },
   {
     "id": 3634,
-    "entrezid": 881224,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47243,7 +43609,6 @@
   },
   {
     "id": 3635,
-    "entrezid": 881225,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47256,7 +43621,6 @@
   },
   {
     "id": 3636,
-    "entrezid": 881226,
     "description": "ClpXP protease specificity-enhancing factor",
     "aliases": "-",
     "obsolete": false,
@@ -47269,7 +43633,6 @@
   },
   {
     "id": 3637,
-    "entrezid": 881227,
     "description": "alkaline protease secretion protein AprF",
     "aliases": "-",
     "obsolete": false,
@@ -47282,7 +43645,6 @@
   },
   {
     "id": 3638,
-    "entrezid": 881228,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47295,7 +43657,6 @@
   },
   {
     "id": 3639,
-    "entrezid": 881229,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47308,7 +43669,6 @@
   },
   {
     "id": 3640,
-    "entrezid": 881230,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47321,7 +43681,6 @@
   },
   {
     "id": 3641,
-    "entrezid": 881231,
     "description": "16S ribosomal RNA methyltransferase RsmE",
     "aliases": "-",
     "obsolete": false,
@@ -47334,7 +43693,6 @@
   },
   {
     "id": 3642,
-    "entrezid": 881232,
     "description": "chemotaxis transducer",
     "aliases": "-",
     "obsolete": false,
@@ -47347,7 +43705,6 @@
   },
   {
     "id": 3643,
-    "entrezid": 881233,
     "description": "cell division protein FtsL",
     "aliases": "-",
     "obsolete": false,
@@ -47360,7 +43717,6 @@
   },
   {
     "id": 3644,
-    "entrezid": 881234,
     "description": "sensor/response regulator hybrid protein",
     "aliases": "-",
     "obsolete": false,
@@ -47373,7 +43729,6 @@
   },
   {
     "id": 3645,
-    "entrezid": 881235,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47386,7 +43741,6 @@
   },
   {
     "id": 3646,
-    "entrezid": 881236,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47399,7 +43753,6 @@
   },
   {
     "id": 3647,
-    "entrezid": 881237,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47412,7 +43765,6 @@
   },
   {
     "id": 3648,
-    "entrezid": 881238,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47425,7 +43777,6 @@
   },
   {
     "id": 3649,
-    "entrezid": 881239,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47438,7 +43789,6 @@
   },
   {
     "id": 3650,
-    "entrezid": 881240,
     "description": "peptide methionine sulfoxide reductase",
     "aliases": "-",
     "obsolete": false,
@@ -47451,7 +43801,6 @@
   },
   {
     "id": 3651,
-    "entrezid": 881241,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47464,7 +43813,6 @@
   },
   {
     "id": 3652,
-    "entrezid": 881242,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47477,7 +43825,6 @@
   },
   {
     "id": 3653,
-    "entrezid": 881243,
     "description": "branched-chain amino acid ABC transporter permease BraD",
     "aliases": "-",
     "obsolete": false,
@@ -47490,7 +43837,6 @@
   },
   {
     "id": 3654,
-    "entrezid": 881244,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47503,7 +43849,6 @@
   },
   {
     "id": 3655,
-    "entrezid": 881245,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47516,7 +43861,6 @@
   },
   {
     "id": 3656,
-    "entrezid": 881246,
     "description": "UDP-N-acetylmuramoylalanyl-D-glutamate--2,6-diaminopimelate ligase",
     "aliases": "-",
     "obsolete": false,
@@ -47529,7 +43873,6 @@
   },
   {
     "id": 3657,
-    "entrezid": 881247,
     "description": "penicillin-binding protein 3",
     "aliases": "-",
     "obsolete": false,
@@ -47542,7 +43885,6 @@
   },
   {
     "id": 3658,
-    "entrezid": 881248,
     "description": "alkaline metalloproteinase",
     "aliases": "-",
     "obsolete": false,
@@ -47555,7 +43897,6 @@
   },
   {
     "id": 3659,
-    "entrezid": 881249,
     "description": "malate:quinone oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -47568,7 +43909,6 @@
   },
   {
     "id": 3660,
-    "entrezid": 881250,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -47581,7 +43921,6 @@
   },
   {
     "id": 3661,
-    "entrezid": 881251,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47594,7 +43933,6 @@
   },
   {
     "id": 3662,
-    "entrezid": 881252,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47607,7 +43945,6 @@
   },
   {
     "id": 3663,
-    "entrezid": 881253,
     "description": "3-dehydroquinate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -47620,7 +43957,6 @@
   },
   {
     "id": 3664,
-    "entrezid": 881254,
     "description": "S-adenosyl-methyltransferase MraW",
     "aliases": "-",
     "obsolete": false,
@@ -47633,7 +43969,6 @@
   },
   {
     "id": 3665,
-    "entrezid": 881255,
     "description": "cell division protein MraZ",
     "aliases": "-",
     "obsolete": false,
@@ -47646,7 +43981,6 @@
   },
   {
     "id": 3666,
-    "entrezid": 881256,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47659,7 +43993,6 @@
   },
   {
     "id": 3667,
-    "entrezid": 881257,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47672,7 +44005,6 @@
   },
   {
     "id": 3668,
-    "entrezid": 881258,
     "description": "potassium efflux protein KefA",
     "aliases": "-",
     "obsolete": false,
@@ -47685,7 +44017,6 @@
   },
   {
     "id": 3669,
-    "entrezid": 881259,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47698,7 +44029,6 @@
   },
   {
     "id": 3670,
-    "entrezid": 881260,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47711,7 +44041,6 @@
   },
   {
     "id": 3671,
-    "entrezid": 881261,
     "description": "alkaline proteinase inhibitor AprI",
     "aliases": "-",
     "obsolete": false,
@@ -47724,7 +44053,6 @@
   },
   {
     "id": 3672,
-    "entrezid": 881262,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47737,7 +44065,6 @@
   },
   {
     "id": 3673,
-    "entrezid": 881263,
     "description": "alkaline protease secretion ATP-binding protein AprD",
     "aliases": "-",
     "obsolete": false,
@@ -47750,7 +44077,6 @@
   },
   {
     "id": 3674,
-    "entrezid": 881264,
     "description": "undecaprenyldiphospho-muramoylpentapeptide beta-N- acetylglucosaminyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -47763,7 +44089,6 @@
   },
   {
     "id": 3675,
-    "entrezid": 881265,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47776,7 +44101,6 @@
   },
   {
     "id": 3676,
-    "entrezid": 881266,
     "description": "hypoxanthine-guanine phosphoribosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -47789,7 +44113,6 @@
   },
   {
     "id": 3677,
-    "entrezid": 881267,
     "description": "cell division protein FtsW",
     "aliases": "-",
     "obsolete": false,
@@ -47802,7 +44125,6 @@
   },
   {
     "id": 3678,
-    "entrezid": 881268,
     "description": "UDP-N-acetylmuramoyl-L-alanyl-D-glutamate synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -47815,7 +44137,6 @@
   },
   {
     "id": 3679,
-    "entrezid": 881269,
     "description": "glycosyl hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -47828,7 +44149,6 @@
   },
   {
     "id": 3680,
-    "entrezid": 881270,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47841,7 +44161,6 @@
   },
   {
     "id": 3681,
-    "entrezid": 881271,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -47854,7 +44173,6 @@
   },
   {
     "id": 3682,
-    "entrezid": 881272,
     "description": "sodium/hydrogen antiporter",
     "aliases": "-",
     "obsolete": false,
@@ -47867,7 +44185,6 @@
   },
   {
     "id": 3683,
-    "entrezid": 881273,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47880,7 +44197,6 @@
   },
   {
     "id": 3684,
-    "entrezid": 881274,
     "description": "30S ribosomal protein S9",
     "aliases": "-",
     "obsolete": false,
@@ -47893,7 +44209,6 @@
   },
   {
     "id": 3685,
-    "entrezid": 881275,
     "description": "50S ribosomal protein L13",
     "aliases": "-",
     "obsolete": false,
@@ -47906,7 +44221,6 @@
   },
   {
     "id": 3686,
-    "entrezid": 881276,
     "description": "alkaline protease secretion protein AprE",
     "aliases": "-",
     "obsolete": false,
@@ -47919,7 +44233,6 @@
   },
   {
     "id": 3687,
-    "entrezid": 881277,
     "description": "uracil phosphoribosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -47932,7 +44245,6 @@
   },
   {
     "id": 3688,
-    "entrezid": 881278,
     "description": "uracil permease",
     "aliases": "-",
     "obsolete": false,
@@ -47945,7 +44257,6 @@
   },
   {
     "id": 3689,
-    "entrezid": 881279,
     "description": "AmpG protein",
     "aliases": "-",
     "obsolete": false,
@@ -47958,7 +44269,6 @@
   },
   {
     "id": 3690,
-    "entrezid": 881280,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -47971,7 +44281,6 @@
   },
   {
     "id": 3691,
-    "entrezid": 881281,
     "description": "chemotaxis transducer",
     "aliases": "-",
     "obsolete": false,
@@ -47984,7 +44293,6 @@
   },
   {
     "id": 3692,
-    "entrezid": 881282,
     "description": "D-alanine--D-alanine ligase",
     "aliases": "-",
     "obsolete": false,
@@ -47997,7 +44305,6 @@
   },
   {
     "id": 3693,
-    "entrezid": 881283,
     "description": "UDP-N-acetylmuramate--L-alanine ligase",
     "aliases": "-",
     "obsolete": false,
@@ -48010,7 +44317,6 @@
   },
   {
     "id": 3694,
-    "entrezid": 881284,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48023,7 +44329,6 @@
   },
   {
     "id": 3695,
-    "entrezid": 881285,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48036,7 +44341,6 @@
   },
   {
     "id": 3696,
-    "entrezid": 881286,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48049,7 +44353,6 @@
   },
   {
     "id": 3697,
-    "entrezid": 881287,
     "description": "trans-3-hydroxy-L-proline dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -48062,7 +44365,6 @@
   },
   {
     "id": 3698,
-    "entrezid": 881288,
     "description": "phospho-N-acetylmuramoyl-pentapeptide-transferase",
     "aliases": "-",
     "obsolete": false,
@@ -48075,7 +44377,6 @@
   },
   {
     "id": 3699,
-    "entrezid": 881289,
     "description": "UDP-N-acetylmuramoyl-tripeptide--D-alanyl-D-alanine ligase",
     "aliases": "-",
     "obsolete": false,
@@ -48088,7 +44389,6 @@
   },
   {
     "id": 3700,
-    "entrezid": 881290,
     "description": "bifunctional Delta(1)-pyrroline-2-carboxylate/Delta(1)-piperideine-2-carboxylate reductase",
     "aliases": "-",
     "obsolete": false,
@@ -48101,7 +44401,6 @@
   },
   {
     "id": 3701,
-    "entrezid": 881291,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48114,7 +44413,6 @@
   },
   {
     "id": 3702,
-    "entrezid": 881292,
     "description": "UDP-3-O-[3-hydroxymyristoyl] N-acetylglucosamine deacetylase",
     "aliases": "-",
     "obsolete": false,
@@ -48127,7 +44425,6 @@
   },
   {
     "id": 3703,
-    "entrezid": 881293,
     "description": "alcohol dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -48140,7 +44437,6 @@
   },
   {
     "id": 3704,
-    "entrezid": 881294,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48153,7 +44449,6 @@
   },
   {
     "id": 3705,
-    "entrezid": 881295,
     "description": "pili assembly chaperone",
     "aliases": "-",
     "obsolete": false,
@@ -48166,7 +44461,6 @@
   },
   {
     "id": 3706,
-    "entrezid": 881296,
     "description": "cell division protein FtsZ",
     "aliases": "-",
     "obsolete": false,
@@ -48179,7 +44473,6 @@
   },
   {
     "id": 3707,
-    "entrezid": 881297,
     "description": "dihydrolipoamide acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -48192,7 +44485,6 @@
   },
   {
     "id": 3708,
-    "entrezid": 881298,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48205,7 +44497,6 @@
   },
   {
     "id": 3709,
-    "entrezid": 881299,
     "description": "GTP pyrophosphokinase",
     "aliases": "-",
     "obsolete": false,
@@ -48218,7 +44509,6 @@
   },
   {
     "id": 3710,
-    "entrezid": 881300,
     "description": "amino acid ABC transporter ATP binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -48231,7 +44521,6 @@
   },
   {
     "id": 3711,
-    "entrezid": 881301,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48244,7 +44533,6 @@
   },
   {
     "id": 3712,
-    "entrezid": 881302,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48257,7 +44545,6 @@
   },
   {
     "id": 3713,
-    "entrezid": 881303,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48270,7 +44557,6 @@
   },
   {
     "id": 3714,
-    "entrezid": 881304,
     "description": "glutathione S-transferase",
     "aliases": "-",
     "obsolete": false,
@@ -48283,7 +44569,6 @@
   },
   {
     "id": 3715,
-    "entrezid": 881305,
     "description": "bifunctional ornithine acetyltransferase/N-acetylglutamate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -48296,7 +44581,6 @@
   },
   {
     "id": 3716,
-    "entrezid": 881306,
     "description": "amino acid ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -48309,7 +44593,6 @@
   },
   {
     "id": 3717,
-    "entrezid": 881307,
     "description": "preprotein translocase subunit SecA",
     "aliases": "-",
     "obsolete": false,
@@ -48322,7 +44605,6 @@
   },
   {
     "id": 3718,
-    "entrezid": 881308,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48335,7 +44617,6 @@
   },
   {
     "id": 3719,
-    "entrezid": 881309,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -48348,7 +44629,6 @@
   },
   {
     "id": 3720,
-    "entrezid": 881310,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -48361,7 +44641,6 @@
   },
   {
     "id": 3721,
-    "entrezid": 881311,
     "description": "ferrochelatase",
     "aliases": "-",
     "obsolete": false,
@@ -48374,7 +44653,6 @@
   },
   {
     "id": 3722,
-    "entrezid": 881312,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48387,7 +44665,6 @@
   },
   {
     "id": 3723,
-    "entrezid": 881313,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48400,7 +44677,6 @@
   },
   {
     "id": 3724,
-    "entrezid": 881314,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48413,7 +44689,6 @@
   },
   {
     "id": 3725,
-    "entrezid": 881315,
     "description": "monovalent cation/H+ antiporter subunit A",
     "aliases": "-",
     "obsolete": false,
@@ -48426,7 +44701,6 @@
   },
   {
     "id": 3726,
-    "entrezid": 881316,
     "description": "amino acid ABC transporter substrate-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -48439,7 +44713,6 @@
   },
   {
     "id": 3727,
-    "entrezid": 881317,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48452,7 +44725,6 @@
   },
   {
     "id": 3728,
-    "entrezid": 881318,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48465,7 +44737,6 @@
   },
   {
     "id": 3729,
-    "entrezid": 881319,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48478,7 +44749,6 @@
   },
   {
     "id": 3730,
-    "entrezid": 881320,
     "description": "dihydrodipicolinate synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -48491,7 +44761,6 @@
   },
   {
     "id": 3731,
-    "entrezid": 881321,
     "description": "cell division protein FtsA",
     "aliases": "-",
     "obsolete": false,
@@ -48504,7 +44773,6 @@
   },
   {
     "id": 3732,
-    "entrezid": 881322,
     "description": "cell division protein FtsQ",
     "aliases": "-",
     "obsolete": false,
@@ -48517,7 +44785,6 @@
   },
   {
     "id": 3733,
-    "entrezid": 881323,
     "description": "cardiolipin synthase 2",
     "aliases": "-",
     "obsolete": false,
@@ -48530,7 +44797,6 @@
   },
   {
     "id": 3734,
-    "entrezid": 881324,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -48543,7 +44809,6 @@
   },
   {
     "id": 3735,
-    "entrezid": 881325,
     "description": "bifunctional glutamine-synthetase adenylyltransferase/deadenyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -48556,7 +44821,6 @@
   },
   {
     "id": 3736,
-    "entrezid": 881326,
     "description": "pyruvate dehydrogenase subunit E1",
     "aliases": "-",
     "obsolete": false,
@@ -48569,7 +44833,6 @@
   },
   {
     "id": 3737,
-    "entrezid": 881327,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48582,7 +44845,6 @@
   },
   {
     "id": 3738,
-    "entrezid": 881328,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48595,7 +44857,6 @@
   },
   {
     "id": 3739,
-    "entrezid": 881329,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48608,7 +44869,6 @@
   },
   {
     "id": 3740,
-    "entrezid": 881330,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48621,7 +44881,6 @@
   },
   {
     "id": 3741,
-    "entrezid": 881331,
     "description": "nucleotide-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -48634,7 +44893,6 @@
   },
   {
     "id": 3742,
-    "entrezid": 881332,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -48647,7 +44905,6 @@
   },
   {
     "id": 3743,
-    "entrezid": 881334,
     "description": "phage exclusion suppressor FxsA",
     "aliases": "-",
     "obsolete": false,
@@ -48660,7 +44917,6 @@
   },
   {
     "id": 3744,
-    "entrezid": 881335,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48673,7 +44929,6 @@
   },
   {
     "id": 3745,
-    "entrezid": 881336,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -48686,7 +44941,6 @@
   },
   {
     "id": 3746,
-    "entrezid": 881337,
     "description": "deoxyribodipyrimidine photolyase",
     "aliases": "-",
     "obsolete": false,
@@ -48699,7 +44953,6 @@
   },
   {
     "id": 3747,
-    "entrezid": 881338,
     "description": "3-ketoacyl-ACP reductase",
     "aliases": "-",
     "obsolete": false,
@@ -48712,7 +44965,6 @@
   },
   {
     "id": 3748,
-    "entrezid": 881339,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48725,7 +44977,6 @@
   },
   {
     "id": 3749,
-    "entrezid": 881340,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48738,7 +44989,6 @@
   },
   {
     "id": 3750,
-    "entrezid": 881341,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48751,7 +45001,6 @@
   },
   {
     "id": 3751,
-    "entrezid": 881342,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48764,7 +45013,6 @@
   },
   {
     "id": 3752,
-    "entrezid": 881343,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48777,7 +45025,6 @@
   },
   {
     "id": 3753,
-    "entrezid": 881344,
     "description": "lipid A 3-O-deacylase",
     "aliases": "-",
     "obsolete": false,
@@ -48790,7 +45037,6 @@
   },
   {
     "id": 3754,
-    "entrezid": 881345,
     "description": "glutamate racemase",
     "aliases": "-",
     "obsolete": false,
@@ -48803,7 +45049,6 @@
   },
   {
     "id": 3755,
-    "entrezid": 881346,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48816,7 +45061,6 @@
   },
   {
     "id": 3756,
-    "entrezid": 881347,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -48829,7 +45073,6 @@
   },
   {
     "id": 3757,
-    "entrezid": 881348,
     "description": "molecular chaperone GroEL",
     "aliases": "-",
     "obsolete": false,
@@ -48842,7 +45085,6 @@
   },
   {
     "id": 3758,
-    "entrezid": 881349,
     "description": "co-chaperonin GroES",
     "aliases": "-",
     "obsolete": false,
@@ -48855,7 +45097,6 @@
   },
   {
     "id": 3759,
-    "entrezid": 881350,
     "description": "1,4-alpha-glucan branching protein GlgB",
     "aliases": "-",
     "obsolete": false,
@@ -48868,7 +45109,6 @@
   },
   {
     "id": 3760,
-    "entrezid": 881351,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -48881,7 +45121,6 @@
   },
   {
     "id": 3761,
-    "entrezid": 881352,
     "description": "molybdopterin biosynthesis protein MoeB",
     "aliases": "-",
     "obsolete": false,
@@ -48894,7 +45133,6 @@
   },
   {
     "id": 3762,
-    "entrezid": 881353,
     "description": "methyl transferase",
     "aliases": "-",
     "obsolete": false,
@@ -48907,7 +45145,6 @@
   },
   {
     "id": 3763,
-    "entrezid": 881354,
     "description": "2-dehydropantoate 2-reductase",
     "aliases": "-",
     "obsolete": false,
@@ -48920,7 +45157,6 @@
   },
   {
     "id": 3764,
-    "entrezid": 881355,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -48933,7 +45169,6 @@
   },
   {
     "id": 3765,
-    "entrezid": 881356,
     "description": "trehalose synthase",
     "aliases": "-",
     "obsolete": false,
@@ -48946,7 +45181,6 @@
   },
   {
     "id": 3766,
-    "entrezid": 881357,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -48959,7 +45193,6 @@
   },
   {
     "id": 3767,
-    "entrezid": 881358,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -48972,7 +45205,6 @@
   },
   {
     "id": 3768,
-    "entrezid": 881359,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -48985,7 +45217,6 @@
   },
   {
     "id": 3769,
-    "entrezid": 881360,
     "description": "peptide chain release factor 1",
     "aliases": "-",
     "obsolete": false,
@@ -48998,7 +45229,6 @@
   },
   {
     "id": 3770,
-    "entrezid": 881361,
     "description": "glutamyl-tRNA reductase",
     "aliases": "-",
     "obsolete": false,
@@ -49011,7 +45241,6 @@
   },
   {
     "id": 3771,
-    "entrezid": 881362,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49024,7 +45253,6 @@
   },
   {
     "id": 3772,
-    "entrezid": 881363,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -49037,7 +45265,6 @@
   },
   {
     "id": 3773,
-    "entrezid": 881364,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -49050,7 +45277,6 @@
   },
   {
     "id": 3774,
-    "entrezid": 881365,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49063,7 +45289,6 @@
   },
   {
     "id": 3775,
-    "entrezid": 881366,
     "description": "alpha-1,4-glucan:maltose-1-phosphate maltosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -49076,7 +45301,6 @@
   },
   {
     "id": 3776,
-    "entrezid": 881367,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -49089,7 +45313,6 @@
   },
   {
     "id": 3777,
-    "entrezid": 881368,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49102,7 +45325,6 @@
   },
   {
     "id": 3778,
-    "entrezid": 881369,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49115,7 +45337,6 @@
   },
   {
     "id": 3779,
-    "entrezid": 881370,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49128,7 +45349,6 @@
   },
   {
     "id": 3780,
-    "entrezid": 881371,
     "description": "molecular chaperone LolB",
     "aliases": "-",
     "obsolete": false,
@@ -49141,7 +45361,6 @@
   },
   {
     "id": 3781,
-    "entrezid": 881372,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -49154,7 +45373,6 @@
   },
   {
     "id": 3782,
-    "entrezid": 881373,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49167,7 +45385,6 @@
   },
   {
     "id": 3783,
-    "entrezid": 881374,
     "description": "resistance-nodulation-cell division (RND) efflux membrane fusion protein",
     "aliases": "-",
     "obsolete": false,
@@ -49180,7 +45397,6 @@
   },
   {
     "id": 3784,
-    "entrezid": 881375,
     "description": "non-homologous end joining protein Ku",
     "aliases": "-",
     "obsolete": false,
@@ -49193,7 +45409,6 @@
   },
   {
     "id": 3785,
-    "entrezid": 881376,
     "description": "4-hydroxyproline 2-epimerase",
     "aliases": "-",
     "obsolete": false,
@@ -49206,7 +45421,6 @@
   },
   {
     "id": 3786,
-    "entrezid": 881377,
     "description": "multidrug efflux protein",
     "aliases": "-",
     "obsolete": false,
@@ -49219,7 +45433,6 @@
   },
   {
     "id": 3787,
-    "entrezid": 881378,
     "description": "nicotinate phosphoribosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -49232,7 +45445,6 @@
   },
   {
     "id": 3788,
-    "entrezid": 881379,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49245,7 +45457,6 @@
   },
   {
     "id": 3789,
-    "entrezid": 881380,
     "description": "4-diphosphocytidyl-2C-methyl-D-erythritol kinase",
     "aliases": "-",
     "obsolete": false,
@@ -49258,7 +45469,6 @@
   },
   {
     "id": 3790,
-    "entrezid": 881381,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -49271,7 +45481,6 @@
   },
   {
     "id": 3791,
-    "entrezid": 881382,
     "description": "xenobiotic reductase",
     "aliases": "-",
     "obsolete": false,
@@ -49284,7 +45493,6 @@
   },
   {
     "id": 3792,
-    "entrezid": 881383,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49297,7 +45505,6 @@
   },
   {
     "id": 3793,
-    "entrezid": 881384,
     "description": "cobalamin biosynthesis protein CobD",
     "aliases": "-",
     "obsolete": false,
@@ -49310,7 +45517,6 @@
   },
   {
     "id": 3794,
-    "entrezid": 881385,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49323,7 +45529,6 @@
   },
   {
     "id": 3795,
-    "entrezid": 881386,
     "description": "insulin-cleaving metalloproteinase outer membrane protein",
     "aliases": "-",
     "obsolete": false,
@@ -49336,7 +45541,6 @@
   },
   {
     "id": 3796,
-    "entrezid": 881387,
     "description": "ribose-phosphate pyrophosphokinase",
     "aliases": "-",
     "obsolete": false,
@@ -49349,7 +45553,6 @@
   },
   {
     "id": 3797,
-    "entrezid": 881388,
     "description": "camphor resistance protein CrcB",
     "aliases": "-",
     "obsolete": false,
@@ -49362,7 +45565,6 @@
   },
   {
     "id": 3798,
-    "entrezid": 881389,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49375,7 +45577,6 @@
   },
   {
     "id": 3799,
-    "entrezid": 881390,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49388,7 +45589,6 @@
   },
   {
     "id": 3800,
-    "entrezid": 881391,
     "description": "ATP-dependent DNA helicase Rep",
     "aliases": "-",
     "obsolete": false,
@@ -49401,7 +45601,6 @@
   },
   {
     "id": 3801,
-    "entrezid": 881392,
     "description": "pyruvate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -49414,7 +45613,6 @@
   },
   {
     "id": 3802,
-    "entrezid": 881393,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49427,7 +45625,6 @@
   },
   {
     "id": 3803,
-    "entrezid": 881394,
     "description": "cold-shock protein",
     "aliases": "-",
     "obsolete": false,
@@ -49440,7 +45637,6 @@
   },
   {
     "id": 3804,
-    "entrezid": 881395,
     "description": "50S ribosomal protein L25/general stress protein Ctc",
     "aliases": "-",
     "obsolete": false,
@@ -49453,7 +45649,6 @@
   },
   {
     "id": 3805,
-    "entrezid": 881396,
     "description": "peptidyl-tRNA hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -49466,7 +45661,6 @@
   },
   {
     "id": 3806,
-    "entrezid": 881397,
     "description": "superoxide dismutase",
     "aliases": "-",
     "obsolete": false,
@@ -49479,7 +45673,6 @@
   },
   {
     "id": 3807,
-    "entrezid": 881398,
     "description": "tonB-dependent receptor",
     "aliases": "-",
     "obsolete": false,
@@ -49492,7 +45685,6 @@
   },
   {
     "id": 3808,
-    "entrezid": 881399,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49505,7 +45697,6 @@
   },
   {
     "id": 3809,
-    "entrezid": 881400,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -49518,7 +45709,6 @@
   },
   {
     "id": 3810,
-    "entrezid": 881401,
     "description": "ferrous iron transporter B",
     "aliases": "-",
     "obsolete": false,
@@ -49531,7 +45721,6 @@
   },
   {
     "id": 3811,
-    "entrezid": 881402,
     "description": "ferrous iron transporter A",
     "aliases": "-",
     "obsolete": false,
@@ -49544,7 +45733,6 @@
   },
   {
     "id": 3812,
-    "entrezid": 881403,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49557,7 +45745,6 @@
   },
   {
     "id": 3813,
-    "entrezid": 881404,
     "description": "GTP-dependent nucleic acid-binding protein EngD",
     "aliases": "-",
     "obsolete": false,
@@ -49570,7 +45757,6 @@
   },
   {
     "id": 3814,
-    "entrezid": 881405,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49583,7 +45769,6 @@
   },
   {
     "id": 3815,
-    "entrezid": 881406,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -49596,7 +45781,6 @@
   },
   {
     "id": 3816,
-    "entrezid": 881407,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -49609,7 +45793,6 @@
   },
   {
     "id": 3817,
-    "entrezid": 881408,
     "description": "cob(I)yrinic acid a,c-diamide adenosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -49622,7 +45805,6 @@
   },
   {
     "id": 3818,
-    "entrezid": 881409,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -49635,7 +45817,6 @@
   },
   {
     "id": 3819,
-    "entrezid": 881410,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49648,7 +45829,6 @@
   },
   {
     "id": 3820,
-    "entrezid": 881411,
     "description": "esterase",
     "aliases": "-",
     "obsolete": false,
@@ -49661,7 +45841,6 @@
   },
   {
     "id": 3821,
-    "entrezid": 881412,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49674,7 +45853,6 @@
   },
   {
     "id": 3822,
-    "entrezid": 881413,
     "description": "chromosome replication initiation inhibitor protein",
     "aliases": "-",
     "obsolete": false,
@@ -49687,7 +45865,6 @@
   },
   {
     "id": 3823,
-    "entrezid": 881414,
     "description": "threonine-phosphate decarboxylase",
     "aliases": "-",
     "obsolete": false,
@@ -49700,7 +45877,6 @@
   },
   {
     "id": 3824,
-    "entrezid": 881415,
     "description": "TonB-dependent receptor",
     "aliases": "-",
     "obsolete": false,
@@ -49713,7 +45889,6 @@
   },
   {
     "id": 3825,
-    "entrezid": 881416,
     "description": "carbonic anhydrase",
     "aliases": "-",
     "obsolete": false,
@@ -49726,7 +45901,6 @@
   },
   {
     "id": 3826,
-    "entrezid": 881417,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49739,7 +45913,6 @@
   },
   {
     "id": 3827,
-    "entrezid": 881418,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49752,7 +45925,6 @@
   },
   {
     "id": 3828,
-    "entrezid": 881419,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49765,7 +45937,6 @@
   },
   {
     "id": 3829,
-    "entrezid": 881420,
     "description": "phosphoribosyl transferase",
     "aliases": "-",
     "obsolete": false,
@@ -49778,7 +45949,6 @@
   },
   {
     "id": 3830,
-    "entrezid": 881421,
     "description": "cobyric acid synthase",
     "aliases": "-",
     "obsolete": false,
@@ -49791,7 +45961,6 @@
   },
   {
     "id": 3831,
-    "entrezid": 881422,
     "description": "heptosyltransferase II",
     "aliases": "-",
     "obsolete": false,
@@ -49804,7 +45973,6 @@
   },
   {
     "id": 3832,
-    "entrezid": 881423,
     "description": "branched-chain amino acid aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -49817,7 +45985,6 @@
   },
   {
     "id": 3833,
-    "entrezid": 881424,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49830,7 +45997,6 @@
   },
   {
     "id": 3917,
-    "entrezid": 881508,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49843,7 +46009,6 @@
   },
   {
     "id": 3834,
-    "entrezid": 881425,
     "description": "nicotinate-nucleotide--dimethylbenzimidazole phosphoribosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -49856,7 +46021,6 @@
   },
   {
     "id": 3835,
-    "entrezid": 881426,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49869,7 +46033,6 @@
   },
   {
     "id": 3836,
-    "entrezid": 881427,
     "description": "peptide n-acetyltransferase RimI",
     "aliases": "-",
     "obsolete": false,
@@ -49882,7 +46045,6 @@
   },
   {
     "id": 3837,
-    "entrezid": 881428,
     "description": "protein BifA",
     "aliases": "-",
     "obsolete": false,
@@ -49895,7 +46057,6 @@
   },
   {
     "id": 3838,
-    "entrezid": 881429,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49908,7 +46069,6 @@
   },
   {
     "id": 3839,
-    "entrezid": 881430,
     "description": "5,6-dimethylbenzimidazole synthase",
     "aliases": "-",
     "obsolete": false,
@@ -49921,7 +46081,6 @@
   },
   {
     "id": 3840,
-    "entrezid": 881431,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49934,7 +46093,6 @@
   },
   {
     "id": 3841,
-    "entrezid": 881432,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49947,7 +46105,6 @@
   },
   {
     "id": 3842,
-    "entrezid": 881433,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49960,7 +46117,6 @@
   },
   {
     "id": 3843,
-    "entrezid": 881434,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49973,7 +46129,6 @@
   },
   {
     "id": 3844,
-    "entrezid": 881435,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -49986,7 +46141,6 @@
   },
   {
     "id": 3845,
-    "entrezid": 881436,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -49999,7 +46153,6 @@
   },
   {
     "id": 3846,
-    "entrezid": 881437,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50012,7 +46165,6 @@
   },
   {
     "id": 3847,
-    "entrezid": 881438,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50025,7 +46177,6 @@
   },
   {
     "id": 3848,
-    "entrezid": 881439,
     "description": "adenosylcobinamide-GDP ribazoletransferase",
     "aliases": "-",
     "obsolete": false,
@@ -50038,7 +46189,6 @@
   },
   {
     "id": 3849,
-    "entrezid": 881440,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -50051,7 +46201,6 @@
   },
   {
     "id": 3850,
-    "entrezid": 881441,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50064,7 +46213,6 @@
   },
   {
     "id": 3851,
-    "entrezid": 881442,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -50077,7 +46225,6 @@
   },
   {
     "id": 3852,
-    "entrezid": 881443,
     "description": "bifunctional adenosylcobinamide kinase/adenosylcobinamide-phosphate guanylyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -50090,7 +46237,6 @@
   },
   {
     "id": 3853,
-    "entrezid": 881444,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50103,7 +46249,6 @@
   },
   {
     "id": 3854,
-    "entrezid": 881445,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50116,7 +46261,6 @@
   },
   {
     "id": 3855,
-    "entrezid": 881446,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50129,7 +46273,6 @@
   },
   {
     "id": 3856,
-    "entrezid": 881447,
     "description": "acyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -50142,7 +46285,6 @@
   },
   {
     "id": 3857,
-    "entrezid": 881448,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50155,7 +46297,6 @@
   },
   {
     "id": 3858,
-    "entrezid": 881449,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50168,7 +46309,6 @@
   },
   {
     "id": 3859,
-    "entrezid": 881450,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50181,7 +46321,6 @@
   },
   {
     "id": 3860,
-    "entrezid": 881451,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -50194,7 +46333,6 @@
   },
   {
     "id": 3861,
-    "entrezid": 881452,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50207,7 +46345,6 @@
   },
   {
     "id": 3862,
-    "entrezid": 881453,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50220,7 +46357,6 @@
   },
   {
     "id": 3863,
-    "entrezid": 881454,
     "description": "ferric iron-binding periplasmic protein HitA",
     "aliases": "-",
     "obsolete": false,
@@ -50233,7 +46369,6 @@
   },
   {
     "id": 3864,
-    "entrezid": 881455,
     "description": "semialdehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -50246,7 +46381,6 @@
   },
   {
     "id": 3865,
-    "entrezid": 881456,
     "description": "amidase",
     "aliases": "-",
     "obsolete": false,
@@ -50259,7 +46393,6 @@
   },
   {
     "id": 3866,
-    "entrezid": 881457,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -50272,7 +46405,6 @@
   },
   {
     "id": 3867,
-    "entrezid": 881458,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -50285,7 +46417,6 @@
   },
   {
     "id": 3868,
-    "entrezid": 881459,
     "description": "ATP-dependent RNA helicase DbpA",
     "aliases": "-",
     "obsolete": false,
@@ -50298,7 +46429,6 @@
   },
   {
     "id": 3869,
-    "entrezid": 881460,
     "description": "iron (III)-transporter permease HitB",
     "aliases": "-",
     "obsolete": false,
@@ -50311,7 +46441,6 @@
   },
   {
     "id": 3870,
-    "entrezid": 881461,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50324,7 +46453,6 @@
   },
   {
     "id": 3871,
-    "entrezid": 881462,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -50337,7 +46465,6 @@
   },
   {
     "id": 3872,
-    "entrezid": 881463,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -50350,7 +46477,6 @@
   },
   {
     "id": 3873,
-    "entrezid": 881464,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50363,7 +46489,6 @@
   },
   {
     "id": 3874,
-    "entrezid": 881465,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50376,7 +46501,6 @@
   },
   {
     "id": 3875,
-    "entrezid": 881466,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50389,7 +46513,6 @@
   },
   {
     "id": 3876,
-    "entrezid": 881467,
     "description": "pyridoxine/pyridoxamine 5'-phosphate oxidase",
     "aliases": "-",
     "obsolete": false,
@@ -50402,7 +46525,6 @@
   },
   {
     "id": 3877,
-    "entrezid": 881468,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50415,7 +46537,6 @@
   },
   {
     "id": 3878,
-    "entrezid": 881469,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -50428,7 +46549,6 @@
   },
   {
     "id": 3879,
-    "entrezid": 881470,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50441,7 +46561,6 @@
   },
   {
     "id": 3880,
-    "entrezid": 881471,
     "description": "acyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -50454,7 +46573,6 @@
   },
   {
     "id": 3881,
-    "entrezid": 881472,
     "description": "phospholipase",
     "aliases": "-",
     "obsolete": false,
@@ -50467,7 +46585,6 @@
   },
   {
     "id": 3882,
-    "entrezid": 881473,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50480,7 +46597,6 @@
   },
   {
     "id": 3883,
-    "entrezid": 881474,
     "description": "sulfite oxidase subunit YedZ",
     "aliases": "-",
     "obsolete": false,
@@ -50493,7 +46609,6 @@
   },
   {
     "id": 3884,
-    "entrezid": 881475,
     "description": "sulfite oxidase subunit YedY",
     "aliases": "-",
     "obsolete": false,
@@ -50506,7 +46621,6 @@
   },
   {
     "id": 3885,
-    "entrezid": 881476,
     "description": "oligopeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -50519,7 +46633,6 @@
   },
   {
     "id": 3886,
-    "entrezid": 881477,
     "description": "23S rRNA (uracil(1939)-C(5))-methyltransferase RlmD",
     "aliases": "-",
     "obsolete": false,
@@ -50532,7 +46645,6 @@
   },
   {
     "id": 3887,
-    "entrezid": 881478,
     "description": "glutathione peroxidase",
     "aliases": "-",
     "obsolete": false,
@@ -50545,7 +46657,6 @@
   },
   {
     "id": 3888,
-    "entrezid": 881479,
     "description": "manganese transporter MntH",
     "aliases": "-",
     "obsolete": false,
@@ -50558,7 +46669,6 @@
   },
   {
     "id": 3889,
-    "entrezid": 881480,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50571,7 +46681,6 @@
   },
   {
     "id": 3890,
-    "entrezid": 881481,
     "description": "cytochrome o ubiquinol oxidase subunit I",
     "aliases": "-",
     "obsolete": false,
@@ -50584,7 +46693,6 @@
   },
   {
     "id": 3891,
-    "entrezid": 881482,
     "description": "phosphatidylserine synthase",
     "aliases": "-",
     "obsolete": false,
@@ -50597,7 +46705,6 @@
   },
   {
     "id": 3892,
-    "entrezid": 881483,
     "description": "ketol-acid reductoisomerase",
     "aliases": "-",
     "obsolete": false,
@@ -50610,7 +46717,6 @@
   },
   {
     "id": 3893,
-    "entrezid": 881484,
     "description": "phosphonoacetaldehyde hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -50623,7 +46729,6 @@
   },
   {
     "id": 3894,
-    "entrezid": 881485,
     "description": "3-hydroxyacyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -50636,7 +46741,6 @@
   },
   {
     "id": 3895,
-    "entrezid": 881486,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -50649,7 +46753,6 @@
   },
   {
     "id": 3896,
-    "entrezid": 881487,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50662,7 +46765,6 @@
   },
   {
     "id": 3897,
-    "entrezid": 881488,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50675,7 +46777,6 @@
   },
   {
     "id": 3898,
-    "entrezid": 881489,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50688,7 +46789,6 @@
   },
   {
     "id": 3899,
-    "entrezid": 881490,
     "description": "acetolactate synthase small subunit",
     "aliases": "-",
     "obsolete": false,
@@ -50701,7 +46801,6 @@
   },
   {
     "id": 3900,
-    "entrezid": 881491,
     "description": "2-aminoethylphosphonate--pyruvate transaminase",
     "aliases": "-",
     "obsolete": false,
@@ -50714,7 +46813,6 @@
   },
   {
     "id": 3901,
-    "entrezid": 881492,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50727,7 +46825,6 @@
   },
   {
     "id": 3902,
-    "entrezid": 881493,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50740,7 +46837,6 @@
   },
   {
     "id": 3903,
-    "entrezid": 881494,
     "description": "fumarase",
     "aliases": "-",
     "obsolete": false,
@@ -50753,7 +46849,6 @@
   },
   {
     "id": 3904,
-    "entrezid": 881495,
     "description": "3-mercaptopyruvate sulfurtransferase",
     "aliases": "-",
     "obsolete": false,
@@ -50766,7 +46861,6 @@
   },
   {
     "id": 3905,
-    "entrezid": 881496,
     "description": "acetolactate synthase 3 catalytic subunit",
     "aliases": "-",
     "obsolete": false,
@@ -50779,7 +46873,6 @@
   },
   {
     "id": 3906,
-    "entrezid": 881497,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50792,7 +46885,6 @@
   },
   {
     "id": 3907,
-    "entrezid": 881498,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50805,7 +46897,6 @@
   },
   {
     "id": 3908,
-    "entrezid": 881499,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50818,7 +46909,6 @@
   },
   {
     "id": 3909,
-    "entrezid": 881500,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -50831,7 +46921,6 @@
   },
   {
     "id": 3910,
-    "entrezid": 881501,
     "description": "NADH-quinone oxidoreductase subunit A",
     "aliases": "-",
     "obsolete": false,
@@ -50844,7 +46933,6 @@
   },
   {
     "id": 3911,
-    "entrezid": 881502,
     "description": "enoyl-CoA hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -50857,7 +46945,6 @@
   },
   {
     "id": 3912,
-    "entrezid": 881503,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50870,7 +46957,6 @@
   },
   {
     "id": 3913,
-    "entrezid": 881504,
     "description": "ECF subfamily sigma-70 factor",
     "aliases": "-",
     "obsolete": false,
@@ -50883,7 +46969,6 @@
   },
   {
     "id": 3914,
-    "entrezid": 881505,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50896,7 +46981,6 @@
   },
   {
     "id": 3915,
-    "entrezid": 881506,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50909,7 +46993,6 @@
   },
   {
     "id": 3916,
-    "entrezid": 881507,
     "description": "HIT family protein",
     "aliases": "-",
     "obsolete": false,
@@ -50922,7 +47005,6 @@
   },
   {
     "id": 3918,
-    "entrezid": 881509,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50935,7 +47017,6 @@
   },
   {
     "id": 3919,
-    "entrezid": 881510,
     "description": "metal transporter",
     "aliases": "-",
     "obsolete": false,
@@ -50948,7 +47029,6 @@
   },
   {
     "id": 3920,
-    "entrezid": 881511,
     "description": "penicillin-binding protein 1B",
     "aliases": "-",
     "obsolete": false,
@@ -50961,7 +47041,6 @@
   },
   {
     "id": 3921,
-    "entrezid": 881512,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -50974,7 +47053,6 @@
   },
   {
     "id": 3922,
-    "entrezid": 881513,
     "description": "cytochrome o ubiquinol oxidase subunit II",
     "aliases": "-",
     "obsolete": false,
@@ -50987,7 +47065,6 @@
   },
   {
     "id": 3923,
-    "entrezid": 881514,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51000,7 +47077,6 @@
   },
   {
     "id": 3924,
-    "entrezid": 881515,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51013,7 +47089,6 @@
   },
   {
     "id": 3925,
-    "entrezid": 881516,
     "description": "pyruvate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -51026,7 +47101,6 @@
   },
   {
     "id": 3926,
-    "entrezid": 881517,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51039,7 +47113,6 @@
   },
   {
     "id": 3927,
-    "entrezid": 881518,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51052,7 +47125,6 @@
   },
   {
     "id": 3928,
-    "entrezid": 881519,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51065,7 +47137,6 @@
   },
   {
     "id": 3929,
-    "entrezid": 881520,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51078,7 +47149,6 @@
   },
   {
     "id": 3930,
-    "entrezid": 881521,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51091,7 +47161,6 @@
   },
   {
     "id": 3931,
-    "entrezid": 881522,
     "description": "iron-containing alcohol dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -51104,7 +47173,6 @@
   },
   {
     "id": 3932,
-    "entrezid": 881523,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -51117,7 +47185,6 @@
   },
   {
     "id": 3933,
-    "entrezid": 881524,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51130,7 +47197,6 @@
   },
   {
     "id": 3934,
-    "entrezid": 881525,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51143,7 +47209,6 @@
   },
   {
     "id": 3935,
-    "entrezid": 881526,
     "description": "2-hydroxyacid dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -51156,7 +47221,6 @@
   },
   {
     "id": 3936,
-    "entrezid": 881527,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51169,7 +47233,6 @@
   },
   {
     "id": 3937,
-    "entrezid": 881528,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51182,7 +47245,6 @@
   },
   {
     "id": 3938,
-    "entrezid": 881529,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51195,7 +47257,6 @@
   },
   {
     "id": 3939,
-    "entrezid": 881530,
     "description": "cAMP-binding protein A",
     "aliases": "-",
     "obsolete": false,
@@ -51208,7 +47269,6 @@
   },
   {
     "id": 3940,
-    "entrezid": 881531,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51221,7 +47281,6 @@
   },
   {
     "id": 3941,
-    "entrezid": 881532,
     "description": "UDP-glucose:(heptosyl) LPS alpha 1,3-glucosyltransferase WaaG",
     "aliases": "-",
     "obsolete": false,
@@ -51234,7 +47293,6 @@
   },
   {
     "id": 3942,
-    "entrezid": 881533,
     "description": "heptosyltransferase I",
     "aliases": "-",
     "obsolete": false,
@@ -51247,7 +47305,6 @@
   },
   {
     "id": 3943,
-    "entrezid": 881534,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51260,7 +47317,6 @@
   },
   {
     "id": 3944,
-    "entrezid": 881535,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51273,7 +47329,6 @@
   },
   {
     "id": 3945,
-    "entrezid": 881536,
     "description": "hemin importer ATP-binding subunit",
     "aliases": "-",
     "obsolete": false,
@@ -51286,7 +47341,6 @@
   },
   {
     "id": 3946,
-    "entrezid": 881537,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -51299,7 +47353,6 @@
   },
   {
     "id": 3947,
-    "entrezid": 881538,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -51312,7 +47365,6 @@
   },
   {
     "id": 3948,
-    "entrezid": 881539,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51325,7 +47377,6 @@
   },
   {
     "id": 3949,
-    "entrezid": 881540,
     "description": "lipopolysaccharide kinase WaaP",
     "aliases": "-",
     "obsolete": false,
@@ -51338,7 +47389,6 @@
   },
   {
     "id": 3950,
-    "entrezid": 881541,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51351,7 +47401,6 @@
   },
   {
     "id": 3951,
-    "entrezid": 881542,
     "description": "transcriptional regulator MvaT",
     "aliases": "-",
     "obsolete": false,
@@ -51364,7 +47413,6 @@
   },
   {
     "id": 3952,
-    "entrezid": 881543,
     "description": "heme-transporter PhuT",
     "aliases": "-",
     "obsolete": false,
@@ -51377,7 +47425,6 @@
   },
   {
     "id": 3953,
-    "entrezid": 881544,
     "description": "hemin degrading factor",
     "aliases": "-",
     "obsolete": false,
@@ -51390,7 +47437,6 @@
   },
   {
     "id": 3954,
-    "entrezid": 881545,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51403,7 +47449,6 @@
   },
   {
     "id": 3955,
-    "entrezid": 881546,
     "description": "exonuclease I",
     "aliases": "-",
     "obsolete": false,
@@ -51416,7 +47461,6 @@
   },
   {
     "id": 3956,
-    "entrezid": 881547,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51429,7 +47473,6 @@
   },
   {
     "id": 3957,
-    "entrezid": 881548,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51442,7 +47485,6 @@
   },
   {
     "id": 3958,
-    "entrezid": 881549,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51455,7 +47497,6 @@
   },
   {
     "id": 3959,
-    "entrezid": 881550,
     "description": "heme/hemoglobin uptake outer membrane receptor PhuR",
     "aliases": "-",
     "obsolete": false,
@@ -51468,7 +47509,6 @@
   },
   {
     "id": 3960,
-    "entrezid": 881551,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51481,7 +47521,6 @@
   },
   {
     "id": 3961,
-    "entrezid": 881552,
     "description": "type II secretion system protein TadD",
     "aliases": "-",
     "obsolete": false,
@@ -51494,7 +47533,6 @@
   },
   {
     "id": 3962,
-    "entrezid": 881553,
     "description": "type II secretion system protein TadC",
     "aliases": "-",
     "obsolete": false,
@@ -51507,7 +47545,6 @@
   },
   {
     "id": 3963,
-    "entrezid": 881554,
     "description": "catalase HPII",
     "aliases": "-",
     "obsolete": false,
@@ -51520,7 +47557,6 @@
   },
   {
     "id": 3964,
-    "entrezid": 881555,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51533,7 +47569,6 @@
   },
   {
     "id": 3965,
-    "entrezid": 881556,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51546,7 +47581,6 @@
   },
   {
     "id": 3966,
-    "entrezid": 881557,
     "description": "formyltetrahydrofolate deformylase",
     "aliases": "-",
     "obsolete": false,
@@ -51559,7 +47593,6 @@
   },
   {
     "id": 3967,
-    "entrezid": 881558,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51572,7 +47605,6 @@
   },
   {
     "id": 3968,
-    "entrezid": 881559,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51585,7 +47617,6 @@
   },
   {
     "id": 3969,
-    "entrezid": 881560,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51598,7 +47629,6 @@
   },
   {
     "id": 3970,
-    "entrezid": 881561,
     "description": "signal peptidase",
     "aliases": "-",
     "obsolete": false,
@@ -51611,7 +47641,6 @@
   },
   {
     "id": 3971,
-    "entrezid": 881562,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51624,7 +47653,6 @@
   },
   {
     "id": 3972,
-    "entrezid": 881563,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51637,7 +47665,6 @@
   },
   {
     "id": 3973,
-    "entrezid": 881564,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -51650,7 +47677,6 @@
   },
   {
     "id": 3974,
-    "entrezid": 881565,
     "description": "chemotactic transducer PctA",
     "aliases": "-",
     "obsolete": false,
@@ -51663,7 +47689,6 @@
   },
   {
     "id": 3975,
-    "entrezid": 881566,
     "description": "chemotactic transducer PctB",
     "aliases": "-",
     "obsolete": false,
@@ -51676,7 +47701,6 @@
   },
   {
     "id": 3976,
-    "entrezid": 881567,
     "description": "heme utilization protein",
     "aliases": "-",
     "obsolete": false,
@@ -51689,7 +47713,6 @@
   },
   {
     "id": 3977,
-    "entrezid": 881568,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51702,7 +47725,6 @@
   },
   {
     "id": 3978,
-    "entrezid": 881569,
     "description": "aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -51715,7 +47737,6 @@
   },
   {
     "id": 3979,
-    "entrezid": 881570,
     "description": "transmembrane sensor",
     "aliases": "-",
     "obsolete": false,
@@ -51728,7 +47749,6 @@
   },
   {
     "id": 3980,
-    "entrezid": 881571,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51741,7 +47761,6 @@
   },
   {
     "id": 3981,
-    "entrezid": 881572,
     "description": "type IVb pilin Flp",
     "aliases": "-",
     "obsolete": false,
@@ -51754,7 +47773,6 @@
   },
   {
     "id": 3982,
-    "entrezid": 881573,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51767,7 +47785,6 @@
   },
   {
     "id": 3983,
-    "entrezid": 881574,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51780,7 +47797,6 @@
   },
   {
     "id": 3984,
-    "entrezid": 881575,
     "description": "protoheme IX farnesyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -51793,7 +47809,6 @@
   },
   {
     "id": 3985,
-    "entrezid": 881576,
     "description": "chemotactic transducer PctC",
     "aliases": "-",
     "obsolete": false,
@@ -51806,7 +47821,6 @@
   },
   {
     "id": 3986,
-    "entrezid": 881577,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51819,7 +47833,6 @@
   },
   {
     "id": 3987,
-    "entrezid": 881578,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51832,7 +47845,6 @@
   },
   {
     "id": 3988,
-    "entrezid": 881579,
     "description": "ribonuclease D",
     "aliases": "-",
     "obsolete": false,
@@ -51845,7 +47857,6 @@
   },
   {
     "id": 3989,
-    "entrezid": 881580,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51858,7 +47869,6 @@
   },
   {
     "id": 3990,
-    "entrezid": 881581,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -51871,7 +47881,6 @@
   },
   {
     "id": 3991,
-    "entrezid": 881582,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51884,7 +47893,6 @@
   },
   {
     "id": 3992,
-    "entrezid": 881583,
     "description": "phosphate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -51897,7 +47905,6 @@
   },
   {
     "id": 3993,
-    "entrezid": 881584,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51910,7 +47917,6 @@
   },
   {
     "id": 3994,
-    "entrezid": 881585,
     "description": "TonB-dependent receptor",
     "aliases": "-",
     "obsolete": false,
@@ -51923,7 +47929,6 @@
   },
   {
     "id": 3995,
-    "entrezid": 881586,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51936,7 +47941,6 @@
   },
   {
     "id": 3996,
-    "entrezid": 881587,
     "description": "tRNA (uracil-5-)-methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -51949,7 +47953,6 @@
   },
   {
     "id": 3997,
-    "entrezid": 881588,
     "description": "sugar fermentation stimulation protein A",
     "aliases": "-",
     "obsolete": false,
@@ -51962,7 +47965,6 @@
   },
   {
     "id": 3998,
-    "entrezid": 881589,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51975,7 +47977,6 @@
   },
   {
     "id": 3999,
-    "entrezid": 881590,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -51988,7 +47989,6 @@
   },
   {
     "id": 4000,
-    "entrezid": 881591,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52001,7 +48001,6 @@
   },
   {
     "id": 4001,
-    "entrezid": 881592,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52014,7 +48013,6 @@
   },
   {
     "id": 4002,
-    "entrezid": 881593,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52027,7 +48025,6 @@
   },
   {
     "id": 4003,
-    "entrezid": 881594,
     "description": "suppressor protein DksA",
     "aliases": "-",
     "obsolete": false,
@@ -52040,7 +48037,6 @@
   },
   {
     "id": 4004,
-    "entrezid": 881595,
     "description": "cytochrome o ubiquinol oxidase subunit III",
     "aliases": "-",
     "obsolete": false,
@@ -52053,7 +48049,6 @@
   },
   {
     "id": 4005,
-    "entrezid": 881596,
     "description": "type II secretion system protein TadB",
     "aliases": "-",
     "obsolete": false,
@@ -52066,7 +48061,6 @@
   },
   {
     "id": 4006,
-    "entrezid": 881597,
     "description": "ATPase TadA",
     "aliases": "-",
     "obsolete": false,
@@ -52079,7 +48073,6 @@
   },
   {
     "id": 4007,
-    "entrezid": 881598,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -52092,7 +48085,6 @@
   },
   {
     "id": 4008,
-    "entrezid": 881599,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52105,7 +48097,6 @@
   },
   {
     "id": 4009,
-    "entrezid": 881600,
     "description": "chorismate mutase",
     "aliases": "-",
     "obsolete": false,
@@ -52118,7 +48109,6 @@
   },
   {
     "id": 4010,
-    "entrezid": 881601,
     "description": "glutamyl-Q tRNA(Asp) synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -52131,7 +48121,6 @@
   },
   {
     "id": 4011,
-    "entrezid": 881602,
     "description": "two-component sensor CbrA",
     "aliases": "-",
     "obsolete": false,
@@ -52144,7 +48133,6 @@
   },
   {
     "id": 4012,
-    "entrezid": 881603,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52157,7 +48145,6 @@
   },
   {
     "id": 4013,
-    "entrezid": 881604,
     "description": "cytochrome o ubiquinol oxidase subunit IV",
     "aliases": "-",
     "obsolete": false,
@@ -52170,7 +48157,6 @@
   },
   {
     "id": 4014,
-    "entrezid": 881605,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52183,7 +48169,6 @@
   },
   {
     "id": 4015,
-    "entrezid": 881606,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52196,7 +48181,6 @@
   },
   {
     "id": 4016,
-    "entrezid": 881607,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52209,7 +48193,6 @@
   },
   {
     "id": 4017,
-    "entrezid": 881608,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52222,7 +48205,6 @@
   },
   {
     "id": 4018,
-    "entrezid": 881609,
     "description": "two-component response regulator CbrB",
     "aliases": "-",
     "obsolete": false,
@@ -52235,7 +48217,6 @@
   },
   {
     "id": 4019,
-    "entrezid": 881610,
     "description": "poly(A) polymerase",
     "aliases": "-",
     "obsolete": false,
@@ -52248,7 +48229,6 @@
   },
   {
     "id": 4020,
-    "entrezid": 881611,
     "description": "exonuclease SbcD",
     "aliases": "-",
     "obsolete": false,
@@ -52261,7 +48241,6 @@
   },
   {
     "id": 4021,
-    "entrezid": 881612,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -52274,7 +48253,6 @@
   },
   {
     "id": 4022,
-    "entrezid": 881613,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52287,7 +48265,6 @@
   },
   {
     "id": 4023,
-    "entrezid": 881614,
     "description": "glycosyl transferase family protein",
     "aliases": "-",
     "obsolete": false,
@@ -52300,7 +48277,6 @@
   },
   {
     "id": 4024,
-    "entrezid": 881615,
     "description": "carbamoyl transferase",
     "aliases": "-",
     "obsolete": false,
@@ -52313,7 +48289,6 @@
   },
   {
     "id": 4025,
-    "entrezid": 881616,
     "description": "2-amino-4-hydroxy-6-hydroxymethyldihydropteridine pyrophosphokinase",
     "aliases": "-",
     "obsolete": false,
@@ -52326,7 +48301,6 @@
   },
   {
     "id": 4026,
-    "entrezid": 881617,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52339,7 +48313,6 @@
   },
   {
     "id": 4027,
-    "entrezid": 881618,
     "description": "type II/III secretion system protein",
     "aliases": "-",
     "obsolete": false,
@@ -52352,7 +48325,6 @@
   },
   {
     "id": 4028,
-    "entrezid": 881619,
     "description": "betaine aldehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -52365,7 +48337,6 @@
   },
   {
     "id": 4029,
-    "entrezid": 881620,
     "description": "BetI family transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -52378,7 +48349,6 @@
   },
   {
     "id": 4030,
-    "entrezid": 881621,
     "description": "3-methyl-2-oxobutanoate hydroxymethyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -52391,7 +48361,6 @@
   },
   {
     "id": 4031,
-    "entrezid": 881622,
     "description": "pantoate--beta-alanine ligase",
     "aliases": "-",
     "obsolete": false,
@@ -52404,7 +48373,6 @@
   },
   {
     "id": 4032,
-    "entrezid": 881623,
     "description": "sulfate ABC transporter substrate-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -52417,7 +48385,6 @@
   },
   {
     "id": 4033,
-    "entrezid": 881624,
     "description": "two-component sensor PprA",
     "aliases": "-",
     "obsolete": false,
@@ -52430,7 +48397,6 @@
   },
   {
     "id": 4034,
-    "entrezid": 881625,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52443,7 +48409,6 @@
   },
   {
     "id": 4035,
-    "entrezid": 881626,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -52456,7 +48421,6 @@
   },
   {
     "id": 4036,
-    "entrezid": 881627,
     "description": "phosphate uptake regulatory protein PhoU",
     "aliases": "-",
     "obsolete": false,
@@ -52469,7 +48433,6 @@
   },
   {
     "id": 4037,
-    "entrezid": 881628,
     "description": "phosphate ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -52482,7 +48445,6 @@
   },
   {
     "id": 4038,
-    "entrezid": 881629,
     "description": "phosphate ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -52495,7 +48457,6 @@
   },
   {
     "id": 4039,
-    "entrezid": 881630,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -52508,7 +48469,6 @@
   },
   {
     "id": 4040,
-    "entrezid": 881631,
     "description": "glycolate oxidase subunit GlcD",
     "aliases": "-",
     "obsolete": false,
@@ -52521,7 +48481,6 @@
   },
   {
     "id": 4041,
-    "entrezid": 881632,
     "description": "DNA-binding transcriptional regulator GlcC",
     "aliases": "-",
     "obsolete": false,
@@ -52534,7 +48493,6 @@
   },
   {
     "id": 4042,
-    "entrezid": 881633,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52547,7 +48505,6 @@
   },
   {
     "id": 4043,
-    "entrezid": 881634,
     "description": "exodeoxyribonuclease V subunit gamma",
     "aliases": "-",
     "obsolete": false,
@@ -52560,7 +48517,6 @@
   },
   {
     "id": 4044,
-    "entrezid": 881635,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52573,7 +48529,6 @@
   },
   {
     "id": 4045,
-    "entrezid": 881636,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -52586,7 +48541,6 @@
   },
   {
     "id": 4046,
-    "entrezid": 881637,
     "description": "aspartate alpha-decarboxylase",
     "aliases": "-",
     "obsolete": false,
@@ -52599,7 +48553,6 @@
   },
   {
     "id": 4047,
-    "entrezid": 881638,
     "description": "glucose-6-phosphate isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -52612,7 +48565,6 @@
   },
   {
     "id": 4048,
-    "entrezid": 881639,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -52625,7 +48577,6 @@
   },
   {
     "id": 4049,
-    "entrezid": 881640,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52638,7 +48589,6 @@
   },
   {
     "id": 4050,
-    "entrezid": 881641,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -52651,7 +48601,6 @@
   },
   {
     "id": 4051,
-    "entrezid": 881642,
     "description": "phosphoribosylaminoimidazole-succinocarboxamide synthase",
     "aliases": "-",
     "obsolete": false,
@@ -52664,7 +48613,6 @@
   },
   {
     "id": 4052,
-    "entrezid": 881643,
     "description": "lipolytic protein",
     "aliases": "-",
     "obsolete": false,
@@ -52677,7 +48625,6 @@
   },
   {
     "id": 4053,
-    "entrezid": 881644,
     "description": "carnitine dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -52690,7 +48637,6 @@
   },
   {
     "id": 4054,
-    "entrezid": 881645,
     "description": "3-hydroxybutyryl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -52703,7 +48649,6 @@
   },
   {
     "id": 4055,
-    "entrezid": 881646,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52716,7 +48661,6 @@
   },
   {
     "id": 4056,
-    "entrezid": 881647,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -52729,7 +48673,6 @@
   },
   {
     "id": 4057,
-    "entrezid": 881648,
     "description": "chemotaxis transducer",
     "aliases": "-",
     "obsolete": false,
@@ -52742,7 +48685,6 @@
   },
   {
     "id": 4058,
-    "entrezid": 881649,
     "description": "carbohydrate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -52755,7 +48697,6 @@
   },
   {
     "id": 4059,
-    "entrezid": 881650,
     "description": "acetyl-CoA synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -52768,7 +48709,6 @@
   },
   {
     "id": 4060,
-    "entrezid": 881651,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52781,7 +48721,6 @@
   },
   {
     "id": 4061,
-    "entrezid": 881652,
     "description": "exodeoxyribonuclease V subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -52794,7 +48733,6 @@
   },
   {
     "id": 4062,
-    "entrezid": 881653,
     "description": "exodeoxyribonuclease V subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -52807,7 +48745,6 @@
   },
   {
     "id": 4063,
-    "entrezid": 881654,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52820,7 +48757,6 @@
   },
   {
     "id": 4064,
-    "entrezid": 881655,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52833,7 +48769,6 @@
   },
   {
     "id": 4065,
-    "entrezid": 881656,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52846,7 +48781,6 @@
   },
   {
     "id": 4066,
-    "entrezid": 881657,
     "description": "Flp prepilin peptidase FppA",
     "aliases": "-",
     "obsolete": false,
@@ -52859,7 +48793,6 @@
   },
   {
     "id": 4067,
-    "entrezid": 881658,
     "description": "two-component response regulator PprB",
     "aliases": "-",
     "obsolete": false,
@@ -52872,7 +48805,6 @@
   },
   {
     "id": 4068,
-    "entrezid": 881659,
     "description": "chaperone protein ClpB",
     "aliases": "-",
     "obsolete": false,
@@ -52885,7 +48817,6 @@
   },
   {
     "id": 4069,
-    "entrezid": 881660,
     "description": "ATP-dependent DNA helicase DinG",
     "aliases": "-",
     "obsolete": false,
@@ -52898,7 +48829,6 @@
   },
   {
     "id": 4070,
-    "entrezid": 881661,
     "description": "O-antigen ligase WaaL",
     "aliases": "-",
     "obsolete": false,
@@ -52911,7 +48841,6 @@
   },
   {
     "id": 4071,
-    "entrezid": 881662,
     "description": "alpha-1,3-rhamnosyltransferase WapR",
     "aliases": "-",
     "obsolete": false,
@@ -52924,7 +48853,6 @@
   },
   {
     "id": 4072,
-    "entrezid": 881663,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52937,7 +48865,6 @@
   },
   {
     "id": 4073,
-    "entrezid": 881664,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52950,7 +48877,6 @@
   },
   {
     "id": 4074,
-    "entrezid": 881665,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52963,7 +48889,6 @@
   },
   {
     "id": 4075,
-    "entrezid": 881666,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -52976,7 +48901,6 @@
   },
   {
     "id": 4076,
-    "entrezid": 881667,
     "description": "pantothenate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -52989,7 +48913,6 @@
   },
   {
     "id": 4077,
-    "entrezid": 881668,
     "description": "biotin--protein ligase",
     "aliases": "-",
     "obsolete": false,
@@ -53002,7 +48925,6 @@
   },
   {
     "id": 4078,
-    "entrezid": 881669,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53015,7 +48937,6 @@
   },
   {
     "id": 4079,
-    "entrezid": 881670,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53028,7 +48949,6 @@
   },
   {
     "id": 4080,
-    "entrezid": 881671,
     "description": "polynucleotide phosphorylase",
     "aliases": "-",
     "obsolete": false,
@@ -53041,7 +48961,6 @@
   },
   {
     "id": 4081,
-    "entrezid": 881672,
     "description": "transporter MsbA",
     "aliases": "-",
     "obsolete": false,
@@ -53054,7 +48973,6 @@
   },
   {
     "id": 4082,
-    "entrezid": 881673,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53067,7 +48985,6 @@
   },
   {
     "id": 4083,
-    "entrezid": 881674,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53080,7 +48997,6 @@
   },
   {
     "id": 4084,
-    "entrezid": 881675,
     "description": "30S ribosomal protein S15",
     "aliases": "-",
     "obsolete": false,
@@ -53093,7 +49009,6 @@
   },
   {
     "id": 4085,
-    "entrezid": 881676,
     "description": "tRNA pseudouridine synthase B",
     "aliases": "-",
     "obsolete": false,
@@ -53106,7 +49021,6 @@
   },
   {
     "id": 4086,
-    "entrezid": 881677,
     "description": "dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -53119,7 +49033,6 @@
   },
   {
     "id": 4087,
-    "entrezid": 881678,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -53132,7 +49045,6 @@
   },
   {
     "id": 4088,
-    "entrezid": 881679,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -53145,7 +49057,6 @@
   },
   {
     "id": 4089,
-    "entrezid": 881680,
     "description": "bifunctional heptose 7-phosphate kinase/heptose 1-phosphate adenyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -53158,7 +49069,6 @@
   },
   {
     "id": 4090,
-    "entrezid": 881681,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53171,7 +49081,6 @@
   },
   {
     "id": 4091,
-    "entrezid": 881682,
     "description": "pyruvate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -53184,7 +49093,6 @@
   },
   {
     "id": 4092,
-    "entrezid": 881683,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53197,7 +49105,6 @@
   },
   {
     "id": 4093,
-    "entrezid": 881684,
     "description": "diguanylate cyclase",
     "aliases": "-",
     "obsolete": false,
@@ -53210,7 +49117,6 @@
   },
   {
     "id": 4094,
-    "entrezid": 881685,
     "description": "DNA replication initiation factor",
     "aliases": "-",
     "obsolete": false,
@@ -53223,7 +49129,6 @@
   },
   {
     "id": 4095,
-    "entrezid": 881686,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53236,7 +49141,6 @@
   },
   {
     "id": 4096,
-    "entrezid": 881687,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53249,7 +49153,6 @@
   },
   {
     "id": 4097,
-    "entrezid": 881688,
     "description": "ribosome-binding factor A",
     "aliases": "-",
     "obsolete": false,
@@ -53262,7 +49165,6 @@
   },
   {
     "id": 4098,
-    "entrezid": 881689,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53275,7 +49177,6 @@
   },
   {
     "id": 4099,
-    "entrezid": 881690,
     "description": "exonuclease",
     "aliases": "-",
     "obsolete": false,
@@ -53288,7 +49189,6 @@
   },
   {
     "id": 4100,
-    "entrezid": 881691,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53301,7 +49201,6 @@
   },
   {
     "id": 4101,
-    "entrezid": 881692,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -53314,7 +49213,6 @@
   },
   {
     "id": 4102,
-    "entrezid": 881693,
     "description": "transcription antitermination protein NusG",
     "aliases": "-",
     "obsolete": false,
@@ -53327,7 +49225,6 @@
   },
   {
     "id": 4103,
-    "entrezid": 881694,
     "description": "preprotein translocase subunit SecE",
     "aliases": "-",
     "obsolete": false,
@@ -53340,7 +49237,6 @@
   },
   {
     "id": 4104,
-    "entrezid": 881695,
     "description": "translation initiation factor IF-2",
     "aliases": "-",
     "obsolete": false,
@@ -53353,7 +49249,6 @@
   },
   {
     "id": 4105,
-    "entrezid": 881696,
     "description": "transcription elongation factor NusA",
     "aliases": "-",
     "obsolete": false,
@@ -53366,7 +49261,6 @@
   },
   {
     "id": 4106,
-    "entrezid": 881697,
     "description": "elongation factor Tu",
     "aliases": "-",
     "obsolete": false,
@@ -53379,7 +49273,6 @@
   },
   {
     "id": 4107,
-    "entrezid": 881698,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53392,7 +49285,6 @@
   },
   {
     "id": 4108,
-    "entrezid": 881699,
     "description": "DNA-directed RNA polymerase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -53405,7 +49297,6 @@
   },
   {
     "id": 4109,
-    "entrezid": 881700,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53418,7 +49309,6 @@
   },
   {
     "id": 4110,
-    "entrezid": 881701,
     "description": "50S ribosomal protein L7/L12",
     "aliases": "-",
     "obsolete": false,
@@ -53431,7 +49321,6 @@
   },
   {
     "id": 4111,
-    "entrezid": 881702,
     "description": "50S ribosomal protein L10",
     "aliases": "-",
     "obsolete": false,
@@ -53444,7 +49333,6 @@
   },
   {
     "id": 4112,
-    "entrezid": 881703,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53457,7 +49345,6 @@
   },
   {
     "id": 4113,
-    "entrezid": 881704,
     "description": "50S ribosomal protein L1",
     "aliases": "-",
     "obsolete": false,
@@ -53470,7 +49357,6 @@
   },
   {
     "id": 4114,
-    "entrezid": 881705,
     "description": "50S ribosomal protein L11",
     "aliases": "-",
     "obsolete": false,
@@ -53483,7 +49369,6 @@
   },
   {
     "id": 4115,
-    "entrezid": 881706,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53496,7 +49381,6 @@
   },
   {
     "id": 4116,
-    "entrezid": 881707,
     "description": "preprotein translocase subunit SecG",
     "aliases": "-",
     "obsolete": false,
@@ -53509,7 +49393,6 @@
   },
   {
     "id": 4117,
-    "entrezid": 881708,
     "description": "potassium channel",
     "aliases": "-",
     "obsolete": false,
@@ -53522,7 +49405,6 @@
   },
   {
     "id": 4118,
-    "entrezid": 881709,
     "description": "30S ribosomal protein S12",
     "aliases": "-",
     "obsolete": false,
@@ -53535,7 +49417,6 @@
   },
   {
     "id": 4119,
-    "entrezid": 881710,
     "description": "DNA-directed RNA polymerase subunit beta'",
     "aliases": "-",
     "obsolete": false,
@@ -53548,7 +49429,6 @@
   },
   {
     "id": 4120,
-    "entrezid": 881711,
     "description": "sodium:solute symport protein",
     "aliases": "-",
     "obsolete": false,
@@ -53561,7 +49441,6 @@
   },
   {
     "id": 4121,
-    "entrezid": 881712,
     "description": "triosephosphate isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -53574,7 +49453,6 @@
   },
   {
     "id": 4122,
-    "entrezid": 881713,
     "description": "phosphoglucosamine mutase",
     "aliases": "-",
     "obsolete": false,
@@ -53587,7 +49465,6 @@
   },
   {
     "id": 4123,
-    "entrezid": 881714,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53600,7 +49477,6 @@
   },
   {
     "id": 4124,
-    "entrezid": 881715,
     "description": "dihydropteroate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -53613,7 +49489,6 @@
   },
   {
     "id": 4125,
-    "entrezid": 881716,
     "description": "cell division protein FtsH",
     "aliases": "-",
     "obsolete": false,
@@ -53626,7 +49501,6 @@
   },
   {
     "id": 4126,
-    "entrezid": 881717,
     "description": "30S ribosomal protein S10",
     "aliases": "-",
     "obsolete": false,
@@ -53639,7 +49513,6 @@
   },
   {
     "id": 4127,
-    "entrezid": 881718,
     "description": "elongation factor Tu",
     "aliases": "-",
     "obsolete": false,
@@ -53652,7 +49525,6 @@
   },
   {
     "id": 4128,
-    "entrezid": 881719,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53665,7 +49537,6 @@
   },
   {
     "id": 4129,
-    "entrezid": 881720,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53678,7 +49549,6 @@
   },
   {
     "id": 4130,
-    "entrezid": 881721,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53691,7 +49561,6 @@
   },
   {
     "id": 4131,
-    "entrezid": 881722,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -53704,7 +49573,6 @@
   },
   {
     "id": 4132,
-    "entrezid": 881723,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53717,7 +49585,6 @@
   },
   {
     "id": 4133,
-    "entrezid": 881724,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -53730,7 +49597,6 @@
   },
   {
     "id": 4134,
-    "entrezid": 881725,
     "description": "cell division protein FtsJ",
     "aliases": "-",
     "obsolete": false,
@@ -53743,7 +49609,6 @@
   },
   {
     "id": 4135,
-    "entrezid": 881726,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53756,7 +49621,6 @@
   },
   {
     "id": 4136,
-    "entrezid": 881727,
     "description": "hydrogenobyrinate a,c-diamide synthase",
     "aliases": "-",
     "obsolete": false,
@@ -53769,7 +49633,6 @@
   },
   {
     "id": 4137,
-    "entrezid": 881728,
     "description": "50S ribosomal protein L3",
     "aliases": "-",
     "obsolete": false,
@@ -53782,7 +49645,6 @@
   },
   {
     "id": 4138,
-    "entrezid": 881729,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53795,7 +49657,6 @@
   },
   {
     "id": 4139,
-    "entrezid": 881730,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -53808,7 +49669,6 @@
   },
   {
     "id": 4140,
-    "entrezid": 881731,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -53821,7 +49681,6 @@
   },
   {
     "id": 4141,
-    "entrezid": 881732,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53834,7 +49693,6 @@
   },
   {
     "id": 4142,
-    "entrezid": 881733,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -53847,7 +49705,6 @@
   },
   {
     "id": 4143,
-    "entrezid": 881734,
     "description": "biofilm dispersion protein",
     "aliases": "-",
     "obsolete": false,
@@ -53860,7 +49717,6 @@
   },
   {
     "id": 4144,
-    "entrezid": 881735,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53873,7 +49729,6 @@
   },
   {
     "id": 4145,
-    "entrezid": 881736,
     "description": "transcription elongation factor GreA",
     "aliases": "-",
     "obsolete": false,
@@ -53886,7 +49741,6 @@
   },
   {
     "id": 4146,
-    "entrezid": 881737,
     "description": "amino acid permease",
     "aliases": "-",
     "obsolete": false,
@@ -53899,7 +49753,6 @@
   },
   {
     "id": 4147,
-    "entrezid": 881738,
     "description": "30S ribosomal protein S8",
     "aliases": "-",
     "obsolete": false,
@@ -53912,7 +49765,6 @@
   },
   {
     "id": 4148,
-    "entrezid": 881739,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -53925,7 +49777,6 @@
   },
   {
     "id": 4149,
-    "entrezid": 881740,
     "description": "ADP-ribose diphosphatase NudE",
     "aliases": "-",
     "obsolete": false,
@@ -53938,7 +49789,6 @@
   },
   {
     "id": 4150,
-    "entrezid": 881741,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -53951,7 +49801,6 @@
   },
   {
     "id": 4151,
-    "entrezid": 881742,
     "description": "cytochrome c-type biogenesis protein CycH",
     "aliases": "-",
     "obsolete": false,
@@ -53964,7 +49813,6 @@
   },
   {
     "id": 4152,
-    "entrezid": 881743,
     "description": "carbamoyl phosphate synthase large subunit",
     "aliases": "-",
     "obsolete": false,
@@ -53977,7 +49825,6 @@
   },
   {
     "id": 4153,
-    "entrezid": 881744,
     "description": "elongation factor G",
     "aliases": "-",
     "obsolete": false,
@@ -53990,7 +49837,6 @@
   },
   {
     "id": 4154,
-    "entrezid": 881745,
     "description": "30S ribosomal protein S7",
     "aliases": "-",
     "obsolete": false,
@@ -54003,7 +49849,6 @@
   },
   {
     "id": 4155,
-    "entrezid": 881746,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -54016,7 +49861,6 @@
   },
   {
     "id": 4156,
-    "entrezid": 881747,
     "description": "guanidinobutyrase",
     "aliases": "-",
     "obsolete": false,
@@ -54029,7 +49873,6 @@
   },
   {
     "id": 4157,
-    "entrezid": 881748,
     "description": "30S ribosomal protein S19",
     "aliases": "-",
     "obsolete": false,
@@ -54042,7 +49885,6 @@
   },
   {
     "id": 4158,
-    "entrezid": 881749,
     "description": "50S ribosomal protein L2",
     "aliases": "-",
     "obsolete": false,
@@ -54055,7 +49897,6 @@
   },
   {
     "id": 4159,
-    "entrezid": 881750,
     "description": "leucine export protein LeuE",
     "aliases": "-",
     "obsolete": false,
@@ -54068,7 +49909,6 @@
   },
   {
     "id": 4160,
-    "entrezid": 881751,
     "description": "carbamoyl phosphate synthase small subunit",
     "aliases": "-",
     "obsolete": false,
@@ -54081,7 +49921,6 @@
   },
   {
     "id": 4161,
-    "entrezid": 881752,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -54094,7 +49933,6 @@
   },
   {
     "id": 4162,
-    "entrezid": 881753,
     "description": "50S ribosomal protein L23",
     "aliases": "-",
     "obsolete": false,
@@ -54107,7 +49945,6 @@
   },
   {
     "id": 4163,
-    "entrezid": 881754,
     "description": "50S ribosomal protein L4",
     "aliases": "-",
     "obsolete": false,
@@ -54120,7 +49957,6 @@
   },
   {
     "id": 4164,
-    "entrezid": 881755,
     "description": "acyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -54133,7 +49969,6 @@
   },
   {
     "id": 4165,
-    "entrezid": 881756,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -54146,7 +49981,6 @@
   },
   {
     "id": 4166,
-    "entrezid": 881758,
     "description": "50S ribosomal protein L16",
     "aliases": "-",
     "obsolete": false,
@@ -54159,7 +49993,6 @@
   },
   {
     "id": 4167,
-    "entrezid": 881759,
     "description": "4-hydroxy-tetrahydrodipicolinate reductase",
     "aliases": "-",
     "obsolete": false,
@@ -54172,7 +50005,6 @@
   },
   {
     "id": 4168,
-    "entrezid": 881760,
     "description": "molecular chaperone DnaJ",
     "aliases": "-",
     "obsolete": false,
@@ -54185,7 +50017,6 @@
   },
   {
     "id": 4169,
-    "entrezid": 881761,
     "description": "30S ribosomal protein S3",
     "aliases": "-",
     "obsolete": false,
@@ -54198,7 +50029,6 @@
   },
   {
     "id": 4170,
-    "entrezid": 881762,
     "description": "50S ribosomal protein L22",
     "aliases": "-",
     "obsolete": false,
@@ -54211,7 +50041,6 @@
   },
   {
     "id": 4171,
-    "entrezid": 881763,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -54224,7 +50053,6 @@
   },
   {
     "id": 4172,
-    "entrezid": 881764,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -54237,7 +50065,6 @@
   },
   {
     "id": 4173,
-    "entrezid": 881765,
     "description": "molecular chaperone DnaK",
     "aliases": "-",
     "obsolete": false,
@@ -54250,7 +50077,6 @@
   },
   {
     "id": 4174,
-    "entrezid": 881766,
     "description": "heat shock protein GrpE",
     "aliases": "-",
     "obsolete": false,
@@ -54263,7 +50089,6 @@
   },
   {
     "id": 4175,
-    "entrezid": 881767,
     "description": "50S ribosomal protein L17",
     "aliases": "-",
     "obsolete": false,
@@ -54276,7 +50101,6 @@
   },
   {
     "id": 4176,
-    "entrezid": 881769,
     "description": "protein GbuR",
     "aliases": "-",
     "obsolete": false,
@@ -54289,7 +50113,6 @@
   },
   {
     "id": 4177,
-    "entrezid": 881770,
     "description": "30S ribosomal protein S17",
     "aliases": "-",
     "obsolete": false,
@@ -54302,7 +50125,6 @@
   },
   {
     "id": 4178,
-    "entrezid": 881771,
     "description": "50S ribosomal protein L29",
     "aliases": "-",
     "obsolete": false,
@@ -54315,7 +50137,6 @@
   },
   {
     "id": 4179,
-    "entrezid": 881772,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -54328,7 +50149,6 @@
   },
   {
     "id": 4180,
-    "entrezid": 881773,
     "description": "DNA repair protein RecN",
     "aliases": "-",
     "obsolete": false,
@@ -54341,7 +50161,6 @@
   },
   {
     "id": 4181,
-    "entrezid": 881774,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -54354,7 +50173,6 @@
   },
   {
     "id": 4182,
-    "entrezid": 881775,
     "description": "B-type flagellar hook-associated protein",
     "aliases": "-",
     "obsolete": false,
@@ -54367,7 +50185,6 @@
   },
   {
     "id": 4183,
-    "entrezid": 881776,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -54380,7 +50197,6 @@
   },
   {
     "id": 4184,
-    "entrezid": 881777,
     "description": "acyl-homoserine-lactone synthase",
     "aliases": "-",
     "obsolete": false,
@@ -54393,7 +50209,6 @@
   },
   {
     "id": 4185,
-    "entrezid": 881778,
     "description": "30S ribosomal protein S14",
     "aliases": "-",
     "obsolete": false,
@@ -54406,7 +50221,6 @@
   },
   {
     "id": 4186,
-    "entrezid": 881779,
     "description": "50S ribosomal protein L5",
     "aliases": "-",
     "obsolete": false,
@@ -54419,7 +50233,6 @@
   },
   {
     "id": 4187,
-    "entrezid": 881780,
     "description": "ferric uptake regulation protein",
     "aliases": "-",
     "obsolete": false,
@@ -54432,7 +50245,6 @@
   },
   {
     "id": 4188,
-    "entrezid": 881781,
     "description": "outer membrane lipoprotein OmlA",
     "aliases": "-",
     "obsolete": false,
@@ -54445,7 +50257,6 @@
   },
   {
     "id": 4189,
-    "entrezid": 881782,
     "description": "regulatory protein RsaL",
     "aliases": "-",
     "obsolete": false,
@@ -54458,7 +50269,6 @@
   },
   {
     "id": 4190,
-    "entrezid": 881783,
     "description": "beta-ketoacyl synthase",
     "aliases": "-",
     "obsolete": false,
@@ -54471,7 +50281,6 @@
   },
   {
     "id": 4191,
-    "entrezid": 881784,
     "description": "3'(2'),5'-bisphosphate nucleotidase CysQ",
     "aliases": "-",
     "obsolete": false,
@@ -54484,7 +50293,6 @@
   },
   {
     "id": 4192,
-    "entrezid": 881785,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -54497,7 +50305,6 @@
   },
   {
     "id": 4193,
-    "entrezid": 881786,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -54510,7 +50317,6 @@
   },
   {
     "id": 4194,
-    "entrezid": 881787,
     "description": "50S ribosomal protein L30",
     "aliases": "-",
     "obsolete": false,
@@ -54523,7 +50329,6 @@
   },
   {
     "id": 4195,
-    "entrezid": 881788,
     "description": "30S ribosomal protein S5",
     "aliases": "-",
     "obsolete": false,
@@ -54536,7 +50341,6 @@
   },
   {
     "id": 4196,
-    "entrezid": 881789,
     "description": "transcriptional regulator LasR",
     "aliases": "-",
     "obsolete": false,
@@ -54549,7 +50353,6 @@
   },
   {
     "id": 4197,
-    "entrezid": 881790,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -54562,7 +50365,6 @@
   },
   {
     "id": 4198,
-    "entrezid": 881791,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -54575,7 +50377,6 @@
   },
   {
     "id": 4199,
-    "entrezid": 881792,
     "description": "ornithine carbamoyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -54588,7 +50389,6 @@
   },
   {
     "id": 4200,
-    "entrezid": 881793,
     "description": "carbamate kinase",
     "aliases": "-",
     "obsolete": false,
@@ -54601,7 +50401,6 @@
   },
   {
     "id": 4201,
-    "entrezid": 881794,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -54614,7 +50413,6 @@
   },
   {
     "id": 4202,
-    "entrezid": 881795,
     "description": "50S ribosomal protein L18",
     "aliases": "-",
     "obsolete": false,
@@ -54627,7 +50425,6 @@
   },
   {
     "id": 4203,
-    "entrezid": 881796,
     "description": "50S ribosomal protein L6",
     "aliases": "-",
     "obsolete": false,
@@ -54640,7 +50437,6 @@
   },
   {
     "id": 4204,
-    "entrezid": 881797,
     "description": "SsrA-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -54653,7 +50449,6 @@
   },
   {
     "id": 4205,
-    "entrezid": 881798,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -54666,7 +50461,6 @@
   },
   {
     "id": 4206,
-    "entrezid": 881799,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -54679,7 +50473,6 @@
   },
   {
     "id": 4207,
-    "entrezid": 881800,
     "description": "arginine/ornithine antiporter",
     "aliases": "-",
     "obsolete": false,
@@ -54692,7 +50485,6 @@
   },
   {
     "id": 4208,
-    "entrezid": 881801,
     "description": "arginine deiminase",
     "aliases": "-",
     "obsolete": false,
@@ -54705,7 +50497,6 @@
   },
   {
     "id": 4209,
-    "entrezid": 881802,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -54718,7 +50509,6 @@
   },
   {
     "id": 4210,
-    "entrezid": 881803,
     "description": "cation-transporting P-type ATPase",
     "aliases": "-",
     "obsolete": false,
@@ -54731,7 +50521,6 @@
   },
   {
     "id": 4211,
-    "entrezid": 881804,
     "description": "preprotein translocase subunit SecY",
     "aliases": "-",
     "obsolete": false,
@@ -54744,7 +50533,6 @@
   },
   {
     "id": 4212,
-    "entrezid": 881805,
     "description": "50S ribosomal protein L15",
     "aliases": "-",
     "obsolete": false,
@@ -54757,7 +50545,6 @@
   },
   {
     "id": 4213,
-    "entrezid": 881806,
     "description": "resistance-nodulation-cell division (RND) efflux membrane fusion protein",
     "aliases": "-",
     "obsolete": false,
@@ -54770,7 +50557,6 @@
   },
   {
     "id": 4214,
-    "entrezid": 881807,
     "description": "sensory histidine kinase CreC",
     "aliases": "-",
     "obsolete": false,
@@ -54783,7 +50569,6 @@
   },
   {
     "id": 4215,
-    "entrezid": 881808,
     "description": "L-lactate permease",
     "aliases": "-",
     "obsolete": false,
@@ -54796,7 +50581,6 @@
   },
   {
     "id": 4216,
-    "entrezid": 881809,
     "description": "L-lactate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -54809,7 +50593,6 @@
   },
   {
     "id": 4217,
-    "entrezid": 881810,
     "description": "50S ribosomal protein L24",
     "aliases": "-",
     "obsolete": false,
@@ -54822,7 +50605,6 @@
   },
   {
     "id": 4218,
-    "entrezid": 881811,
     "description": "50S ribosomal protein L14",
     "aliases": "-",
     "obsolete": false,
@@ -54835,7 +50617,6 @@
   },
   {
     "id": 4219,
-    "entrezid": 881812,
     "description": "glycogen phosphorylase",
     "aliases": "-",
     "obsolete": false,
@@ -54848,7 +50629,6 @@
   },
   {
     "id": 4220,
-    "entrezid": 881813,
     "description": "DNA-directed RNA polymerase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -54861,7 +50641,6 @@
   },
   {
     "id": 4221,
-    "entrezid": 881814,
     "description": "30S ribosomal protein S4",
     "aliases": "-",
     "obsolete": false,
@@ -54874,7 +50653,6 @@
   },
   {
     "id": 4222,
-    "entrezid": 881815,
     "description": "resistance-nodulation-cell division (RND) efflux transporter",
     "aliases": "-",
     "obsolete": false,
@@ -54887,7 +50665,6 @@
   },
   {
     "id": 4223,
-    "entrezid": 881816,
     "description": "ferredoxin",
     "aliases": "-",
     "obsolete": false,
@@ -54900,7 +50677,6 @@
   },
   {
     "id": 4224,
-    "entrezid": 881817,
     "description": "30S ribosomal protein S11",
     "aliases": "-",
     "obsolete": false,
@@ -54913,7 +50689,6 @@
   },
   {
     "id": 4225,
-    "entrezid": 881818,
     "description": "30S ribosomal protein S13",
     "aliases": "-",
     "obsolete": false,
@@ -54926,7 +50701,6 @@
   },
   {
     "id": 4226,
-    "entrezid": 881819,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -54939,7 +50713,6 @@
   },
   {
     "id": 4227,
-    "entrezid": 881820,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -54952,7 +50725,6 @@
   },
   {
     "id": 4228,
-    "entrezid": 881821,
     "description": "salicylate biosynthesis isochorismate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -54965,7 +50737,6 @@
   },
   {
     "id": 4229,
-    "entrezid": 881822,
     "description": "single-stranded DNA-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -54978,7 +50749,6 @@
   },
   {
     "id": 4230,
-    "entrezid": 881823,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -54991,7 +50761,6 @@
   },
   {
     "id": 4231,
-    "entrezid": 881824,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55004,7 +50773,6 @@
   },
   {
     "id": 4232,
-    "entrezid": 881825,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55017,7 +50785,6 @@
   },
   {
     "id": 4233,
-    "entrezid": 881826,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -55030,7 +50797,6 @@
   },
   {
     "id": 4234,
-    "entrezid": 881827,
     "description": "excinuclease ABC subunit A",
     "aliases": "-",
     "obsolete": false,
@@ -55043,7 +50809,6 @@
   },
   {
     "id": 4235,
-    "entrezid": 881828,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -55056,7 +50821,6 @@
   },
   {
     "id": 4236,
-    "entrezid": 881829,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55069,7 +50833,6 @@
   },
   {
     "id": 4237,
-    "entrezid": 881830,
     "description": "bacterioferritin",
     "aliases": "-",
     "obsolete": false,
@@ -55082,7 +50845,6 @@
   },
   {
     "id": 4238,
-    "entrezid": 881831,
     "description": "catalase",
     "aliases": "-",
     "obsolete": false,
@@ -55095,7 +50857,6 @@
   },
   {
     "id": 4239,
-    "entrezid": 881832,
     "description": "cysteine synthase B",
     "aliases": "-",
     "obsolete": false,
@@ -55108,7 +50869,6 @@
   },
   {
     "id": 4240,
-    "entrezid": 881833,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55121,7 +50881,6 @@
   },
   {
     "id": 4241,
-    "entrezid": 881834,
     "description": "two-component regulator system response regulator PmrA",
     "aliases": "-",
     "obsolete": false,
@@ -55134,7 +50893,6 @@
   },
   {
     "id": 4242,
-    "entrezid": 881835,
     "description": "pyridoxamine 5'-phosphate oxidase",
     "aliases": "-",
     "obsolete": false,
@@ -55147,7 +50905,6 @@
   },
   {
     "id": 4243,
-    "entrezid": 881836,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55160,7 +50917,6 @@
   },
   {
     "id": 4244,
-    "entrezid": 881837,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55173,7 +50929,6 @@
   },
   {
     "id": 4245,
-    "entrezid": 881838,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55186,7 +50941,6 @@
   },
   {
     "id": 4246,
-    "entrezid": 881839,
     "description": "50S ribosomal protein L36",
     "aliases": "-",
     "obsolete": false,
@@ -55199,7 +50953,6 @@
   },
   {
     "id": 4247,
-    "entrezid": 881840,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55212,7 +50965,6 @@
   },
   {
     "id": 4248,
-    "entrezid": 881841,
     "description": "two-component regulator system signal sensor kinase PmrB",
     "aliases": "-",
     "obsolete": false,
@@ -55225,7 +50977,6 @@
   },
   {
     "id": 4249,
-    "entrezid": 881842,
     "description": "protein CueR",
     "aliases": "-",
     "obsolete": false,
@@ -55238,7 +50989,6 @@
   },
   {
     "id": 4250,
-    "entrezid": 881843,
     "description": "2,4-dihydroxyhept-2-ene-1,7-dioic acid aldolase",
     "aliases": "-",
     "obsolete": false,
@@ -55251,7 +51001,6 @@
   },
   {
     "id": 4251,
-    "entrezid": 881844,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55264,7 +51013,6 @@
   },
   {
     "id": 4252,
-    "entrezid": 881845,
     "description": "pyochelin biosynthetic protein PchC",
     "aliases": "-",
     "obsolete": false,
@@ -55277,7 +51025,6 @@
   },
   {
     "id": 4253,
-    "entrezid": 881846,
     "description": "isochorismate-pyruvate lyase",
     "aliases": "-",
     "obsolete": false,
@@ -55290,7 +51037,6 @@
   },
   {
     "id": 4254,
-    "entrezid": 881847,
     "description": "sulfite/nitrite reductase",
     "aliases": "-",
     "obsolete": false,
@@ -55303,7 +51049,6 @@
   },
   {
     "id": 4255,
-    "entrezid": 881848,
     "description": "iron-sulfur protein",
     "aliases": "-",
     "obsolete": false,
@@ -55316,7 +51061,6 @@
   },
   {
     "id": 4256,
-    "entrezid": 881849,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -55329,7 +51073,6 @@
   },
   {
     "id": 4257,
-    "entrezid": 881850,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55342,7 +51085,6 @@
   },
   {
     "id": 4258,
-    "entrezid": 881851,
     "description": "flagellar motor switch protein FliN",
     "aliases": "-",
     "obsolete": false,
@@ -55355,7 +51097,6 @@
   },
   {
     "id": 4259,
-    "entrezid": 881852,
     "description": "DNA-binding response regulator CreB",
     "aliases": "-",
     "obsolete": false,
@@ -55368,7 +51109,6 @@
   },
   {
     "id": 4260,
-    "entrezid": 881853,
     "description": "flagellar biosynthesis protein FliQ",
     "aliases": "-",
     "obsolete": false,
@@ -55381,7 +51121,6 @@
   },
   {
     "id": 4261,
-    "entrezid": 881854,
     "description": "flagellar protein FliO",
     "aliases": "-",
     "obsolete": false,
@@ -55394,7 +51133,6 @@
   },
   {
     "id": 4262,
-    "entrezid": 881855,
     "description": "flagellar biosynthesis protein FlhB",
     "aliases": "-",
     "obsolete": false,
@@ -55407,7 +51145,6 @@
   },
   {
     "id": 4263,
-    "entrezid": 881856,
     "description": "flagellar basal body protein FliL",
     "aliases": "-",
     "obsolete": false,
@@ -55420,7 +51157,6 @@
   },
   {
     "id": 4264,
-    "entrezid": 881857,
     "description": "serine/threonine protein kinase",
     "aliases": "-",
     "obsolete": false,
@@ -55433,7 +51169,6 @@
   },
   {
     "id": 4265,
-    "entrezid": 881858,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -55446,7 +51181,6 @@
   },
   {
     "id": 4266,
-    "entrezid": 881859,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55459,7 +51193,6 @@
   },
   {
     "id": 4267,
-    "entrezid": 881860,
     "description": "flagellar motor switch protein FliM",
     "aliases": "-",
     "obsolete": false,
@@ -55472,7 +51205,6 @@
   },
   {
     "id": 4268,
-    "entrezid": 881861,
     "description": "flagellar biosynthesis protein FliR",
     "aliases": "-",
     "obsolete": false,
@@ -55485,7 +51217,6 @@
   },
   {
     "id": 4269,
-    "entrezid": 881862,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55498,7 +51229,6 @@
   },
   {
     "id": 4270,
-    "entrezid": 881863,
     "description": "flagellar biosynthesis protein FliP",
     "aliases": "-",
     "obsolete": false,
@@ -55511,7 +51241,6 @@
   },
   {
     "id": 4271,
-    "entrezid": 881864,
     "description": "translocation protein TolB",
     "aliases": "-",
     "obsolete": false,
@@ -55524,7 +51253,6 @@
   },
   {
     "id": 4272,
-    "entrezid": 881865,
     "description": "flagellar biosynthesis regulator FlhF",
     "aliases": "-",
     "obsolete": false,
@@ -55537,7 +51265,6 @@
   },
   {
     "id": 4273,
-    "entrezid": 881866,
     "description": "flagellar synthesis regulator FleN",
     "aliases": "-",
     "obsolete": false,
@@ -55550,7 +51277,6 @@
   },
   {
     "id": 4274,
-    "entrezid": 881867,
     "description": "flagellar biosynthesis protein FlhA",
     "aliases": "-",
     "obsolete": false,
@@ -55563,7 +51289,6 @@
   },
   {
     "id": 4275,
-    "entrezid": 881868,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55576,7 +51301,6 @@
   },
   {
     "id": 4276,
-    "entrezid": 881869,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55589,7 +51313,6 @@
   },
   {
     "id": 4277,
-    "entrezid": 881870,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55602,7 +51325,6 @@
   },
   {
     "id": 4278,
-    "entrezid": 881871,
     "description": "uroporphyrin-III C-methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -55615,7 +51337,6 @@
   },
   {
     "id": 4279,
-    "entrezid": 881872,
     "description": "uracil-DNA glycosylase",
     "aliases": "-",
     "obsolete": false,
@@ -55628,7 +51349,6 @@
   },
   {
     "id": 4280,
-    "entrezid": 881873,
     "description": "phenazine biosynthesis protein PhzD",
     "aliases": "-",
     "obsolete": false,
@@ -55641,7 +51361,6 @@
   },
   {
     "id": 4281,
-    "entrezid": 881875,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55654,7 +51373,6 @@
   },
   {
     "id": 4282,
-    "entrezid": 881876,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55667,7 +51385,6 @@
   },
   {
     "id": 4283,
-    "entrezid": 881877,
     "description": "cytochrome C oxidase subunit I",
     "aliases": "-",
     "obsolete": false,
@@ -55680,7 +51397,6 @@
   },
   {
     "id": 4284,
-    "entrezid": 881878,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55693,7 +51409,6 @@
   },
   {
     "id": 4285,
-    "entrezid": 881879,
     "description": "2-oxoglutarate dehydrogenase subunit E1",
     "aliases": "-",
     "obsolete": false,
@@ -55706,7 +51421,6 @@
   },
   {
     "id": 4286,
-    "entrezid": 881880,
     "description": "succinate dehydrogenase subunit C",
     "aliases": "-",
     "obsolete": false,
@@ -55719,7 +51433,6 @@
   },
   {
     "id": 4287,
-    "entrezid": 881881,
     "description": "glutathione-regulated potassium-efflux system protein KefB",
     "aliases": "-",
     "obsolete": false,
@@ -55732,7 +51445,6 @@
   },
   {
     "id": 4288,
-    "entrezid": 881882,
     "description": "DNA-binding stress protein",
     "aliases": "-",
     "obsolete": false,
@@ -55745,7 +51457,6 @@
   },
   {
     "id": 4289,
-    "entrezid": 881883,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55758,7 +51469,6 @@
   },
   {
     "id": 4290,
-    "entrezid": 881884,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55771,7 +51481,6 @@
   },
   {
     "id": 4291,
-    "entrezid": 881885,
     "description": "AMP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -55784,7 +51493,6 @@
   },
   {
     "id": 4292,
-    "entrezid": 881886,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55797,7 +51505,6 @@
   },
   {
     "id": 4293,
-    "entrezid": 881887,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -55810,7 +51517,6 @@
   },
   {
     "id": 4294,
-    "entrezid": 881888,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55823,7 +51529,6 @@
   },
   {
     "id": 4295,
-    "entrezid": 881889,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55836,7 +51541,6 @@
   },
   {
     "id": 4296,
-    "entrezid": 881890,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55849,7 +51553,6 @@
   },
   {
     "id": 4297,
-    "entrezid": 881891,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55862,7 +51565,6 @@
   },
   {
     "id": 4298,
-    "entrezid": 881892,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55875,7 +51577,6 @@
   },
   {
     "id": 4299,
-    "entrezid": 881893,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -55888,7 +51589,6 @@
   },
   {
     "id": 4300,
-    "entrezid": 881894,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55901,7 +51601,6 @@
   },
   {
     "id": 4301,
-    "entrezid": 881895,
     "description": "D-lactate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -55914,7 +51613,6 @@
   },
   {
     "id": 4302,
-    "entrezid": 881896,
     "description": "B-type flagellar protein FliS",
     "aliases": "-",
     "obsolete": false,
@@ -55927,7 +51625,6 @@
   },
   {
     "id": 4303,
-    "entrezid": 881897,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55940,7 +51637,6 @@
   },
   {
     "id": 4304,
-    "entrezid": 881898,
     "description": "gluconokinase",
     "aliases": "-",
     "obsolete": false,
@@ -55953,7 +51649,6 @@
   },
   {
     "id": 4305,
-    "entrezid": 881899,
     "description": "esterase",
     "aliases": "-",
     "obsolete": false,
@@ -55966,7 +51661,6 @@
   },
   {
     "id": 4306,
-    "entrezid": 881900,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -55979,7 +51673,6 @@
   },
   {
     "id": 4307,
-    "entrezid": 881901,
     "description": "type III export protein PscJ",
     "aliases": "-",
     "obsolete": false,
@@ -55992,7 +51685,6 @@
   },
   {
     "id": 4308,
-    "entrezid": 881902,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56005,7 +51697,6 @@
   },
   {
     "id": 4309,
-    "entrezid": 881903,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56018,7 +51709,6 @@
   },
   {
     "id": 4310,
-    "entrezid": 881904,
     "description": "glycerol-3-phosphate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -56031,7 +51721,6 @@
   },
   {
     "id": 4311,
-    "entrezid": 881905,
     "description": "transposase",
     "aliases": "-",
     "obsolete": false,
@@ -56044,7 +51733,6 @@
   },
   {
     "id": 4312,
-    "entrezid": 881906,
     "description": "sensor/response regulator hybrid protein",
     "aliases": "-",
     "obsolete": false,
@@ -56057,7 +51745,6 @@
   },
   {
     "id": 4313,
-    "entrezid": 881907,
     "description": "4-hydroxybenzoate transporter PcaK",
     "aliases": "-",
     "obsolete": false,
@@ -56070,7 +51757,6 @@
   },
   {
     "id": 4314,
-    "entrezid": 881908,
     "description": "type III export protein PscE",
     "aliases": "-",
     "obsolete": false,
@@ -56083,7 +51769,6 @@
   },
   {
     "id": 4315,
-    "entrezid": 881909,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56096,7 +51781,6 @@
   },
   {
     "id": 4316,
-    "entrezid": 881910,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56109,7 +51793,6 @@
   },
   {
     "id": 4317,
-    "entrezid": 881911,
     "description": "porin",
     "aliases": "-",
     "obsolete": false,
@@ -56122,7 +51805,6 @@
   },
   {
     "id": 4318,
-    "entrezid": 881912,
     "description": "chemotaxis transducer",
     "aliases": "-",
     "obsolete": false,
@@ -56135,7 +51817,6 @@
   },
   {
     "id": 4319,
-    "entrezid": 881913,
     "description": "glutarate-semialdehyde dehydrogenase DavD",
     "aliases": "-",
     "obsolete": false,
@@ -56148,7 +51829,6 @@
   },
   {
     "id": 4320,
-    "entrezid": 881914,
     "description": "signaling protein",
     "aliases": "-",
     "obsolete": false,
@@ -56161,7 +51841,6 @@
   },
   {
     "id": 4321,
-    "entrezid": 881915,
     "description": "4-hydroxythreonine-4-phosphate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -56174,7 +51853,6 @@
   },
   {
     "id": 4322,
-    "entrezid": 881916,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -56187,7 +51865,6 @@
   },
   {
     "id": 4323,
-    "entrezid": 881917,
     "description": "aspartate--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -56200,7 +51877,6 @@
   },
   {
     "id": 4324,
-    "entrezid": 881918,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -56213,7 +51889,6 @@
   },
   {
     "id": 4325,
-    "entrezid": 881919,
     "description": "chemotaxis transducer",
     "aliases": "-",
     "obsolete": false,
@@ -56226,7 +51901,6 @@
   },
   {
     "id": 4326,
-    "entrezid": 881920,
     "description": "glycerophosphoryl diester phosphodiesterase",
     "aliases": "-",
     "obsolete": false,
@@ -56239,7 +51913,6 @@
   },
   {
     "id": 4327,
-    "entrezid": 881921,
     "description": "aldehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -56252,7 +51925,6 @@
   },
   {
     "id": 4328,
-    "entrezid": 881922,
     "description": "sulfate-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -56265,7 +51937,6 @@
   },
   {
     "id": 4329,
-    "entrezid": 881923,
     "description": "succinate dehydrogenase subunit D",
     "aliases": "-",
     "obsolete": false,
@@ -56278,7 +51949,6 @@
   },
   {
     "id": 4330,
-    "entrezid": 881924,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56291,7 +51961,6 @@
   },
   {
     "id": 4331,
-    "entrezid": 881925,
     "description": "3-oxoacyl-ACP synthase",
     "aliases": "-",
     "obsolete": false,
@@ -56304,7 +51973,6 @@
   },
   {
     "id": 4332,
-    "entrezid": 881926,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56317,7 +51985,6 @@
   },
   {
     "id": 4333,
-    "entrezid": 881927,
     "description": "flagellar MS-ring protein",
     "aliases": "-",
     "obsolete": false,
@@ -56330,7 +51997,6 @@
   },
   {
     "id": 4334,
-    "entrezid": 881928,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -56343,7 +52009,6 @@
   },
   {
     "id": 4335,
-    "entrezid": 881929,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56356,7 +52021,6 @@
   },
   {
     "id": 4336,
-    "entrezid": 881930,
     "description": "2-oxoglutarate dehydrogenase complex dihydrolipoyllysine-residue succinyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -56369,7 +52033,6 @@
   },
   {
     "id": 4337,
-    "entrezid": 881931,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -56382,7 +52045,6 @@
   },
   {
     "id": 4338,
-    "entrezid": 881932,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -56395,7 +52057,6 @@
   },
   {
     "id": 4339,
-    "entrezid": 881933,
     "description": "chaperone protein HtpG",
     "aliases": "-",
     "obsolete": false,
@@ -56408,7 +52069,6 @@
   },
   {
     "id": 4340,
-    "entrezid": 881934,
     "description": "succinate dehydrogenase flavoprotein subunit",
     "aliases": "-",
     "obsolete": false,
@@ -56421,7 +52081,6 @@
   },
   {
     "id": 4341,
-    "entrezid": 881935,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -56434,7 +52093,6 @@
   },
   {
     "id": 4342,
-    "entrezid": 881936,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -56447,7 +52105,6 @@
   },
   {
     "id": 4343,
-    "entrezid": 881937,
     "description": "aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -56460,7 +52117,6 @@
   },
   {
     "id": 4344,
-    "entrezid": 881938,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56473,7 +52129,6 @@
   },
   {
     "id": 4345,
-    "entrezid": 881939,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56486,7 +52141,6 @@
   },
   {
     "id": 4346,
-    "entrezid": 881940,
     "description": "cytochrome C oxidase subunit II",
     "aliases": "-",
     "obsolete": false,
@@ -56499,7 +52153,6 @@
   },
   {
     "id": 4347,
-    "entrezid": 881941,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -56512,7 +52165,6 @@
   },
   {
     "id": 4348,
-    "entrezid": 881942,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56525,7 +52177,6 @@
   },
   {
     "id": 4349,
-    "entrezid": 881943,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56538,7 +52189,6 @@
   },
   {
     "id": 4350,
-    "entrezid": 881944,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56551,7 +52201,6 @@
   },
   {
     "id": 4351,
-    "entrezid": 881945,
     "description": "cytochrome C",
     "aliases": "-",
     "obsolete": false,
@@ -56564,7 +52213,6 @@
   },
   {
     "id": 4352,
-    "entrezid": 881946,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -56577,7 +52225,6 @@
   },
   {
     "id": 4353,
-    "entrezid": 881947,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56590,7 +52237,6 @@
   },
   {
     "id": 4354,
-    "entrezid": 881948,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -56603,7 +52249,6 @@
   },
   {
     "id": 4355,
-    "entrezid": 881949,
     "description": "3-hydroxyisobutyrate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -56616,7 +52261,6 @@
   },
   {
     "id": 4356,
-    "entrezid": 881950,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56629,7 +52273,6 @@
   },
   {
     "id": 4357,
-    "entrezid": 881951,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56642,7 +52285,6 @@
   },
   {
     "id": 4358,
-    "entrezid": 881952,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -56655,7 +52297,6 @@
   },
   {
     "id": 4359,
-    "entrezid": 881953,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56668,7 +52309,6 @@
   },
   {
     "id": 4360,
-    "entrezid": 881954,
     "description": "porin",
     "aliases": "-",
     "obsolete": false,
@@ -56681,7 +52321,6 @@
   },
   {
     "id": 4361,
-    "entrezid": 881955,
     "description": "acyl carrier protein",
     "aliases": "-",
     "obsolete": false,
@@ -56694,7 +52333,6 @@
   },
   {
     "id": 4362,
-    "entrezid": 881956,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -56707,7 +52345,6 @@
   },
   {
     "id": 4363,
-    "entrezid": 881957,
     "description": "3-carboxy-cis,cis-muconate cycloisomerase",
     "aliases": "-",
     "obsolete": false,
@@ -56720,7 +52357,6 @@
   },
   {
     "id": 4364,
-    "entrezid": 881958,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56733,7 +52369,6 @@
   },
   {
     "id": 4365,
-    "entrezid": 881959,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56746,7 +52381,6 @@
   },
   {
     "id": 4366,
-    "entrezid": 881960,
     "description": "transcriptional regulator FleQ",
     "aliases": "-",
     "obsolete": false,
@@ -56759,7 +52393,6 @@
   },
   {
     "id": 4367,
-    "entrezid": 881961,
     "description": "TonB-dependent receptor",
     "aliases": "-",
     "obsolete": false,
@@ -56772,7 +52405,6 @@
   },
   {
     "id": 4368,
-    "entrezid": 881962,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56785,7 +52417,6 @@
   },
   {
     "id": 4369,
-    "entrezid": 881963,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56798,7 +52429,6 @@
   },
   {
     "id": 4370,
-    "entrezid": 881964,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56811,7 +52441,6 @@
   },
   {
     "id": 4371,
-    "entrezid": 881965,
     "description": "thioredoxin",
     "aliases": "-",
     "obsolete": false,
@@ -56824,7 +52453,6 @@
   },
   {
     "id": 4372,
-    "entrezid": 881966,
     "description": "quercetin 2,3-dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -56837,7 +52465,6 @@
   },
   {
     "id": 4373,
-    "entrezid": 881967,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -56850,7 +52477,6 @@
   },
   {
     "id": 4374,
-    "entrezid": 881968,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56863,7 +52489,6 @@
   },
   {
     "id": 4375,
-    "entrezid": 881969,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -56876,7 +52501,6 @@
   },
   {
     "id": 4376,
-    "entrezid": 881970,
     "description": "porin D",
     "aliases": "-",
     "obsolete": false,
@@ -56889,7 +52513,6 @@
   },
   {
     "id": 4377,
-    "entrezid": 881971,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56902,7 +52525,6 @@
   },
   {
     "id": 4378,
-    "entrezid": 881972,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56915,7 +52537,6 @@
   },
   {
     "id": 4379,
-    "entrezid": 881973,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56928,7 +52549,6 @@
   },
   {
     "id": 4380,
-    "entrezid": 881974,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -56941,7 +52561,6 @@
   },
   {
     "id": 4381,
-    "entrezid": 881975,
     "description": "lipase",
     "aliases": "-",
     "obsolete": false,
@@ -56954,7 +52573,6 @@
   },
   {
     "id": 4382,
-    "entrezid": 881976,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -56967,7 +52585,6 @@
   },
   {
     "id": 4383,
-    "entrezid": 881977,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -56980,7 +52597,6 @@
   },
   {
     "id": 4384,
-    "entrezid": 881978,
     "description": "type III secretion outer membrane protein PscC",
     "aliases": "-",
     "obsolete": false,
@@ -56993,7 +52609,6 @@
   },
   {
     "id": 4385,
-    "entrezid": 881979,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57006,7 +52621,6 @@
   },
   {
     "id": 4386,
-    "entrezid": 881980,
     "description": "HIT family protein",
     "aliases": "-",
     "obsolete": false,
@@ -57019,7 +52633,6 @@
   },
   {
     "id": 4387,
-    "entrezid": 881981,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57032,7 +52645,6 @@
   },
   {
     "id": 4388,
-    "entrezid": 881982,
     "description": "type III export protein PscG",
     "aliases": "-",
     "obsolete": false,
@@ -57045,7 +52657,6 @@
   },
   {
     "id": 4389,
-    "entrezid": 881983,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57058,7 +52669,6 @@
   },
   {
     "id": 4390,
-    "entrezid": 881984,
     "description": "3-hydroxydecanoyl-ACP dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -57071,7 +52681,6 @@
   },
   {
     "id": 4391,
-    "entrezid": 881985,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57084,7 +52693,6 @@
   },
   {
     "id": 4392,
-    "entrezid": 881986,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57097,7 +52705,6 @@
   },
   {
     "id": 4393,
-    "entrezid": 881987,
     "description": "DNA polymerase IV",
     "aliases": "-",
     "obsolete": false,
@@ -57110,7 +52717,6 @@
   },
   {
     "id": 4394,
-    "entrezid": 881988,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -57123,7 +52729,6 @@
   },
   {
     "id": 4395,
-    "entrezid": 881989,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57136,7 +52741,6 @@
   },
   {
     "id": 4396,
-    "entrezid": 881990,
     "description": "2-methylcitrate dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -57149,7 +52753,6 @@
   },
   {
     "id": 4397,
-    "entrezid": 881991,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -57162,7 +52765,6 @@
   },
   {
     "id": 4398,
-    "entrezid": 881992,
     "description": "phospholipid methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -57175,7 +52777,6 @@
   },
   {
     "id": 4399,
-    "entrezid": 881993,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57188,7 +52789,6 @@
   },
   {
     "id": 4400,
-    "entrezid": 881994,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57201,7 +52801,6 @@
   },
   {
     "id": 4401,
-    "entrezid": 881995,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57214,7 +52813,6 @@
   },
   {
     "id": 4402,
-    "entrezid": 881996,
     "description": "flagellar biosynthesis sigma factor FliA",
     "aliases": "-",
     "obsolete": false,
@@ -57227,7 +52825,6 @@
   },
   {
     "id": 4403,
-    "entrezid": 881997,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -57240,7 +52837,6 @@
   },
   {
     "id": 4404,
-    "entrezid": 881998,
     "description": "elongation factor 4",
     "aliases": "-",
     "obsolete": false,
@@ -57253,7 +52849,6 @@
   },
   {
     "id": 4405,
-    "entrezid": 881999,
     "description": "arsenate reductase",
     "aliases": "-",
     "obsolete": false,
@@ -57266,7 +52861,6 @@
   },
   {
     "id": 4406,
-    "entrezid": 882000,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57279,7 +52873,6 @@
   },
   {
     "id": 4407,
-    "entrezid": 882001,
     "description": "cytochrome C oxidase subunit III",
     "aliases": "-",
     "obsolete": false,
@@ -57292,7 +52885,6 @@
   },
   {
     "id": 4408,
-    "entrezid": 882002,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57305,7 +52897,6 @@
   },
   {
     "id": 4409,
-    "entrezid": 882003,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -57318,7 +52909,6 @@
   },
   {
     "id": 4410,
-    "entrezid": 882004,
     "description": "N-acetyl-gamma-glutamyl-phosphate reductase",
     "aliases": "-",
     "obsolete": false,
@@ -57331,7 +52921,6 @@
   },
   {
     "id": 4411,
-    "entrezid": 882005,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57344,7 +52933,6 @@
   },
   {
     "id": 4412,
-    "entrezid": 882006,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57357,7 +52945,6 @@
   },
   {
     "id": 4413,
-    "entrezid": 882007,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57370,7 +52957,6 @@
   },
   {
     "id": 4414,
-    "entrezid": 882008,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57383,7 +52969,6 @@
   },
   {
     "id": 4415,
-    "entrezid": 882009,
     "description": "cytochrome C oxidase assembly protein",
     "aliases": "-",
     "obsolete": false,
@@ -57396,7 +52981,6 @@
   },
   {
     "id": 4416,
-    "entrezid": 882010,
     "description": "flagellum-specific ATP synthase",
     "aliases": "-",
     "obsolete": false,
@@ -57409,7 +52993,6 @@
   },
   {
     "id": 4417,
-    "entrezid": 882011,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -57422,7 +53005,6 @@
   },
   {
     "id": 4418,
-    "entrezid": 882012,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57435,7 +53017,6 @@
   },
   {
     "id": 4419,
-    "entrezid": 882013,
     "description": "cold-shock protein",
     "aliases": "-",
     "obsolete": false,
@@ -57448,7 +53029,6 @@
   },
   {
     "id": 4420,
-    "entrezid": 882014,
     "description": "bacteriophage integrase",
     "aliases": "-",
     "obsolete": false,
@@ -57461,7 +53041,6 @@
   },
   {
     "id": 4421,
-    "entrezid": 882015,
     "description": "streptomycin 3''-phosphotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -57474,7 +53053,6 @@
   },
   {
     "id": 4422,
-    "entrezid": 882016,
     "description": "succinyl-CoA ligase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -57487,7 +53065,6 @@
   },
   {
     "id": 4423,
-    "entrezid": 882017,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57500,7 +53077,6 @@
   },
   {
     "id": 4424,
-    "entrezid": 882018,
     "description": "amidotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -57513,7 +53089,6 @@
   },
   {
     "id": 4425,
-    "entrezid": 882019,
     "description": "molybdenum ABC transporter ATP-binding protein ModC",
     "aliases": "-",
     "obsolete": false,
@@ -57526,7 +53101,6 @@
   },
   {
     "id": 4426,
-    "entrezid": 882020,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57539,7 +53113,6 @@
   },
   {
     "id": 4427,
-    "entrezid": 882021,
     "description": "NAD(P)H dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -57552,7 +53125,6 @@
   },
   {
     "id": 4428,
-    "entrezid": 882022,
     "description": "acylphosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -57565,7 +53137,6 @@
   },
   {
     "id": 4429,
-    "entrezid": 882023,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -57578,7 +53149,6 @@
   },
   {
     "id": 4430,
-    "entrezid": 882024,
     "description": "thioredoxin reductase",
     "aliases": "-",
     "obsolete": false,
@@ -57591,7 +53161,6 @@
   },
   {
     "id": 4431,
-    "entrezid": 882025,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -57604,7 +53173,6 @@
   },
   {
     "id": 4432,
-    "entrezid": 882026,
     "description": "2-methylisocitrate lyase",
     "aliases": "-",
     "obsolete": false,
@@ -57617,7 +53185,6 @@
   },
   {
     "id": 4433,
-    "entrezid": 882027,
     "description": "aconitate hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -57630,7 +53197,6 @@
   },
   {
     "id": 4434,
-    "entrezid": 882028,
     "description": "Holliday junction ATP-dependent DNA helicase RuvB",
     "aliases": "-",
     "obsolete": false,
@@ -57643,7 +53209,6 @@
   },
   {
     "id": 4435,
-    "entrezid": 882029,
     "description": "phenazine biosynthesis protein PhzE",
     "aliases": "-",
     "obsolete": false,
@@ -57656,7 +53221,6 @@
   },
   {
     "id": 4436,
-    "entrezid": 882030,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -57669,7 +53233,6 @@
   },
   {
     "id": 4437,
-    "entrezid": 882031,
     "description": "flagellar hook-basal body complex protein FliE",
     "aliases": "-",
     "obsolete": false,
@@ -57682,7 +53245,6 @@
   },
   {
     "id": 4438,
-    "entrezid": 882032,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57695,7 +53257,6 @@
   },
   {
     "id": 4439,
-    "entrezid": 882033,
     "description": "translocation protein TolA",
     "aliases": "-",
     "obsolete": false,
@@ -57708,7 +53269,6 @@
   },
   {
     "id": 4440,
-    "entrezid": 882034,
     "description": "succinate dehydrogenase iron-sulfur subunit",
     "aliases": "-",
     "obsolete": false,
@@ -57721,7 +53281,6 @@
   },
   {
     "id": 4441,
-    "entrezid": 882035,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -57734,7 +53293,6 @@
   },
   {
     "id": 4442,
-    "entrezid": 882036,
     "description": "FMN-dependent NADH-azoreductase AzoR",
     "aliases": "-",
     "obsolete": false,
@@ -57747,7 +53305,6 @@
   },
   {
     "id": 4443,
-    "entrezid": 882037,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -57760,7 +53317,6 @@
   },
   {
     "id": 4444,
-    "entrezid": 882038,
     "description": "RNA polymerase sigma factor RpoD",
     "aliases": "-",
     "obsolete": false,
@@ -57773,7 +53329,6 @@
   },
   {
     "id": 4445,
-    "entrezid": 882039,
     "description": "succinyl-CoA ligase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -57786,7 +53341,6 @@
   },
   {
     "id": 4446,
-    "entrezid": 882040,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57799,7 +53353,6 @@
   },
   {
     "id": 4447,
-    "entrezid": 882041,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57812,7 +53365,6 @@
   },
   {
     "id": 4448,
-    "entrezid": 882042,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57825,7 +53377,6 @@
   },
   {
     "id": 4449,
-    "entrezid": 882043,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -57838,7 +53389,6 @@
   },
   {
     "id": 4450,
-    "entrezid": 882044,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57851,7 +53401,6 @@
   },
   {
     "id": 4451,
-    "entrezid": 882045,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57864,7 +53413,6 @@
   },
   {
     "id": 4452,
-    "entrezid": 882046,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57877,7 +53425,6 @@
   },
   {
     "id": 4453,
-    "entrezid": 882047,
     "description": "DNA primase",
     "aliases": "-",
     "obsolete": false,
@@ -57890,7 +53437,6 @@
   },
   {
     "id": 4454,
-    "entrezid": 882048,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57903,7 +53449,6 @@
   },
   {
     "id": 4455,
-    "entrezid": 882049,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57916,7 +53461,6 @@
   },
   {
     "id": 4456,
-    "entrezid": 882050,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -57929,7 +53473,6 @@
   },
   {
     "id": 4457,
-    "entrezid": 882051,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57942,7 +53485,6 @@
   },
   {
     "id": 4458,
-    "entrezid": 882052,
     "description": "B-type flagellin",
     "aliases": "-",
     "obsolete": false,
@@ -57955,7 +53497,6 @@
   },
   {
     "id": 4459,
-    "entrezid": 882053,
     "description": "phospho-2-dehydro-3-deoxyheptonate aldolase",
     "aliases": "-",
     "obsolete": false,
@@ -57968,7 +53509,6 @@
   },
   {
     "id": 4460,
-    "entrezid": 882054,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -57981,7 +53521,6 @@
   },
   {
     "id": 4461,
-    "entrezid": 882055,
     "description": "translocation protein TolQ",
     "aliases": "-",
     "obsolete": false,
@@ -57994,7 +53533,6 @@
   },
   {
     "id": 4462,
-    "entrezid": 882056,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58007,7 +53545,6 @@
   },
   {
     "id": 4463,
-    "entrezid": 882057,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -58020,7 +53557,6 @@
   },
   {
     "id": 4464,
-    "entrezid": 882058,
     "description": "plasmid partitioning protein",
     "aliases": "-",
     "obsolete": false,
@@ -58033,7 +53569,6 @@
   },
   {
     "id": 4465,
-    "entrezid": 882059,
     "description": "cis-aconitate porin OpdH",
     "aliases": "-",
     "obsolete": false,
@@ -58046,7 +53581,6 @@
   },
   {
     "id": 4466,
-    "entrezid": 882060,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -58059,7 +53593,6 @@
   },
   {
     "id": 4467,
-    "entrezid": 882061,
     "description": "phenazine biosynthesis protein PhzC",
     "aliases": "-",
     "obsolete": false,
@@ -58072,7 +53605,6 @@
   },
   {
     "id": 4468,
-    "entrezid": 882062,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58085,7 +53617,6 @@
   },
   {
     "id": 4469,
-    "entrezid": 882063,
     "description": "ribosomal protein alanine acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -58098,7 +53629,6 @@
   },
   {
     "id": 4470,
-    "entrezid": 882064,
     "description": "sigma factor AlgU regulator MucB",
     "aliases": "-",
     "obsolete": false,
@@ -58111,7 +53641,6 @@
   },
   {
     "id": 4471,
-    "entrezid": 882065,
     "description": "molybdenum ABC transporter permease ModB",
     "aliases": "-",
     "obsolete": false,
@@ -58124,7 +53653,6 @@
   },
   {
     "id": 4472,
-    "entrezid": 882066,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58137,7 +53665,6 @@
   },
   {
     "id": 4473,
-    "entrezid": 882067,
     "description": "L-aspartate oxidase",
     "aliases": "-",
     "obsolete": false,
@@ -58150,7 +53677,6 @@
   },
   {
     "id": 4474,
-    "entrezid": 882068,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58163,7 +53689,6 @@
   },
   {
     "id": 4475,
-    "entrezid": 882069,
     "description": "SDS hydrolase SdsA1",
     "aliases": "-",
     "obsolete": false,
@@ -58176,7 +53701,6 @@
   },
   {
     "id": 4476,
-    "entrezid": 882070,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -58189,7 +53713,6 @@
   },
   {
     "id": 4477,
-    "entrezid": 882071,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58202,7 +53725,6 @@
   },
   {
     "id": 4478,
-    "entrezid": 882072,
     "description": "anhydro-N-acetylmuramic acid kinase",
     "aliases": "-",
     "obsolete": false,
@@ -58215,7 +53737,6 @@
   },
   {
     "id": 4479,
-    "entrezid": 882073,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58228,7 +53749,6 @@
   },
   {
     "id": 4480,
-    "entrezid": 882074,
     "description": "flagellar motor switch protein FliG",
     "aliases": "-",
     "obsolete": false,
@@ -58241,7 +53761,6 @@
   },
   {
     "id": 4481,
-    "entrezid": 882076,
     "description": "haloacid dehalogenase",
     "aliases": "-",
     "obsolete": false,
@@ -58254,7 +53773,6 @@
   },
   {
     "id": 4482,
-    "entrezid": 882077,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58267,7 +53785,6 @@
   },
   {
     "id": 4483,
-    "entrezid": 882078,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -58280,7 +53797,6 @@
   },
   {
     "id": 4484,
-    "entrezid": 882079,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58293,7 +53809,6 @@
   },
   {
     "id": 4485,
-    "entrezid": 882080,
     "description": "purine-binding chemotaxis protein",
     "aliases": "-",
     "obsolete": false,
@@ -58306,7 +53821,6 @@
   },
   {
     "id": 4486,
-    "entrezid": 882081,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -58319,7 +53833,6 @@
   },
   {
     "id": 4487,
-    "entrezid": 882082,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58332,7 +53845,6 @@
   },
   {
     "id": 4488,
-    "entrezid": 882083,
     "description": "branched-chain amino acid transporter",
     "aliases": "-",
     "obsolete": false,
@@ -58345,7 +53857,6 @@
   },
   {
     "id": 4489,
-    "entrezid": 882084,
     "description": "chemotaxis-specific methylesterase",
     "aliases": "-",
     "obsolete": false,
@@ -58358,7 +53869,6 @@
   },
   {
     "id": 4490,
-    "entrezid": 882085,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58371,7 +53881,6 @@
   },
   {
     "id": 4491,
-    "entrezid": 882086,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -58384,7 +53893,6 @@
   },
   {
     "id": 4492,
-    "entrezid": 882087,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -58397,7 +53905,6 @@
   },
   {
     "id": 4493,
-    "entrezid": 882088,
     "description": "quercetin 2,3-dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -58410,7 +53917,6 @@
   },
   {
     "id": 4494,
-    "entrezid": 882089,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58423,7 +53929,6 @@
   },
   {
     "id": 4495,
-    "entrezid": 882090,
     "description": "2-oxoglutarate dehydrogenase complex dihydrolipoyl dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -58436,7 +53941,6 @@
   },
   {
     "id": 4496,
-    "entrezid": 882091,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58449,7 +53953,6 @@
   },
   {
     "id": 4497,
-    "entrezid": 882092,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58462,7 +53965,6 @@
   },
   {
     "id": 4498,
-    "entrezid": 882093,
     "description": "phosphoglycolate phosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -58475,7 +53977,6 @@
   },
   {
     "id": 4499,
-    "entrezid": 882094,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58488,7 +53989,6 @@
   },
   {
     "id": 4500,
-    "entrezid": 882095,
     "description": "aldehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -58501,7 +54001,6 @@
   },
   {
     "id": 4501,
-    "entrezid": 882097,
     "description": "chemotaxis protein CheY",
     "aliases": "-",
     "obsolete": false,
@@ -58514,7 +54013,6 @@
   },
   {
     "id": 4502,
-    "entrezid": 882098,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58527,7 +54025,6 @@
   },
   {
     "id": 4503,
-    "entrezid": 882099,
     "description": "phospholipase C accessory protein PlcR",
     "aliases": "-",
     "obsolete": false,
@@ -58540,7 +54037,6 @@
   },
   {
     "id": 4504,
-    "entrezid": 882100,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58553,7 +54049,6 @@
   },
   {
     "id": 4505,
-    "entrezid": 882101,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58566,7 +54061,6 @@
   },
   {
     "id": 4506,
-    "entrezid": 882103,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58579,7 +54073,6 @@
   },
   {
     "id": 4507,
-    "entrezid": 882104,
     "description": "signal peptidase I",
     "aliases": "-",
     "obsolete": false,
@@ -58592,7 +54085,6 @@
   },
   {
     "id": 4508,
-    "entrezid": 882105,
     "description": "glycosyl transferase family protein",
     "aliases": "-",
     "obsolete": false,
@@ -58605,7 +54097,6 @@
   },
   {
     "id": 4509,
-    "entrezid": 882106,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58618,7 +54109,6 @@
   },
   {
     "id": 4510,
-    "entrezid": 882107,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -58631,7 +54121,6 @@
   },
   {
     "id": 4511,
-    "entrezid": 882108,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58644,7 +54133,6 @@
   },
   {
     "id": 4512,
-    "entrezid": 882109,
     "description": "cbb3-type cytochrome C oxidase subunit I",
     "aliases": "-",
     "obsolete": false,
@@ -58657,7 +54145,6 @@
   },
   {
     "id": 4513,
-    "entrezid": 882110,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58670,7 +54157,6 @@
   },
   {
     "id": 4514,
-    "entrezid": 882111,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58683,7 +54169,6 @@
   },
   {
     "id": 4515,
-    "entrezid": 882112,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58696,7 +54181,6 @@
   },
   {
     "id": 4516,
-    "entrezid": 882113,
     "description": "translocation protein TolR",
     "aliases": "-",
     "obsolete": false,
@@ -58709,7 +54193,6 @@
   },
   {
     "id": 4517,
-    "entrezid": 882114,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58722,7 +54205,6 @@
   },
   {
     "id": 4518,
-    "entrezid": 882115,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58735,7 +54217,6 @@
   },
   {
     "id": 4519,
-    "entrezid": 882116,
     "description": "4-carboxymuconolactone decarboxylase",
     "aliases": "-",
     "obsolete": false,
@@ -58748,7 +54229,6 @@
   },
   {
     "id": 4520,
-    "entrezid": 882117,
     "description": "citrate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -58761,7 +54241,6 @@
   },
   {
     "id": 4521,
-    "entrezid": 882118,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58774,7 +54253,6 @@
   },
   {
     "id": 4522,
-    "entrezid": 882119,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58787,7 +54265,6 @@
   },
   {
     "id": 4523,
-    "entrezid": 882120,
     "description": "indole-3-glycerol phosphate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -58800,7 +54277,6 @@
   },
   {
     "id": 4524,
-    "entrezid": 882121,
     "description": "epoxide hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -58813,7 +54289,6 @@
   },
   {
     "id": 4525,
-    "entrezid": 882122,
     "description": "acyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -58826,7 +54301,6 @@
   },
   {
     "id": 4526,
-    "entrezid": 882123,
     "description": "phosphate acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -58839,7 +54313,6 @@
   },
   {
     "id": 4527,
-    "entrezid": 882124,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58852,7 +54325,6 @@
   },
   {
     "id": 4528,
-    "entrezid": 882125,
     "description": "RNA polymerase sigma factor AlgU",
     "aliases": "-",
     "obsolete": false,
@@ -58865,7 +54337,6 @@
   },
   {
     "id": 4529,
-    "entrezid": 882126,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58878,7 +54349,6 @@
   },
   {
     "id": 4530,
-    "entrezid": 882127,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58891,7 +54361,6 @@
   },
   {
     "id": 4531,
-    "entrezid": 882128,
     "description": "4-hydroxybenzoate 3-monooxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -58904,7 +54373,6 @@
   },
   {
     "id": 4532,
-    "entrezid": 882129,
     "description": "enoyl-CoA hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -58917,7 +54385,6 @@
   },
   {
     "id": 4533,
-    "entrezid": 882130,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58930,7 +54397,6 @@
   },
   {
     "id": 4534,
-    "entrezid": 882131,
     "description": "crossover junction endodeoxyribonuclease RuvC",
     "aliases": "-",
     "obsolete": false,
@@ -58943,7 +54409,6 @@
   },
   {
     "id": 4535,
-    "entrezid": 882132,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -58956,7 +54421,6 @@
   },
   {
     "id": 4536,
-    "entrezid": 882133,
     "description": "NAD(P)H-dependent FMN reductase",
     "aliases": "-",
     "obsolete": false,
@@ -58969,7 +54433,6 @@
   },
   {
     "id": 4537,
-    "entrezid": 882134,
     "description": "resistance-nodulation-cell division (RND) efflux membrane fusion protein",
     "aliases": "-",
     "obsolete": false,
@@ -58982,7 +54445,6 @@
   },
   {
     "id": 4538,
-    "entrezid": 882135,
     "description": "NAD-dependent L-serine dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -58995,7 +54457,6 @@
   },
   {
     "id": 4539,
-    "entrezid": 882136,
     "description": "transcriptional regulator PcaR",
     "aliases": "-",
     "obsolete": false,
@@ -59008,7 +54469,6 @@
   },
   {
     "id": 4540,
-    "entrezid": 882137,
     "description": "3-methyl-2-oxobutanoate hydroxymethyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -59021,7 +54481,6 @@
   },
   {
     "id": 4541,
-    "entrezid": 882138,
     "description": "cobaltochelatase subunit CobN",
     "aliases": "-",
     "obsolete": false,
@@ -59034,7 +54493,6 @@
   },
   {
     "id": 4542,
-    "entrezid": 882139,
     "description": "ribonuclease III",
     "aliases": "-",
     "obsolete": false,
@@ -59047,7 +54505,6 @@
   },
   {
     "id": 4543,
-    "entrezid": 882140,
     "description": "resistance-nodulation-cell division (RND) efflux transporter",
     "aliases": "-",
     "obsolete": false,
@@ -59060,7 +54517,6 @@
   },
   {
     "id": 4544,
-    "entrezid": 882141,
     "description": "dimethylglycine catabolism protein DgcB",
     "aliases": "-",
     "obsolete": false,
@@ -59073,7 +54529,6 @@
   },
   {
     "id": 4545,
-    "entrezid": 882142,
     "description": "electron transfer flavoprotein subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -59086,7 +54541,6 @@
   },
   {
     "id": 4546,
-    "entrezid": 882143,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59099,7 +54553,6 @@
   },
   {
     "id": 4547,
-    "entrezid": 882144,
     "description": "ABC transporter ATP-binding protein/permease",
     "aliases": "-",
     "obsolete": false,
@@ -59112,7 +54565,6 @@
   },
   {
     "id": 4548,
-    "entrezid": 882145,
     "description": "protocatechuate 3,4-dioxygenase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -59125,7 +54577,6 @@
   },
   {
     "id": 4549,
-    "entrezid": 882146,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59138,7 +54589,6 @@
   },
   {
     "id": 4550,
-    "entrezid": 882147,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59151,7 +54601,6 @@
   },
   {
     "id": 4551,
-    "entrezid": 882148,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59164,7 +54613,6 @@
   },
   {
     "id": 4552,
-    "entrezid": 882149,
     "description": "resistance-nodulation-cell division (RND) efflux membrane fusion protein",
     "aliases": "-",
     "obsolete": false,
@@ -59177,7 +54625,6 @@
   },
   {
     "id": 4553,
-    "entrezid": 882150,
     "description": "3-oxoadipate enol-lactonase",
     "aliases": "-",
     "obsolete": false,
@@ -59190,7 +54637,6 @@
   },
   {
     "id": 4554,
-    "entrezid": 882151,
     "description": "ABC transporter ATP-binding protein/permease",
     "aliases": "-",
     "obsolete": false,
@@ -59203,7 +54649,6 @@
   },
   {
     "id": 4555,
-    "entrezid": 882152,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59216,7 +54661,6 @@
   },
   {
     "id": 4556,
-    "entrezid": 882153,
     "description": "transcriptional regulator PmpR",
     "aliases": "-",
     "obsolete": false,
@@ -59229,7 +54673,6 @@
   },
   {
     "id": 4557,
-    "entrezid": 882154,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59242,7 +54685,6 @@
   },
   {
     "id": 4558,
-    "entrezid": 882155,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59255,7 +54697,6 @@
   },
   {
     "id": 4559,
-    "entrezid": 882156,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59268,7 +54709,6 @@
   },
   {
     "id": 4560,
-    "entrezid": 882157,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59281,7 +54721,6 @@
   },
   {
     "id": 4561,
-    "entrezid": 882158,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -59294,7 +54733,6 @@
   },
   {
     "id": 4562,
-    "entrezid": 882159,
     "description": "3-dehydroquinate dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -59307,7 +54745,6 @@
   },
   {
     "id": 4563,
-    "entrezid": 882160,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59320,7 +54757,6 @@
   },
   {
     "id": 4564,
-    "entrezid": 882161,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59333,7 +54769,6 @@
   },
   {
     "id": 4565,
-    "entrezid": 882162,
     "description": "flagellar motor protein",
     "aliases": "-",
     "obsolete": false,
@@ -59346,7 +54781,6 @@
   },
   {
     "id": 4566,
-    "entrezid": 882163,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59359,7 +54793,6 @@
   },
   {
     "id": 4567,
-    "entrezid": 882164,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59372,7 +54805,6 @@
   },
   {
     "id": 4568,
-    "entrezid": 882165,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59385,7 +54817,6 @@
   },
   {
     "id": 4569,
-    "entrezid": 882166,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59398,7 +54829,6 @@
   },
   {
     "id": 4570,
-    "entrezid": 882167,
     "description": "L-ornithine N5-oxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -59411,7 +54841,6 @@
   },
   {
     "id": 4571,
-    "entrezid": 882168,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59424,7 +54853,6 @@
   },
   {
     "id": 4572,
-    "entrezid": 882169,
     "description": "arylamine N-acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -59437,7 +54865,6 @@
   },
   {
     "id": 4573,
-    "entrezid": 882170,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -59450,7 +54877,6 @@
   },
   {
     "id": 4574,
-    "entrezid": 882171,
     "description": "ribose-5-phosphate isomerase A",
     "aliases": "-",
     "obsolete": false,
@@ -59463,7 +54889,6 @@
   },
   {
     "id": 4575,
-    "entrezid": 882172,
     "description": "anaerobic ribonucleoside triphosphate reductase",
     "aliases": "-",
     "obsolete": false,
@@ -59476,7 +54901,6 @@
   },
   {
     "id": 4576,
-    "entrezid": 882173,
     "description": "penicillin-binding protein 3A",
     "aliases": "-",
     "obsolete": false,
@@ -59489,7 +54913,6 @@
   },
   {
     "id": 4577,
-    "entrezid": 882174,
     "description": "thiol:disulfide interchange protein",
     "aliases": "-",
     "obsolete": false,
@@ -59502,7 +54925,6 @@
   },
   {
     "id": 4578,
-    "entrezid": 882175,
     "description": "thiol:disulfide interchange protein DsbD",
     "aliases": "-",
     "obsolete": false,
@@ -59515,7 +54937,6 @@
   },
   {
     "id": 4579,
-    "entrezid": 882176,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -59528,7 +54949,6 @@
   },
   {
     "id": 4580,
-    "entrezid": 882177,
     "description": "benzoylformate decarboxylase",
     "aliases": "-",
     "obsolete": false,
@@ -59541,7 +54961,6 @@
   },
   {
     "id": 4581,
-    "entrezid": 882178,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -59554,7 +54973,6 @@
   },
   {
     "id": 4582,
-    "entrezid": 882179,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59567,7 +54985,6 @@
   },
   {
     "id": 4583,
-    "entrezid": 882180,
     "description": "transcriptional regulator Dnr",
     "aliases": "-",
     "obsolete": false,
@@ -59580,7 +54997,6 @@
   },
   {
     "id": 4584,
-    "entrezid": 882181,
     "description": "TonB-dependent receptor",
     "aliases": "-",
     "obsolete": false,
@@ -59593,7 +55009,6 @@
   },
   {
     "id": 4585,
-    "entrezid": 882182,
     "description": "hydrogen cyanide synthase subunit HcnB",
     "aliases": "-",
     "obsolete": false,
@@ -59606,7 +55021,6 @@
   },
   {
     "id": 4586,
-    "entrezid": 882183,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59619,7 +55033,6 @@
   },
   {
     "id": 4587,
-    "entrezid": 882184,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59632,7 +55045,6 @@
   },
   {
     "id": 4588,
-    "entrezid": 882185,
     "description": "urease subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -59645,7 +55057,6 @@
   },
   {
     "id": 4589,
-    "entrezid": 882186,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59658,7 +55069,6 @@
   },
   {
     "id": 4590,
-    "entrezid": 882187,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59671,7 +55081,6 @@
   },
   {
     "id": 4591,
-    "entrezid": 882188,
     "description": "pyoverdine biosynthesis protein PvdO",
     "aliases": "-",
     "obsolete": false,
@@ -59684,7 +55093,6 @@
   },
   {
     "id": 4592,
-    "entrezid": 882189,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59697,7 +55105,6 @@
   },
   {
     "id": 4593,
-    "entrezid": 882190,
     "description": "denitrification protein NorD",
     "aliases": "-",
     "obsolete": false,
@@ -59710,7 +55117,6 @@
   },
   {
     "id": 4594,
-    "entrezid": 882191,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59723,7 +55129,6 @@
   },
   {
     "id": 4595,
-    "entrezid": 882192,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -59736,7 +55141,6 @@
   },
   {
     "id": 4596,
-    "entrezid": 882193,
     "description": "nitric oxide reductase subunit B",
     "aliases": "-",
     "obsolete": false,
@@ -59749,7 +55153,6 @@
   },
   {
     "id": 4597,
-    "entrezid": 882194,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -59762,7 +55165,6 @@
   },
   {
     "id": 4598,
-    "entrezid": 882195,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -59775,7 +55177,6 @@
   },
   {
     "id": 4599,
-    "entrezid": 882196,
     "description": "hydrogen cyanide synthase subunit HcnC",
     "aliases": "-",
     "obsolete": false,
@@ -59788,7 +55189,6 @@
   },
   {
     "id": 4600,
-    "entrezid": 882197,
     "description": "hydrogen cyanide synthase subunit HcnA",
     "aliases": "-",
     "obsolete": false,
@@ -59801,7 +55201,6 @@
   },
   {
     "id": 4601,
-    "entrezid": 882198,
     "description": "heme d1 biosynthesis protein NirF",
     "aliases": "-",
     "obsolete": false,
@@ -59814,7 +55213,6 @@
   },
   {
     "id": 4602,
-    "entrezid": 882199,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -59827,7 +55225,6 @@
   },
   {
     "id": 4603,
-    "entrezid": 882200,
     "description": "nitric oxide reductase subunit C",
     "aliases": "-",
     "obsolete": false,
@@ -59840,7 +55237,6 @@
   },
   {
     "id": 4604,
-    "entrezid": 882201,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59853,7 +55249,6 @@
   },
   {
     "id": 4605,
-    "entrezid": 882202,
     "description": "pyoverdine biosynthesis protein PvdN",
     "aliases": "-",
     "obsolete": false,
@@ -59866,7 +55261,6 @@
   },
   {
     "id": 4606,
-    "entrezid": 882203,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59879,7 +55273,6 @@
   },
   {
     "id": 4607,
-    "entrezid": 882204,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59892,7 +55285,6 @@
   },
   {
     "id": 4608,
-    "entrezid": 882205,
     "description": "arginine/ornithine ABC transporter permease AotQ",
     "aliases": "-",
     "obsolete": false,
@@ -59905,7 +55297,6 @@
   },
   {
     "id": 4609,
-    "entrezid": 882206,
     "description": "cytochrome C oxidase subunit",
     "aliases": "-",
     "obsolete": false,
@@ -59918,7 +55309,6 @@
   },
   {
     "id": 4610,
-    "entrezid": 882207,
     "description": "glutaminase-asparaginase",
     "aliases": "-",
     "obsolete": false,
@@ -59931,7 +55321,6 @@
   },
   {
     "id": 4611,
-    "entrezid": 882208,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -59944,7 +55333,6 @@
   },
   {
     "id": 4612,
-    "entrezid": 882209,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59957,7 +55345,6 @@
   },
   {
     "id": 4613,
-    "entrezid": 882210,
     "description": "urease subunit gamma",
     "aliases": "-",
     "obsolete": false,
@@ -59970,7 +55357,6 @@
   },
   {
     "id": 4614,
-    "entrezid": 882211,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -59983,7 +55369,6 @@
   },
   {
     "id": 4615,
-    "entrezid": 882212,
     "description": "nicotinate phosphoribosyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -59996,7 +55381,6 @@
   },
   {
     "id": 4616,
-    "entrezid": 882213,
     "description": "NAD synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -60009,7 +55393,6 @@
   },
   {
     "id": 4617,
-    "entrezid": 882214,
     "description": "denitrification regulatory protein NirQ",
     "aliases": "-",
     "obsolete": false,
@@ -60022,7 +55405,6 @@
   },
   {
     "id": 4618,
-    "entrezid": 882215,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60035,7 +55417,6 @@
   },
   {
     "id": 4619,
-    "entrezid": 882216,
     "description": "dipeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -60048,7 +55429,6 @@
   },
   {
     "id": 4620,
-    "entrezid": 882217,
     "description": "nitrite reductase",
     "aliases": "-",
     "obsolete": false,
@@ -60061,7 +55441,6 @@
   },
   {
     "id": 4621,
-    "entrezid": 882218,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -60074,7 +55453,6 @@
   },
   {
     "id": 4622,
-    "entrezid": 882219,
     "description": "aerotaxis transducer Aer2",
     "aliases": "-",
     "obsolete": false,
@@ -60087,7 +55465,6 @@
   },
   {
     "id": 4623,
-    "entrezid": 882220,
     "description": "cytochrome C-551",
     "aliases": "-",
     "obsolete": false,
@@ -60100,7 +55477,6 @@
   },
   {
     "id": 4624,
-    "entrezid": 882221,
     "description": "prolipoprotein diacylglyceryl transferase",
     "aliases": "-",
     "obsolete": false,
@@ -60113,7 +55489,6 @@
   },
   {
     "id": 4625,
-    "entrezid": 882222,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60126,7 +55501,6 @@
   },
   {
     "id": 4626,
-    "entrezid": 882223,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60139,7 +55513,6 @@
   },
   {
     "id": 4627,
-    "entrezid": 882224,
     "description": "pyoverdine biosynthesis protein PvdP",
     "aliases": "-",
     "obsolete": false,
@@ -60152,7 +55525,6 @@
   },
   {
     "id": 4628,
-    "entrezid": 882225,
     "description": "4-hydroxyphenylpyruvate dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -60165,7 +55537,6 @@
   },
   {
     "id": 4629,
-    "entrezid": 882226,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -60178,7 +55549,6 @@
   },
   {
     "id": 4630,
-    "entrezid": 882227,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60191,7 +55561,6 @@
   },
   {
     "id": 4631,
-    "entrezid": 882228,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60204,7 +55573,6 @@
   },
   {
     "id": 4632,
-    "entrezid": 882229,
     "description": "N-formylglutamate amidohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -60217,7 +55585,6 @@
   },
   {
     "id": 4633,
-    "entrezid": 882230,
     "description": "amino acid ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -60230,7 +55597,6 @@
   },
   {
     "id": 4634,
-    "entrezid": 882231,
     "description": "ABC transporter ATP-binding protein/permease",
     "aliases": "-",
     "obsolete": false,
@@ -60243,7 +55609,6 @@
   },
   {
     "id": 4635,
-    "entrezid": 882232,
     "description": "phosphoenolpyruvate-protein phosphotransferase PtsP",
     "aliases": "-",
     "obsolete": false,
@@ -60256,7 +55621,6 @@
   },
   {
     "id": 4636,
-    "entrezid": 882233,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60269,7 +55633,6 @@
   },
   {
     "id": 4637,
-    "entrezid": 882234,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -60282,7 +55645,6 @@
   },
   {
     "id": 4638,
-    "entrezid": 882235,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60295,7 +55657,6 @@
   },
   {
     "id": 4639,
-    "entrezid": 882236,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60308,7 +55669,6 @@
   },
   {
     "id": 4640,
-    "entrezid": 882237,
     "description": "pyoverdine biosynthesis protein PvdT",
     "aliases": "-",
     "obsolete": false,
@@ -60321,7 +55681,6 @@
   },
   {
     "id": 4641,
-    "entrezid": 882238,
     "description": "lysozyme inhibitor",
     "aliases": "-",
     "obsolete": false,
@@ -60334,7 +55693,6 @@
   },
   {
     "id": 4642,
-    "entrezid": 882240,
     "description": "fructose-1,6-bisphosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -60347,7 +55705,6 @@
   },
   {
     "id": 4643,
-    "entrezid": 882241,
     "description": "lactoylglutathione lyase",
     "aliases": "-",
     "obsolete": false,
@@ -60360,7 +55717,6 @@
   },
   {
     "id": 4644,
-    "entrezid": 882242,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60373,7 +55729,6 @@
   },
   {
     "id": 4645,
-    "entrezid": 882243,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60386,7 +55741,6 @@
   },
   {
     "id": 4646,
-    "entrezid": 882244,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60399,7 +55753,6 @@
   },
   {
     "id": 4647,
-    "entrezid": 882245,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60412,7 +55765,6 @@
   },
   {
     "id": 4648,
-    "entrezid": 882246,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60425,7 +55777,6 @@
   },
   {
     "id": 4649,
-    "entrezid": 882247,
     "description": "arginine/ornithine ABC transporter ATP-binding protein AotP",
     "aliases": "-",
     "obsolete": false,
@@ -60438,7 +55789,6 @@
   },
   {
     "id": 4650,
-    "entrezid": 882248,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60451,7 +55801,6 @@
   },
   {
     "id": 4651,
-    "entrezid": 882249,
     "description": "RNA polymerase sigma factor",
     "aliases": "-",
     "obsolete": false,
@@ -60464,7 +55813,6 @@
   },
   {
     "id": 4652,
-    "entrezid": 882250,
     "description": "aromatic amino acid transporter AroP",
     "aliases": "-",
     "obsolete": false,
@@ -60477,7 +55825,6 @@
   },
   {
     "id": 4653,
-    "entrezid": 882251,
     "description": "biofilm formation protein PslJ",
     "aliases": "-",
     "obsolete": false,
@@ -60490,7 +55837,6 @@
   },
   {
     "id": 4654,
-    "entrezid": 882252,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60503,7 +55849,6 @@
   },
   {
     "id": 4655,
-    "entrezid": 882253,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60516,7 +55861,6 @@
   },
   {
     "id": 4656,
-    "entrezid": 882254,
     "description": "dihydrolipoamide dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -60529,7 +55873,6 @@
   },
   {
     "id": 4657,
-    "entrezid": 882255,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60542,7 +55885,6 @@
   },
   {
     "id": 4658,
-    "entrezid": 882256,
     "description": "chemotaxis response regulator protein-glutamate methylesterase",
     "aliases": "-",
     "obsolete": false,
@@ -60555,7 +55897,6 @@
   },
   {
     "id": 4659,
-    "entrezid": 882257,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60568,7 +55909,6 @@
   },
   {
     "id": 4660,
-    "entrezid": 882258,
     "description": "protein FpvR",
     "aliases": "-",
     "obsolete": false,
@@ -60581,7 +55921,6 @@
   },
   {
     "id": 4661,
-    "entrezid": 882259,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60594,7 +55933,6 @@
   },
   {
     "id": 4662,
-    "entrezid": 882260,
     "description": "acyl-homoserine lactone acylase PvdQ",
     "aliases": "-",
     "obsolete": false,
@@ -60607,7 +55945,6 @@
   },
   {
     "id": 4663,
-    "entrezid": 882261,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60620,7 +55957,6 @@
   },
   {
     "id": 4664,
-    "entrezid": 882262,
     "description": "gamma-glutamyltranspeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -60633,7 +55969,6 @@
   },
   {
     "id": 4665,
-    "entrezid": 882263,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60646,7 +55981,6 @@
   },
   {
     "id": 4666,
-    "entrezid": 882264,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -60659,7 +55993,6 @@
   },
   {
     "id": 4667,
-    "entrezid": 882265,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -60672,7 +56005,6 @@
   },
   {
     "id": 4668,
-    "entrezid": 882266,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60685,7 +56017,6 @@
   },
   {
     "id": 4669,
-    "entrezid": 882267,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -60698,7 +56029,6 @@
   },
   {
     "id": 4670,
-    "entrezid": 882268,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -60711,7 +56041,6 @@
   },
   {
     "id": 4671,
-    "entrezid": 882269,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60724,7 +56053,6 @@
   },
   {
     "id": 4672,
-    "entrezid": 882270,
     "description": "pyoverdine biosynthesis protein PvdR",
     "aliases": "-",
     "obsolete": false,
@@ -60737,7 +56065,6 @@
   },
   {
     "id": 4673,
-    "entrezid": 882271,
     "description": "tRNA N6-adenosine threonylcarbamoyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -60750,7 +56077,6 @@
   },
   {
     "id": 4674,
-    "entrezid": 882273,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60763,7 +56089,6 @@
   },
   {
     "id": 4675,
-    "entrezid": 882274,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60776,7 +56101,6 @@
   },
   {
     "id": 4676,
-    "entrezid": 882275,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60789,7 +56113,6 @@
   },
   {
     "id": 4677,
-    "entrezid": 882276,
     "description": "biofilm formation protein PslI",
     "aliases": "-",
     "obsolete": false,
@@ -60802,7 +56125,6 @@
   },
   {
     "id": 4678,
-    "entrezid": 882277,
     "description": "serine/threonine phosphoprotein phosphatase Stp1",
     "aliases": "-",
     "obsolete": false,
@@ -60815,7 +56137,6 @@
   },
   {
     "id": 4679,
-    "entrezid": 882278,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -60828,7 +56149,6 @@
   },
   {
     "id": 4680,
-    "entrezid": 882279,
     "description": "acyl-CoA desaturase",
     "aliases": "-",
     "obsolete": false,
@@ -60841,7 +56161,6 @@
   },
   {
     "id": 4681,
-    "entrezid": 882280,
     "description": "glutathione S-transferase",
     "aliases": "-",
     "obsolete": false,
@@ -60854,7 +56173,6 @@
   },
   {
     "id": 4682,
-    "entrezid": 882281,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60867,7 +56185,6 @@
   },
   {
     "id": 4683,
-    "entrezid": 882282,
     "description": "chemotaxis protein methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -60880,7 +56197,6 @@
   },
   {
     "id": 4684,
-    "entrezid": 882283,
     "description": "FMN reductase MsuE",
     "aliases": "-",
     "obsolete": false,
@@ -60893,7 +56209,6 @@
   },
   {
     "id": 4685,
-    "entrezid": 882284,
     "description": "uricase",
     "aliases": "-",
     "obsolete": false,
@@ -60906,7 +56221,6 @@
   },
   {
     "id": 4686,
-    "entrezid": 882285,
     "description": "D-hydantoinase/dihydropyrimidinase",
     "aliases": "-",
     "obsolete": false,
@@ -60919,7 +56233,6 @@
   },
   {
     "id": 4687,
-    "entrezid": 882286,
     "description": "class III pyridoxal phosphate-dependent aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -60932,7 +56245,6 @@
   },
   {
     "id": 4688,
-    "entrezid": 882287,
     "description": "2-octaprenyl-6-methoxyphenyl hydroxylase",
     "aliases": "-",
     "obsolete": false,
@@ -60945,7 +56257,6 @@
   },
   {
     "id": 4689,
-    "entrezid": 882288,
     "description": "aminopeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -60958,7 +56269,6 @@
   },
   {
     "id": 4690,
-    "entrezid": 882289,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60971,7 +56281,6 @@
   },
   {
     "id": 4691,
-    "entrezid": 882290,
     "description": "RNA pyrophosphohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -60984,7 +56293,6 @@
   },
   {
     "id": 4692,
-    "entrezid": 882291,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -60997,7 +56305,6 @@
   },
   {
     "id": 4693,
-    "entrezid": 882292,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61010,7 +56317,6 @@
   },
   {
     "id": 4694,
-    "entrezid": 882293,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61023,7 +56329,6 @@
   },
   {
     "id": 4695,
-    "entrezid": 882294,
     "description": "urease accessory protein UreE",
     "aliases": "-",
     "obsolete": false,
@@ -61036,7 +56341,6 @@
   },
   {
     "id": 4696,
-    "entrezid": 882295,
     "description": "urease accessory protein UreF",
     "aliases": "-",
     "obsolete": false,
@@ -61049,7 +56353,6 @@
   },
   {
     "id": 4697,
-    "entrezid": 882296,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61062,7 +56365,6 @@
   },
   {
     "id": 4698,
-    "entrezid": 882297,
     "description": "HTH-type transcriptional regulator VqsM",
     "aliases": "-",
     "obsolete": false,
@@ -61075,7 +56377,6 @@
   },
   {
     "id": 4699,
-    "entrezid": 882298,
     "description": "redox-sensitive transcriptional activator SoxR",
     "aliases": "-",
     "obsolete": false,
@@ -61088,7 +56389,6 @@
   },
   {
     "id": 4700,
-    "entrezid": 882299,
     "description": "quorum threshold expression protein QteE",
     "aliases": "-",
     "obsolete": false,
@@ -61101,7 +56401,6 @@
   },
   {
     "id": 4701,
-    "entrezid": 882300,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61114,7 +56413,6 @@
   },
   {
     "id": 4702,
-    "entrezid": 882301,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61127,7 +56425,6 @@
   },
   {
     "id": 4703,
-    "entrezid": 882302,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61140,7 +56437,6 @@
   },
   {
     "id": 4704,
-    "entrezid": 882303,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61153,7 +56449,6 @@
   },
   {
     "id": 4705,
-    "entrezid": 882304,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61166,7 +56461,6 @@
   },
   {
     "id": 4706,
-    "entrezid": 882305,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61179,7 +56473,6 @@
   },
   {
     "id": 4707,
-    "entrezid": 882306,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61192,7 +56485,6 @@
   },
   {
     "id": 4708,
-    "entrezid": 882307,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -61205,7 +56497,6 @@
   },
   {
     "id": 4709,
-    "entrezid": 882308,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61218,7 +56509,6 @@
   },
   {
     "id": 4710,
-    "entrezid": 882309,
     "description": "thiosulfate sulfurtransferase",
     "aliases": "-",
     "obsolete": false,
@@ -61231,7 +56521,6 @@
   },
   {
     "id": 4711,
-    "entrezid": 882310,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61244,7 +56533,6 @@
   },
   {
     "id": 4712,
-    "entrezid": 882311,
     "description": "sulfurtransferase TusD",
     "aliases": "-",
     "obsolete": false,
@@ -61257,7 +56545,6 @@
   },
   {
     "id": 4713,
-    "entrezid": 882312,
     "description": "sulfur relay protein TusC",
     "aliases": "-",
     "obsolete": false,
@@ -61270,7 +56557,6 @@
   },
   {
     "id": 4714,
-    "entrezid": 882313,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61283,7 +56569,6 @@
   },
   {
     "id": 4715,
-    "entrezid": 882314,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61296,7 +56581,6 @@
   },
   {
     "id": 4716,
-    "entrezid": 882315,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61309,7 +56593,6 @@
   },
   {
     "id": 4717,
-    "entrezid": 882316,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61322,7 +56605,6 @@
   },
   {
     "id": 4718,
-    "entrezid": 882317,
     "description": "siroheme synthase",
     "aliases": "-",
     "obsolete": false,
@@ -61335,7 +56617,6 @@
   },
   {
     "id": 4719,
-    "entrezid": 882318,
     "description": "serine--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -61348,7 +56629,6 @@
   },
   {
     "id": 4720,
-    "entrezid": 882319,
     "description": "recombination factor protein RarA",
     "aliases": "-",
     "obsolete": false,
@@ -61361,7 +56641,6 @@
   },
   {
     "id": 4721,
-    "entrezid": 882320,
     "description": "outer-membrane lipoprotein carrier protein",
     "aliases": "-",
     "obsolete": false,
@@ -61374,7 +56653,6 @@
   },
   {
     "id": 4722,
-    "entrezid": 882321,
     "description": "DNA translocase FtsK",
     "aliases": "-",
     "obsolete": false,
@@ -61387,7 +56665,6 @@
   },
   {
     "id": 4723,
-    "entrezid": 882322,
     "description": "thioredoxin reductase",
     "aliases": "-",
     "obsolete": false,
@@ -61400,7 +56677,6 @@
   },
   {
     "id": 4724,
-    "entrezid": 882323,
     "description": "leucyl/phenylalanyl-tRNA--protein transferase",
     "aliases": "-",
     "obsolete": false,
@@ -61413,7 +56689,6 @@
   },
   {
     "id": 4725,
-    "entrezid": 882324,
     "description": "arginyl-tRNA--protein transferase",
     "aliases": "-",
     "obsolete": false,
@@ -61426,7 +56701,6 @@
   },
   {
     "id": 4726,
-    "entrezid": 882325,
     "description": "translation initiation factor IF-1",
     "aliases": "-",
     "obsolete": false,
@@ -61439,7 +56713,6 @@
   },
   {
     "id": 4727,
-    "entrezid": 882326,
     "description": "ATP-binding protease component ClpA",
     "aliases": "-",
     "obsolete": false,
@@ -61452,7 +56725,6 @@
   },
   {
     "id": 4728,
-    "entrezid": 882327,
     "description": "ATP-dependent Clp protease adapter protein Clp",
     "aliases": "-",
     "obsolete": false,
@@ -61465,7 +56737,6 @@
   },
   {
     "id": 4729,
-    "entrezid": 882328,
     "description": "cold-shock protein CspD",
     "aliases": "-",
     "obsolete": false,
@@ -61478,7 +56749,6 @@
   },
   {
     "id": 4730,
-    "entrezid": 882329,
     "description": "isocitrate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -61491,7 +56761,6 @@
   },
   {
     "id": 4731,
-    "entrezid": 882330,
     "description": "isocitrate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -61504,7 +56773,6 @@
   },
   {
     "id": 4732,
-    "entrezid": 882331,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61517,7 +56785,6 @@
   },
   {
     "id": 4733,
-    "entrezid": 882332,
     "description": "tRNA-specific 2-thiouridylase MnmA",
     "aliases": "-",
     "obsolete": false,
@@ -61530,7 +56797,6 @@
   },
   {
     "id": 4734,
-    "entrezid": 882333,
     "description": "high frequency lysogenization protein HflD",
     "aliases": "-",
     "obsolete": false,
@@ -61543,7 +56809,6 @@
   },
   {
     "id": 4735,
-    "entrezid": 882334,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61556,7 +56821,6 @@
   },
   {
     "id": 4736,
-    "entrezid": 882335,
     "description": "PA-I galactophilic lectin",
     "aliases": "-",
     "obsolete": false,
@@ -61569,7 +56833,6 @@
   },
   {
     "id": 4737,
-    "entrezid": 882336,
     "description": "adenylosuccinate lyase",
     "aliases": "-",
     "obsolete": false,
@@ -61582,7 +56845,6 @@
   },
   {
     "id": 4738,
-    "entrezid": 882337,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61595,7 +56857,6 @@
   },
   {
     "id": 4739,
-    "entrezid": 882338,
     "description": "acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -61608,7 +56869,6 @@
   },
   {
     "id": 4740,
-    "entrezid": 882339,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61621,7 +56881,6 @@
   },
   {
     "id": 4741,
-    "entrezid": 882340,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61634,7 +56893,6 @@
   },
   {
     "id": 4742,
-    "entrezid": 882341,
     "description": "isocitrate lyase",
     "aliases": "-",
     "obsolete": false,
@@ -61647,7 +56905,6 @@
   },
   {
     "id": 4743,
-    "entrezid": 882342,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61660,7 +56917,6 @@
   },
   {
     "id": 4744,
-    "entrezid": 882343,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61673,7 +56929,6 @@
   },
   {
     "id": 4745,
-    "entrezid": 882344,
     "description": "NADH-quinone oxidoreductase subunit A",
     "aliases": "-",
     "obsolete": false,
@@ -61686,7 +56941,6 @@
   },
   {
     "id": 4746,
-    "entrezid": 882345,
     "description": "NADH-quinone oxidoreductase subunit B",
     "aliases": "-",
     "obsolete": false,
@@ -61699,7 +56953,6 @@
   },
   {
     "id": 4747,
-    "entrezid": 882346,
     "description": "NADH:-quinone oxidoreductase subunit C/D",
     "aliases": "-",
     "obsolete": false,
@@ -61712,7 +56965,6 @@
   },
   {
     "id": 4748,
-    "entrezid": 882347,
     "description": "NADH-quinone oxidoreductase subunit E",
     "aliases": "-",
     "obsolete": false,
@@ -61725,7 +56977,6 @@
   },
   {
     "id": 4749,
-    "entrezid": 882348,
     "description": "NADH dehydrogenase I subunit F",
     "aliases": "-",
     "obsolete": false,
@@ -61738,7 +56989,6 @@
   },
   {
     "id": 4750,
-    "entrezid": 882349,
     "description": "NADH-quinone oxidoreductase subunit G",
     "aliases": "-",
     "obsolete": false,
@@ -61751,7 +57001,6 @@
   },
   {
     "id": 4751,
-    "entrezid": 882350,
     "description": "NADH-quinone oxidoreductase subunit H",
     "aliases": "-",
     "obsolete": false,
@@ -61764,7 +57013,6 @@
   },
   {
     "id": 4752,
-    "entrezid": 882351,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61777,7 +57025,6 @@
   },
   {
     "id": 4753,
-    "entrezid": 882352,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61790,7 +57037,6 @@
   },
   {
     "id": 4754,
-    "entrezid": 882353,
     "description": "NADH-quinone oxidoreductase subunit I",
     "aliases": "-",
     "obsolete": false,
@@ -61803,7 +57049,6 @@
   },
   {
     "id": 4755,
-    "entrezid": 882354,
     "description": "NADH-quinone oxidoreductase subunit J",
     "aliases": "-",
     "obsolete": false,
@@ -61816,7 +57061,6 @@
   },
   {
     "id": 4756,
-    "entrezid": 882355,
     "description": "NADH-quinone oxidoreductase subunit K",
     "aliases": "-",
     "obsolete": false,
@@ -61829,7 +57073,6 @@
   },
   {
     "id": 4757,
-    "entrezid": 882356,
     "description": "NADH-quinone oxidoreductase subunit L",
     "aliases": "-",
     "obsolete": false,
@@ -61842,7 +57085,6 @@
   },
   {
     "id": 4758,
-    "entrezid": 882357,
     "description": "NADH-quinone oxidoreductase subunit M",
     "aliases": "-",
     "obsolete": false,
@@ -61855,7 +57097,6 @@
   },
   {
     "id": 4759,
-    "entrezid": 882358,
     "description": "NADH-quinone oxidoreductase subunit N",
     "aliases": "-",
     "obsolete": false,
@@ -61868,7 +57109,6 @@
   },
   {
     "id": 4760,
-    "entrezid": 882359,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61881,7 +57121,6 @@
   },
   {
     "id": 4761,
-    "entrezid": 882360,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61894,7 +57133,6 @@
   },
   {
     "id": 4762,
-    "entrezid": 882361,
     "description": "methyl-accepting chemotaxis protein",
     "aliases": "-",
     "obsolete": false,
@@ -61907,7 +57145,6 @@
   },
   {
     "id": 4763,
-    "entrezid": 882362,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -61920,7 +57157,6 @@
   },
   {
     "id": 4764,
-    "entrezid": 882363,
     "description": "chemotaxis transducer",
     "aliases": "-",
     "obsolete": false,
@@ -61933,7 +57169,6 @@
   },
   {
     "id": 4765,
-    "entrezid": 882364,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61946,7 +57181,6 @@
   },
   {
     "id": 4766,
-    "entrezid": 882365,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -61959,7 +57193,6 @@
   },
   {
     "id": 4767,
-    "entrezid": 882366,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -61972,7 +57205,6 @@
   },
   {
     "id": 4768,
-    "entrezid": 882367,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61985,7 +57217,6 @@
   },
   {
     "id": 4769,
-    "entrezid": 882368,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -61998,7 +57229,6 @@
   },
   {
     "id": 4770,
-    "entrezid": 882369,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62011,7 +57241,6 @@
   },
   {
     "id": 4771,
-    "entrezid": 882370,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62024,7 +57253,6 @@
   },
   {
     "id": 4772,
-    "entrezid": 882371,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62037,7 +57265,6 @@
   },
   {
     "id": 4773,
-    "entrezid": 882372,
     "description": "psl and pyoverdine operon regulator PpyR",
     "aliases": "-",
     "obsolete": false,
@@ -62050,7 +57277,6 @@
   },
   {
     "id": 4774,
-    "entrezid": 882373,
     "description": "flavohemoprotein",
     "aliases": "-",
     "obsolete": false,
@@ -62063,7 +57289,6 @@
   },
   {
     "id": 4775,
-    "entrezid": 882374,
     "description": "anaerobic nitric oxide reductase transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -62076,7 +57301,6 @@
   },
   {
     "id": 4776,
-    "entrezid": 882375,
     "description": "6-carboxytetrahydropterin synthase QueD",
     "aliases": "-",
     "obsolete": false,
@@ -62089,7 +57313,6 @@
   },
   {
     "id": 4777,
-    "entrezid": 882376,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62102,7 +57325,6 @@
   },
   {
     "id": 4778,
-    "entrezid": 882377,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -62115,7 +57337,6 @@
   },
   {
     "id": 4779,
-    "entrezid": 882378,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62128,7 +57349,6 @@
   },
   {
     "id": 4780,
-    "entrezid": 882379,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62141,7 +57361,6 @@
   },
   {
     "id": 4781,
-    "entrezid": 882380,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62154,7 +57373,6 @@
   },
   {
     "id": 4782,
-    "entrezid": 882381,
     "description": "type II secretion system protein",
     "aliases": "-",
     "obsolete": false,
@@ -62167,7 +57385,6 @@
   },
   {
     "id": 4783,
-    "entrezid": 882382,
     "description": "type II secretion system protein",
     "aliases": "-",
     "obsolete": false,
@@ -62180,7 +57397,6 @@
   },
   {
     "id": 4784,
-    "entrezid": 882383,
     "description": "type II secretion system protein",
     "aliases": "-",
     "obsolete": false,
@@ -62193,7 +57409,6 @@
   },
   {
     "id": 4785,
-    "entrezid": 882384,
     "description": "type II secretion system protein",
     "aliases": "-",
     "obsolete": false,
@@ -62206,7 +57421,6 @@
   },
   {
     "id": 4786,
-    "entrezid": 882385,
     "description": "type II secretion system protein",
     "aliases": "-",
     "obsolete": false,
@@ -62219,7 +57433,6 @@
   },
   {
     "id": 4787,
-    "entrezid": 882386,
     "description": "type II secretion protein",
     "aliases": "-",
     "obsolete": false,
@@ -62232,7 +57445,6 @@
   },
   {
     "id": 4788,
-    "entrezid": 882387,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -62245,7 +57457,6 @@
   },
   {
     "id": 4789,
-    "entrezid": 882388,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62258,7 +57469,6 @@
   },
   {
     "id": 4790,
-    "entrezid": 882389,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62271,7 +57481,6 @@
   },
   {
     "id": 4791,
-    "entrezid": 882390,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62284,7 +57493,6 @@
   },
   {
     "id": 4792,
-    "entrezid": 882391,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62297,7 +57505,6 @@
   },
   {
     "id": 4793,
-    "entrezid": 882392,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62310,7 +57517,6 @@
   },
   {
     "id": 4794,
-    "entrezid": 882393,
     "description": "DNA polymerase III subunit epsilon",
     "aliases": "-",
     "obsolete": false,
@@ -62323,7 +57529,6 @@
   },
   {
     "id": 4795,
-    "entrezid": 882394,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62336,7 +57541,6 @@
   },
   {
     "id": 4796,
-    "entrezid": 882395,
     "description": "acetate permease",
     "aliases": "-",
     "obsolete": false,
@@ -62349,7 +57553,6 @@
   },
   {
     "id": 4797,
-    "entrezid": 882396,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62362,7 +57565,6 @@
   },
   {
     "id": 4798,
-    "entrezid": 882397,
     "description": "glycine betaine-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -62375,7 +57577,6 @@
   },
   {
     "id": 4799,
-    "entrezid": 882398,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62388,7 +57589,6 @@
   },
   {
     "id": 4800,
-    "entrezid": 882399,
     "description": "ABC transporter ATP-binding protein/permease",
     "aliases": "-",
     "obsolete": false,
@@ -62401,7 +57601,6 @@
   },
   {
     "id": 4801,
-    "entrezid": 882400,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62414,7 +57613,6 @@
   },
   {
     "id": 4802,
-    "entrezid": 882401,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62427,7 +57625,6 @@
   },
   {
     "id": 4803,
-    "entrezid": 882402,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62440,7 +57637,6 @@
   },
   {
     "id": 4804,
-    "entrezid": 882403,
     "description": "quercetin 2,3-dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -62453,7 +57649,6 @@
   },
   {
     "id": 4805,
-    "entrezid": 882404,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62466,7 +57661,6 @@
   },
   {
     "id": 4806,
-    "entrezid": 882405,
     "description": "lipid A biosynthesis lauroyl acyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -62479,7 +57673,6 @@
   },
   {
     "id": 4807,
-    "entrezid": 882406,
     "description": "septum formation inhibitor",
     "aliases": "-",
     "obsolete": false,
@@ -62492,7 +57685,6 @@
   },
   {
     "id": 4808,
-    "entrezid": 882407,
     "description": "cell division inhibitor MinD",
     "aliases": "-",
     "obsolete": false,
@@ -62505,7 +57697,6 @@
   },
   {
     "id": 4809,
-    "entrezid": 882408,
     "description": "cell division topological specificity factor MinE",
     "aliases": "-",
     "obsolete": false,
@@ -62518,7 +57709,6 @@
   },
   {
     "id": 4810,
-    "entrezid": 882409,
     "description": "pseudouridine synthase",
     "aliases": "-",
     "obsolete": false,
@@ -62531,7 +57721,6 @@
   },
   {
     "id": 4811,
-    "entrezid": 882410,
     "description": "aminopeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -62544,7 +57733,6 @@
   },
   {
     "id": 4812,
-    "entrezid": 882411,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62557,7 +57745,6 @@
   },
   {
     "id": 4813,
-    "entrezid": 882412,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -62570,7 +57757,6 @@
   },
   {
     "id": 4814,
-    "entrezid": 882413,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62583,7 +57769,6 @@
   },
   {
     "id": 4815,
-    "entrezid": 882414,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62596,7 +57781,6 @@
   },
   {
     "id": 4816,
-    "entrezid": 882415,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -62609,7 +57793,6 @@
   },
   {
     "id": 4817,
-    "entrezid": 882416,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -62622,7 +57805,6 @@
   },
   {
     "id": 4818,
-    "entrezid": 882417,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -62635,7 +57817,6 @@
   },
   {
     "id": 4819,
-    "entrezid": 882418,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62648,7 +57829,6 @@
   },
   {
     "id": 4820,
-    "entrezid": 882419,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -62661,7 +57841,6 @@
   },
   {
     "id": 4821,
-    "entrezid": 882420,
     "description": "tail-specific protease",
     "aliases": "-",
     "obsolete": false,
@@ -62674,7 +57853,6 @@
   },
   {
     "id": 4822,
-    "entrezid": 882421,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62687,7 +57865,6 @@
   },
   {
     "id": 4823,
-    "entrezid": 882422,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62700,7 +57877,6 @@
   },
   {
     "id": 4824,
-    "entrezid": 882423,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -62713,7 +57889,6 @@
   },
   {
     "id": 4825,
-    "entrezid": 882424,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62726,7 +57901,6 @@
   },
   {
     "id": 4826,
-    "entrezid": 882425,
     "description": "FkbP-type peptidyl-prolyl cis-trans isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -62739,7 +57913,6 @@
   },
   {
     "id": 4827,
-    "entrezid": 882426,
     "description": "recombination associated protein RdgC",
     "aliases": "-",
     "obsolete": false,
@@ -62752,7 +57925,6 @@
   },
   {
     "id": 4828,
-    "entrezid": 882427,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -62765,7 +57937,6 @@
   },
   {
     "id": 4829,
-    "entrezid": 882428,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -62778,7 +57949,6 @@
   },
   {
     "id": 4830,
-    "entrezid": 882429,
     "description": "major cold shock protein CspA",
     "aliases": "-",
     "obsolete": false,
@@ -62791,7 +57961,6 @@
   },
   {
     "id": 4831,
-    "entrezid": 882430,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62804,7 +57973,6 @@
   },
   {
     "id": 4832,
-    "entrezid": 882431,
     "description": "TonB-dependent receptor",
     "aliases": "-",
     "obsolete": false,
@@ -62817,7 +57985,6 @@
   },
   {
     "id": 4833,
-    "entrezid": 882432,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -62830,7 +57997,6 @@
   },
   {
     "id": 4834,
-    "entrezid": 882433,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62843,7 +58009,6 @@
   },
   {
     "id": 4835,
-    "entrezid": 882434,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -62856,7 +58021,6 @@
   },
   {
     "id": 4836,
-    "entrezid": 882435,
     "description": "ATP-dependent DNA helicase",
     "aliases": "-",
     "obsolete": false,
@@ -62869,7 +58033,6 @@
   },
   {
     "id": 4837,
-    "entrezid": 882436,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62882,7 +58045,6 @@
   },
   {
     "id": 4838,
-    "entrezid": 882437,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62895,7 +58057,6 @@
   },
   {
     "id": 4839,
-    "entrezid": 882438,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62908,7 +58069,6 @@
   },
   {
     "id": 4840,
-    "entrezid": 882439,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62921,7 +58081,6 @@
   },
   {
     "id": 4841,
-    "entrezid": 882440,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -62934,7 +58093,6 @@
   },
   {
     "id": 4842,
-    "entrezid": 882441,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62947,7 +58105,6 @@
   },
   {
     "id": 4843,
-    "entrezid": 882442,
     "description": "phosphate-specific outer membrane porin OprP",
     "aliases": "-",
     "obsolete": false,
@@ -62960,7 +58117,6 @@
   },
   {
     "id": 4844,
-    "entrezid": 882443,
     "description": "pyrophosphate-specific outer membrane porin OprO",
     "aliases": "-",
     "obsolete": false,
@@ -62973,7 +58129,6 @@
   },
   {
     "id": 4845,
-    "entrezid": 882444,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62986,7 +58141,6 @@
   },
   {
     "id": 4846,
-    "entrezid": 882445,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -62999,7 +58153,6 @@
   },
   {
     "id": 4847,
-    "entrezid": 882446,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63012,7 +58165,6 @@
   },
   {
     "id": 4848,
-    "entrezid": 882447,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63025,7 +58177,6 @@
   },
   {
     "id": 4849,
-    "entrezid": 882448,
     "description": "ECF subfamily sigma-70 factor",
     "aliases": "-",
     "obsolete": false,
@@ -63038,7 +58189,6 @@
   },
   {
     "id": 4850,
-    "entrezid": 882449,
     "description": "3-oxoacyl-ACP synthase",
     "aliases": "-",
     "obsolete": false,
@@ -63051,7 +58201,6 @@
   },
   {
     "id": 4851,
-    "entrezid": 882450,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63064,7 +58213,6 @@
   },
   {
     "id": 4852,
-    "entrezid": 882451,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63077,7 +58225,6 @@
   },
   {
     "id": 4853,
-    "entrezid": 882452,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63090,7 +58237,6 @@
   },
   {
     "id": 4854,
-    "entrezid": 882453,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63103,7 +58249,6 @@
   },
   {
     "id": 4855,
-    "entrezid": 882454,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63116,7 +58261,6 @@
   },
   {
     "id": 4856,
-    "entrezid": 882455,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63129,7 +58273,6 @@
   },
   {
     "id": 4857,
-    "entrezid": 882456,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63142,7 +58285,6 @@
   },
   {
     "id": 4858,
-    "entrezid": 882457,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63155,7 +58297,6 @@
   },
   {
     "id": 4859,
-    "entrezid": 882458,
     "description": "HIT family protein",
     "aliases": "-",
     "obsolete": false,
@@ -63168,7 +58309,6 @@
   },
   {
     "id": 4860,
-    "entrezid": 882459,
     "description": "alkaline phosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -63181,7 +58321,6 @@
   },
   {
     "id": 4861,
-    "entrezid": 882460,
     "description": "ATP-dependent helicase",
     "aliases": "-",
     "obsolete": false,
@@ -63194,7 +58333,6 @@
   },
   {
     "id": 4862,
-    "entrezid": 882461,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63207,7 +58345,6 @@
   },
   {
     "id": 4863,
-    "entrezid": 882462,
     "description": "long-chain-fatty-acid--CoA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -63220,7 +58357,6 @@
   },
   {
     "id": 4864,
-    "entrezid": 882463,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -63233,7 +58369,6 @@
   },
   {
     "id": 4865,
-    "entrezid": 882464,
     "description": "peptidyl-prolyl cis-trans isomerase A",
     "aliases": "-",
     "obsolete": false,
@@ -63246,7 +58381,6 @@
   },
   {
     "id": 4866,
-    "entrezid": 882465,
     "description": "long-chain-fatty-acid--CoA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -63259,7 +58393,6 @@
   },
   {
     "id": 4867,
-    "entrezid": 882466,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63272,7 +58405,6 @@
   },
   {
     "id": 4868,
-    "entrezid": 882467,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63285,7 +58417,6 @@
   },
   {
     "id": 4869,
-    "entrezid": 882468,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -63298,7 +58429,6 @@
   },
   {
     "id": 4870,
-    "entrezid": 882469,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63311,7 +58441,6 @@
   },
   {
     "id": 4871,
-    "entrezid": 882470,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63324,7 +58453,6 @@
   },
   {
     "id": 4872,
-    "entrezid": 882471,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63337,7 +58465,6 @@
   },
   {
     "id": 4873,
-    "entrezid": 882472,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63350,7 +58477,6 @@
   },
   {
     "id": 4874,
-    "entrezid": 882473,
     "description": "RNA polymerase-associated protein RapA",
     "aliases": "-",
     "obsolete": false,
@@ -63363,7 +58489,6 @@
   },
   {
     "id": 4875,
-    "entrezid": 882474,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63376,7 +58501,6 @@
   },
   {
     "id": 4876,
-    "entrezid": 882475,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63389,7 +58513,6 @@
   },
   {
     "id": 4877,
-    "entrezid": 882476,
     "description": "signaling protein",
     "aliases": "-",
     "obsolete": false,
@@ -63402,7 +58525,6 @@
   },
   {
     "id": 4878,
-    "entrezid": 882477,
     "description": "3-hydroxyisobutyrate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -63415,7 +58537,6 @@
   },
   {
     "id": 4879,
-    "entrezid": 882478,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63428,7 +58549,6 @@
   },
   {
     "id": 4880,
-    "entrezid": 882479,
     "description": "phosphonates ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -63441,7 +58561,6 @@
   },
   {
     "id": 4881,
-    "entrezid": 882480,
     "description": "phosphonates ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -63454,7 +58573,6 @@
   },
   {
     "id": 4882,
-    "entrezid": 882481,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -63467,7 +58585,6 @@
   },
   {
     "id": 4883,
-    "entrezid": 882482,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63480,7 +58597,6 @@
   },
   {
     "id": 4884,
-    "entrezid": 882483,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63493,7 +58609,6 @@
   },
   {
     "id": 4885,
-    "entrezid": 882484,
     "description": "non-hemolytic phospholipase C",
     "aliases": "-",
     "obsolete": false,
@@ -63506,7 +58621,6 @@
   },
   {
     "id": 4886,
-    "entrezid": 882485,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63519,7 +58633,6 @@
   },
   {
     "id": 4887,
-    "entrezid": 882486,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -63532,7 +58645,6 @@
   },
   {
     "id": 4888,
-    "entrezid": 882487,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63545,7 +58657,6 @@
   },
   {
     "id": 4889,
-    "entrezid": 882488,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63558,7 +58669,6 @@
   },
   {
     "id": 4890,
-    "entrezid": 882489,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -63571,7 +58681,6 @@
   },
   {
     "id": 4891,
-    "entrezid": 882490,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63584,7 +58693,6 @@
   },
   {
     "id": 4892,
-    "entrezid": 882491,
     "description": "ATP-dependent Clp protease proteolytic subunit",
     "aliases": "-",
     "obsolete": false,
@@ -63597,7 +58705,6 @@
   },
   {
     "id": 4893,
-    "entrezid": 882492,
     "description": "non-ribosomal peptide synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -63610,7 +58717,6 @@
   },
   {
     "id": 4894,
-    "entrezid": 882493,
     "description": "FAD-dependent monooxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -63623,7 +58729,6 @@
   },
   {
     "id": 4895,
-    "entrezid": 882494,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63636,7 +58741,6 @@
   },
   {
     "id": 4896,
-    "entrezid": 882495,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -63649,7 +58753,6 @@
   },
   {
     "id": 4897,
-    "entrezid": 882496,
     "description": "cytochrome P450",
     "aliases": "-",
     "obsolete": false,
@@ -63662,7 +58765,6 @@
   },
   {
     "id": 4898,
-    "entrezid": 882497,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63675,7 +58777,6 @@
   },
   {
     "id": 4899,
-    "entrezid": 882498,
     "description": "3-oxoacyl-ACP synthase III",
     "aliases": "-",
     "obsolete": false,
@@ -63688,7 +58789,6 @@
   },
   {
     "id": 4900,
-    "entrezid": 882499,
     "description": "acyl carrier protein",
     "aliases": "-",
     "obsolete": false,
@@ -63701,7 +58801,6 @@
   },
   {
     "id": 4901,
-    "entrezid": 882500,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63714,7 +58813,6 @@
   },
   {
     "id": 4902,
-    "entrezid": 882501,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -63727,7 +58825,6 @@
   },
   {
     "id": 4903,
-    "entrezid": 882502,
     "description": "ADP-L-glycero-D-mannoheptose-6-epimerase",
     "aliases": "-",
     "obsolete": false,
@@ -63740,7 +58837,6 @@
   },
   {
     "id": 4904,
-    "entrezid": 882503,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63753,7 +58849,6 @@
   },
   {
     "id": 4905,
-    "entrezid": 882504,
     "description": "patatin-like protein",
     "aliases": "-",
     "obsolete": false,
@@ -63766,7 +58861,6 @@
   },
   {
     "id": 4906,
-    "entrezid": 882505,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63779,7 +58873,6 @@
   },
   {
     "id": 4907,
-    "entrezid": 882506,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -63792,7 +58885,6 @@
   },
   {
     "id": 4908,
-    "entrezid": 882507,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63805,7 +58897,6 @@
   },
   {
     "id": 4909,
-    "entrezid": 882508,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63818,7 +58909,6 @@
   },
   {
     "id": 4910,
-    "entrezid": 882509,
     "description": "ATP-dependent DNA helicase RecQ",
     "aliases": "-",
     "obsolete": false,
@@ -63831,7 +58921,6 @@
   },
   {
     "id": 4911,
-    "entrezid": 882510,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63844,7 +58933,6 @@
   },
   {
     "id": 4912,
-    "entrezid": 882511,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63857,7 +58945,6 @@
   },
   {
     "id": 4913,
-    "entrezid": 882512,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63870,7 +58957,6 @@
   },
   {
     "id": 4914,
-    "entrezid": 882513,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -63883,7 +58969,6 @@
   },
   {
     "id": 4915,
-    "entrezid": 882514,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63896,7 +58981,6 @@
   },
   {
     "id": 4916,
-    "entrezid": 882515,
     "description": "chemotaxis protein methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -63909,7 +58993,6 @@
   },
   {
     "id": 4917,
-    "entrezid": 882516,
     "description": "chemotaxis protein",
     "aliases": "-",
     "obsolete": false,
@@ -63922,7 +59005,6 @@
   },
   {
     "id": 4918,
-    "entrezid": 882517,
     "description": "flagellar basal body P-ring biosynthesis protein FlgA",
     "aliases": "-",
     "obsolete": false,
@@ -63935,7 +59017,6 @@
   },
   {
     "id": 4919,
-    "entrezid": 882518,
     "description": "protein FlgM",
     "aliases": "-",
     "obsolete": false,
@@ -63948,7 +59029,6 @@
   },
   {
     "id": 4920,
-    "entrezid": 882519,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63961,7 +59041,6 @@
   },
   {
     "id": 4921,
-    "entrezid": 882520,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63974,7 +59053,6 @@
   },
   {
     "id": 4922,
-    "entrezid": 882521,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -63987,7 +59065,6 @@
   },
   {
     "id": 4923,
-    "entrezid": 882522,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64000,7 +59077,6 @@
   },
   {
     "id": 4924,
-    "entrezid": 882523,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64013,7 +59089,6 @@
   },
   {
     "id": 4925,
-    "entrezid": 882524,
     "description": "D-serine dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -64026,7 +59101,6 @@
   },
   {
     "id": 4926,
-    "entrezid": 882525,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64039,7 +59113,6 @@
   },
   {
     "id": 4927,
-    "entrezid": 882526,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64052,7 +59125,6 @@
   },
   {
     "id": 4928,
-    "entrezid": 882527,
     "description": "secretion protein",
     "aliases": "-",
     "obsolete": false,
@@ -64065,7 +59137,6 @@
   },
   {
     "id": 4929,
-    "entrezid": 882528,
     "description": "fucose-binding lectin PA-IIL",
     "aliases": "-",
     "obsolete": false,
@@ -64078,7 +59149,6 @@
   },
   {
     "id": 4930,
-    "entrezid": 882529,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64091,7 +59161,6 @@
   },
   {
     "id": 4931,
-    "entrezid": 882530,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -64104,7 +59173,6 @@
   },
   {
     "id": 4932,
-    "entrezid": 882531,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64117,7 +59185,6 @@
   },
   {
     "id": 4933,
-    "entrezid": 882532,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64130,7 +59197,6 @@
   },
   {
     "id": 4934,
-    "entrezid": 882533,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -64143,7 +59209,6 @@
   },
   {
     "id": 4935,
-    "entrezid": 882534,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64156,7 +59221,6 @@
   },
   {
     "id": 4936,
-    "entrezid": 882535,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64169,7 +59233,6 @@
   },
   {
     "id": 4937,
-    "entrezid": 882536,
     "description": "potassium uptake protein TrkH",
     "aliases": "-",
     "obsolete": false,
@@ -64182,7 +59245,6 @@
   },
   {
     "id": 4938,
-    "entrezid": 882537,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64195,7 +59257,6 @@
   },
   {
     "id": 4939,
-    "entrezid": 882538,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64208,7 +59269,6 @@
   },
   {
     "id": 4940,
-    "entrezid": 882539,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64221,7 +59281,6 @@
   },
   {
     "id": 4941,
-    "entrezid": 882540,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64234,7 +59293,6 @@
   },
   {
     "id": 4942,
-    "entrezid": 882541,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -64247,7 +59305,6 @@
   },
   {
     "id": 4943,
-    "entrezid": 882542,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64260,7 +59317,6 @@
   },
   {
     "id": 4944,
-    "entrezid": 882543,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64273,7 +59329,6 @@
   },
   {
     "id": 4945,
-    "entrezid": 882544,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -64286,7 +59341,6 @@
   },
   {
     "id": 4946,
-    "entrezid": 882545,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64299,7 +59353,6 @@
   },
   {
     "id": 4947,
-    "entrezid": 882546,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -64312,7 +59365,6 @@
   },
   {
     "id": 4948,
-    "entrezid": 882547,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64325,7 +59377,6 @@
   },
   {
     "id": 4949,
-    "entrezid": 882548,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -64338,7 +59389,6 @@
   },
   {
     "id": 4950,
-    "entrezid": 882549,
     "description": "thiol:disulfide interchange protein DsbG",
     "aliases": "-",
     "obsolete": false,
@@ -64351,7 +59401,6 @@
   },
   {
     "id": 4951,
-    "entrezid": 882550,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -64364,7 +59413,6 @@
   },
   {
     "id": 4952,
-    "entrezid": 882551,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -64377,7 +59425,6 @@
   },
   {
     "id": 4953,
-    "entrezid": 882552,
     "description": "molecular chaperone CsaA",
     "aliases": "-",
     "obsolete": false,
@@ -64390,7 +59437,6 @@
   },
   {
     "id": 4954,
-    "entrezid": 882553,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64403,7 +59449,6 @@
   },
   {
     "id": 4955,
-    "entrezid": 882554,
     "description": "FMN-dependent NADH-azoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -64416,7 +59461,6 @@
   },
   {
     "id": 4956,
-    "entrezid": 882555,
     "description": "protein CyaB",
     "aliases": "-",
     "obsolete": false,
@@ -64429,7 +59473,6 @@
   },
   {
     "id": 4957,
-    "entrezid": 882557,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -64442,7 +59485,6 @@
   },
   {
     "id": 4958,
-    "entrezid": 882558,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -64455,7 +59497,6 @@
   },
   {
     "id": 4959,
-    "entrezid": 882559,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -64468,7 +59509,6 @@
   },
   {
     "id": 4960,
-    "entrezid": 882560,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64481,7 +59521,6 @@
   },
   {
     "id": 4961,
-    "entrezid": 882561,
     "description": "integration host factor subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -64494,7 +59533,6 @@
   },
   {
     "id": 4962,
-    "entrezid": 882562,
     "description": "30S ribosomal protein S1",
     "aliases": "-",
     "obsolete": false,
@@ -64507,7 +59545,6 @@
   },
   {
     "id": 4963,
-    "entrezid": 882563,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64520,7 +59557,6 @@
   },
   {
     "id": 4964,
-    "entrezid": 882564,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64533,7 +59569,6 @@
   },
   {
     "id": 4965,
-    "entrezid": 882565,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64546,7 +59581,6 @@
   },
   {
     "id": 4966,
-    "entrezid": 882566,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64559,7 +59593,6 @@
   },
   {
     "id": 4967,
-    "entrezid": 882567,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64572,7 +59605,6 @@
   },
   {
     "id": 4968,
-    "entrezid": 882568,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -64585,7 +59617,6 @@
   },
   {
     "id": 4969,
-    "entrezid": 882570,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64598,7 +59629,6 @@
   },
   {
     "id": 4970,
-    "entrezid": 882571,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64611,7 +59641,6 @@
   },
   {
     "id": 4971,
-    "entrezid": 882572,
     "description": "chemotaxis transducer",
     "aliases": "-",
     "obsolete": false,
@@ -64624,7 +59653,6 @@
   },
   {
     "id": 4972,
-    "entrezid": 882573,
     "description": "intracellular septation protein A",
     "aliases": "-",
     "obsolete": false,
@@ -64637,7 +59665,6 @@
   },
   {
     "id": 4973,
-    "entrezid": 882574,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64650,7 +59677,6 @@
   },
   {
     "id": 4974,
-    "entrezid": 882575,
     "description": "radical activating enzyme",
     "aliases": "-",
     "obsolete": false,
@@ -64663,7 +59689,6 @@
   },
   {
     "id": 4975,
-    "entrezid": 882576,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -64676,7 +59701,6 @@
   },
   {
     "id": 4976,
-    "entrezid": 882577,
     "description": "histidine ABC transporter permease HisM",
     "aliases": "-",
     "obsolete": false,
@@ -64689,7 +59713,6 @@
   },
   {
     "id": 4977,
-    "entrezid": 882578,
     "description": "histidine ABC transporter ATP-binding protein HisP",
     "aliases": "-",
     "obsolete": false,
@@ -64702,7 +59725,6 @@
   },
   {
     "id": 4978,
-    "entrezid": 882579,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64715,7 +59737,6 @@
   },
   {
     "id": 4979,
-    "entrezid": 882580,
     "description": "2-dehydro-3-deoxy-phosphogluconate aldolase",
     "aliases": "-",
     "obsolete": false,
@@ -64728,7 +59749,6 @@
   },
   {
     "id": 4980,
-    "entrezid": 882581,
     "description": "LPS biosynthesis protein WbpG",
     "aliases": "-",
     "obsolete": false,
@@ -64741,7 +59761,6 @@
   },
   {
     "id": 4981,
-    "entrezid": 882582,
     "description": "imidazole glycerol phosphate synthase subunit HisF",
     "aliases": "-",
     "obsolete": false,
@@ -64754,7 +59773,6 @@
   },
   {
     "id": 4982,
-    "entrezid": 882583,
     "description": "nucleotide sugar epimerase/dehydratase WbpM",
     "aliases": "-",
     "obsolete": false,
@@ -64767,7 +59785,6 @@
   },
   {
     "id": 4983,
-    "entrezid": 882584,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64780,7 +59797,6 @@
   },
   {
     "id": 4984,
-    "entrezid": 882585,
     "description": "orotidine 5'-phosphate decarboxylase",
     "aliases": "-",
     "obsolete": false,
@@ -64793,7 +59809,6 @@
   },
   {
     "id": 4985,
-    "entrezid": 882586,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -64806,7 +59821,6 @@
   },
   {
     "id": 4986,
-    "entrezid": 882587,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -64819,7 +59833,6 @@
   },
   {
     "id": 4987,
-    "entrezid": 882588,
     "description": "long-chain-acyl-CoA synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -64832,7 +59845,6 @@
   },
   {
     "id": 4988,
-    "entrezid": 882589,
     "description": "imidazole glycerol phosphate synthase subunit HisH",
     "aliases": "-",
     "obsolete": false,
@@ -64845,7 +59857,6 @@
   },
   {
     "id": 4989,
-    "entrezid": 882590,
     "description": "O-antigen translocase",
     "aliases": "-",
     "obsolete": false,
@@ -64858,7 +59869,6 @@
   },
   {
     "id": 4990,
-    "entrezid": 882591,
     "description": "TonB-dependent receptor",
     "aliases": "-",
     "obsolete": false,
@@ -64871,7 +59881,6 @@
   },
   {
     "id": 4991,
-    "entrezid": 882592,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -64884,7 +59893,6 @@
   },
   {
     "id": 4992,
-    "entrezid": 882593,
     "description": "UDP-2-acetamido-3-amino-2,3-dideoxy-D-glucuronate N-acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -64897,7 +59905,6 @@
   },
   {
     "id": 4993,
-    "entrezid": 882594,
     "description": "secretion protein MttC",
     "aliases": "-",
     "obsolete": false,
@@ -64910,7 +59917,6 @@
   },
   {
     "id": 4994,
-    "entrezid": 882595,
     "description": "chemotaxis transducer",
     "aliases": "-",
     "obsolete": false,
@@ -64923,7 +59929,6 @@
   },
   {
     "id": 4995,
-    "entrezid": 882596,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64936,7 +59941,6 @@
   },
   {
     "id": 4996,
-    "entrezid": 882597,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64949,7 +59953,6 @@
   },
   {
     "id": 4997,
-    "entrezid": 882598,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64962,7 +59965,6 @@
   },
   {
     "id": 4998,
-    "entrezid": 882599,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64975,7 +59977,6 @@
   },
   {
     "id": 4999,
-    "entrezid": 882600,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -64988,7 +59989,6 @@
   },
   {
     "id": 5000,
-    "entrezid": 882601,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65001,7 +60001,6 @@
   },
   {
     "id": 5001,
-    "entrezid": 882602,
     "description": "secretion protein",
     "aliases": "-",
     "obsolete": false,
@@ -65014,7 +60013,6 @@
   },
   {
     "id": 5002,
-    "entrezid": 882603,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -65027,7 +60025,6 @@
   },
   {
     "id": 5003,
-    "entrezid": 882604,
     "description": "organic hydroperoxide resistance protein",
     "aliases": "-",
     "obsolete": false,
@@ -65040,7 +60037,6 @@
   },
   {
     "id": 5004,
-    "entrezid": 882605,
     "description": "elongation factor P",
     "aliases": "-",
     "obsolete": false,
@@ -65053,7 +60049,6 @@
   },
   {
     "id": 5005,
-    "entrezid": 882606,
     "description": "2'-5' RNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -65066,7 +60061,6 @@
   },
   {
     "id": 5006,
-    "entrezid": 882607,
     "description": "glycosyltransferase WbpH",
     "aliases": "-",
     "obsolete": false,
@@ -65079,7 +60073,6 @@
   },
   {
     "id": 5007,
-    "entrezid": 882608,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65092,7 +60085,6 @@
   },
   {
     "id": 5008,
-    "entrezid": 882609,
     "description": "citronellol catabolism dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -65105,7 +60097,6 @@
   },
   {
     "id": 5009,
-    "entrezid": 882610,
     "description": "molybdopterin oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -65118,7 +60109,6 @@
   },
   {
     "id": 5010,
-    "entrezid": 882611,
     "description": "ferredoxin",
     "aliases": "-",
     "obsolete": false,
@@ -65131,7 +60121,6 @@
   },
   {
     "id": 5011,
-    "entrezid": 882612,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65144,7 +60133,6 @@
   },
   {
     "id": 5012,
-    "entrezid": 882613,
     "description": "cysteine synthase A",
     "aliases": "-",
     "obsolete": false,
@@ -65157,7 +60145,6 @@
   },
   {
     "id": 5013,
-    "entrezid": 882614,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65170,7 +60157,6 @@
   },
   {
     "id": 5014,
-    "entrezid": 882615,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65183,7 +60169,6 @@
   },
   {
     "id": 5015,
-    "entrezid": 882616,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65196,7 +60181,6 @@
   },
   {
     "id": 5016,
-    "entrezid": 882617,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65209,7 +60193,6 @@
   },
   {
     "id": 5017,
-    "entrezid": 882618,
     "description": "HTH-type transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -65222,7 +60205,6 @@
   },
   {
     "id": 5018,
-    "entrezid": 882619,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65235,7 +60217,6 @@
   },
   {
     "id": 5019,
-    "entrezid": 882620,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -65248,7 +60229,6 @@
   },
   {
     "id": 5020,
-    "entrezid": 882621,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -65261,7 +60241,6 @@
   },
   {
     "id": 5021,
-    "entrezid": 882622,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -65274,7 +60253,6 @@
   },
   {
     "id": 5022,
-    "entrezid": 882623,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65287,7 +60265,6 @@
   },
   {
     "id": 5023,
-    "entrezid": 882624,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65300,7 +60277,6 @@
   },
   {
     "id": 5024,
-    "entrezid": 882625,
     "description": "restriction-modification system protein",
     "aliases": "-",
     "obsolete": false,
@@ -65313,7 +60289,6 @@
   },
   {
     "id": 5025,
-    "entrezid": 882626,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -65326,7 +60301,6 @@
   },
   {
     "id": 5026,
-    "entrezid": 882627,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -65339,7 +60313,6 @@
   },
   {
     "id": 5027,
-    "entrezid": 882628,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65352,7 +60325,6 @@
   },
   {
     "id": 5028,
-    "entrezid": 882630,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65365,7 +60337,6 @@
   },
   {
     "id": 5029,
-    "entrezid": 882631,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65378,7 +60349,6 @@
   },
   {
     "id": 5030,
-    "entrezid": 882632,
     "description": "phosphoglycolate phosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -65391,7 +60361,6 @@
   },
   {
     "id": 5031,
-    "entrezid": 882633,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -65404,7 +60373,6 @@
   },
   {
     "id": 5032,
-    "entrezid": 882634,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65417,7 +60385,6 @@
   },
   {
     "id": 5033,
-    "entrezid": 882635,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65430,7 +60397,6 @@
   },
   {
     "id": 5034,
-    "entrezid": 882636,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -65443,7 +60409,6 @@
   },
   {
     "id": 5035,
-    "entrezid": 882637,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65456,7 +60421,6 @@
   },
   {
     "id": 5036,
-    "entrezid": 882638,
     "description": "precorrin-3 methylase CobJ",
     "aliases": "-",
     "obsolete": false,
@@ -65469,7 +60433,6 @@
   },
   {
     "id": 5037,
-    "entrezid": 882639,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65482,7 +60445,6 @@
   },
   {
     "id": 5038,
-    "entrezid": 882640,
     "description": "heat-shock protein IbpA",
     "aliases": "-",
     "obsolete": false,
@@ -65495,7 +60457,6 @@
   },
   {
     "id": 5039,
-    "entrezid": 882641,
     "description": "acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -65508,7 +60469,6 @@
   },
   {
     "id": 5040,
-    "entrezid": 882642,
     "description": "UDP-N-acetyl-2-amino-2-deoxy-D-glucuronate oxidase",
     "aliases": "-",
     "obsolete": false,
@@ -65521,7 +60481,6 @@
   },
   {
     "id": 5041,
-    "entrezid": 882643,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65534,7 +60493,6 @@
   },
   {
     "id": 5042,
-    "entrezid": 882644,
     "description": "protein-glutamine gamma-glutamyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -65547,7 +60505,6 @@
   },
   {
     "id": 5043,
-    "entrezid": 882645,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65560,7 +60517,6 @@
   },
   {
     "id": 5044,
-    "entrezid": 882646,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -65573,7 +60529,6 @@
   },
   {
     "id": 5045,
-    "entrezid": 882647,
     "description": "glutamate--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -65586,7 +60541,6 @@
   },
   {
     "id": 5046,
-    "entrezid": 882648,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -65599,7 +60553,6 @@
   },
   {
     "id": 5047,
-    "entrezid": 882649,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65612,7 +60565,6 @@
   },
   {
     "id": 5048,
-    "entrezid": 882650,
     "description": "chaperone",
     "aliases": "-",
     "obsolete": false,
@@ -65625,7 +60577,6 @@
   },
   {
     "id": 5049,
-    "entrezid": 882651,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -65638,7 +60589,6 @@
   },
   {
     "id": 5050,
-    "entrezid": 882652,
     "description": "B-band O-antigen polymerase",
     "aliases": "-",
     "obsolete": false,
@@ -65651,7 +60601,6 @@
   },
   {
     "id": 5051,
-    "entrezid": 882653,
     "description": "UDP-2-acetamido-2-deoxy-3-oxo-D-glucuronate aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -65664,7 +60613,6 @@
   },
   {
     "id": 5052,
-    "entrezid": 882654,
     "description": "CFTR inhibitory factor",
     "aliases": "-",
     "obsolete": false,
@@ -65677,7 +60625,6 @@
   },
   {
     "id": 5053,
-    "entrezid": 882655,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65690,7 +60637,6 @@
   },
   {
     "id": 5054,
-    "entrezid": 882656,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65703,7 +60649,6 @@
   },
   {
     "id": 5055,
-    "entrezid": 882657,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65716,7 +60661,6 @@
   },
   {
     "id": 5056,
-    "entrezid": 882658,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -65729,7 +60673,6 @@
   },
   {
     "id": 5057,
-    "entrezid": 882659,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65742,7 +60685,6 @@
   },
   {
     "id": 5058,
-    "entrezid": 882660,
     "description": "glutamate/sodium ion symporter GltS",
     "aliases": "-",
     "obsolete": false,
@@ -65755,7 +60697,6 @@
   },
   {
     "id": 5059,
-    "entrezid": 882661,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65768,7 +60709,6 @@
   },
   {
     "id": 5060,
-    "entrezid": 882662,
     "description": "lactonizing lipase",
     "aliases": "-",
     "obsolete": false,
@@ -65781,7 +60721,6 @@
   },
   {
     "id": 5061,
-    "entrezid": 882663,
     "description": "lipase chaperone",
     "aliases": "-",
     "obsolete": false,
@@ -65794,7 +60733,6 @@
   },
   {
     "id": 5062,
-    "entrezid": 882664,
     "description": "acyl-CoA thiolase",
     "aliases": "-",
     "obsolete": false,
@@ -65807,7 +60745,6 @@
   },
   {
     "id": 5063,
-    "entrezid": 882665,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65820,7 +60757,6 @@
   },
   {
     "id": 5064,
-    "entrezid": 882666,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65833,7 +60769,6 @@
   },
   {
     "id": 5065,
-    "entrezid": 882667,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -65846,7 +60781,6 @@
   },
   {
     "id": 5066,
-    "entrezid": 882668,
     "description": "FMN oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -65859,7 +60793,6 @@
   },
   {
     "id": 5067,
-    "entrezid": 882669,
     "description": "chloroperoxidase",
     "aliases": "-",
     "obsolete": false,
@@ -65872,7 +60805,6 @@
   },
   {
     "id": 5068,
-    "entrezid": 882670,
     "description": "excinuclease ABC subunit B",
     "aliases": "-",
     "obsolete": false,
@@ -65885,7 +60817,6 @@
   },
   {
     "id": 5069,
-    "entrezid": 882671,
     "description": "aspartate aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -65898,7 +60829,6 @@
   },
   {
     "id": 5070,
-    "entrezid": 882672,
     "description": "N-ethylammeline chlorohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -65911,7 +60841,6 @@
   },
   {
     "id": 5071,
-    "entrezid": 882673,
     "description": "ubiquinone biosynthesis O-methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -65924,7 +60853,6 @@
   },
   {
     "id": 5072,
-    "entrezid": 882674,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65937,7 +60865,6 @@
   },
   {
     "id": 5073,
-    "entrezid": 882675,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -65950,7 +60877,6 @@
   },
   {
     "id": 5074,
-    "entrezid": 882676,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65963,7 +60889,6 @@
   },
   {
     "id": 5075,
-    "entrezid": 882677,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -65976,7 +60901,6 @@
   },
   {
     "id": 5076,
-    "entrezid": 882678,
     "description": "precorrin-6y-dependent methyltransferase CobL",
     "aliases": "-",
     "obsolete": false,
@@ -65989,7 +60913,6 @@
   },
   {
     "id": 5077,
-    "entrezid": 882679,
     "description": "cobalt-precorrin-5B C(1)-methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -66002,7 +60925,6 @@
   },
   {
     "id": 5078,
-    "entrezid": 882680,
     "description": "6-phosphogluconolactonase",
     "aliases": "-",
     "obsolete": false,
@@ -66015,7 +60937,6 @@
   },
   {
     "id": 5079,
-    "entrezid": 882681,
     "description": "glucose-6-phosphate 1-dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -66028,7 +60949,6 @@
   },
   {
     "id": 5080,
-    "entrezid": 882682,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66041,7 +60961,6 @@
   },
   {
     "id": 5081,
-    "entrezid": 882684,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -66054,7 +60973,6 @@
   },
   {
     "id": 5082,
-    "entrezid": 882685,
     "description": "formimidoylglutamase",
     "aliases": "-",
     "obsolete": false,
@@ -66067,7 +60985,6 @@
   },
   {
     "id": 5083,
-    "entrezid": 882686,
     "description": "cobalt-precorrin-6x reductase",
     "aliases": "-",
     "obsolete": false,
@@ -66080,7 +60997,6 @@
   },
   {
     "id": 5084,
-    "entrezid": 882687,
     "description": "manganese efflux pump MntP",
     "aliases": "-",
     "obsolete": false,
@@ -66093,7 +61009,6 @@
   },
   {
     "id": 5085,
-    "entrezid": 882688,
     "description": "precorrin-2 C(20)-methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -66106,7 +61021,6 @@
   },
   {
     "id": 5086,
-    "entrezid": 882689,
     "description": "precorrin-8X methylmutase",
     "aliases": "-",
     "obsolete": false,
@@ -66119,7 +61033,6 @@
   },
   {
     "id": 5087,
-    "entrezid": 882690,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -66132,7 +61045,6 @@
   },
   {
     "id": 5088,
-    "entrezid": 882691,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66145,7 +61057,6 @@
   },
   {
     "id": 5089,
-    "entrezid": 882692,
     "description": "glycosyl transferase WbpJ",
     "aliases": "-",
     "obsolete": false,
@@ -66158,7 +61069,6 @@
   },
   {
     "id": 5090,
-    "entrezid": 882693,
     "description": "UDP-2,3-diacetamido-2,3-dideoxy-D-glucuronate 2-epimeras",
     "aliases": "-",
     "obsolete": false,
@@ -66171,7 +61081,6 @@
   },
   {
     "id": 5091,
-    "entrezid": 882694,
     "description": "histidinol-phosphate aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -66184,7 +61093,6 @@
   },
   {
     "id": 5092,
-    "entrezid": 882695,
     "description": "histidine ABC transporter substrate-binding protein HisJ",
     "aliases": "-",
     "obsolete": false,
@@ -66197,7 +61105,6 @@
   },
   {
     "id": 5093,
-    "entrezid": 882696,
     "description": "histidine ABC transporter permease HisQ",
     "aliases": "-",
     "obsolete": false,
@@ -66210,7 +61117,6 @@
   },
   {
     "id": 5094,
-    "entrezid": 882697,
     "description": "glycosyltransferase WbpL",
     "aliases": "-",
     "obsolete": false,
@@ -66223,7 +61129,6 @@
   },
   {
     "id": 5095,
-    "entrezid": 882698,
     "description": "NAD-dependent epimerase/dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -66236,7 +61141,6 @@
   },
   {
     "id": 5096,
-    "entrezid": 882699,
     "description": "bifunctional chorismate mutase/prephenate dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -66249,7 +61153,6 @@
   },
   {
     "id": 5097,
-    "entrezid": 882700,
     "description": "3-phosphoserine/phosphohydroxythreonine aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -66262,7 +61165,6 @@
   },
   {
     "id": 5098,
-    "entrezid": 882701,
     "description": "geranyl-CoA carboxylase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -66275,7 +61177,6 @@
   },
   {
     "id": 5099,
-    "entrezid": 882702,
     "description": "citronellyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -66288,7 +61189,6 @@
   },
   {
     "id": 5100,
-    "entrezid": 882703,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66301,7 +61201,6 @@
   },
   {
     "id": 5101,
-    "entrezid": 882704,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66314,7 +61213,6 @@
   },
   {
     "id": 5102,
-    "entrezid": 882705,
     "description": "ribosomal large subunit pseudouridine synthase B",
     "aliases": "-",
     "obsolete": false,
@@ -66327,7 +61225,6 @@
   },
   {
     "id": 5103,
-    "entrezid": 882706,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66340,7 +61237,6 @@
   },
   {
     "id": 5104,
-    "entrezid": 882707,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66353,7 +61249,6 @@
   },
   {
     "id": 5105,
-    "entrezid": 882708,
     "description": "isohexenylglutaconyl-CoA hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -66366,7 +61261,6 @@
   },
   {
     "id": 5106,
-    "entrezid": 882709,
     "description": "geranyl-CoA carboxylase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -66379,7 +61273,6 @@
   },
   {
     "id": 5107,
-    "entrezid": 882710,
     "description": "thioredoxin",
     "aliases": "-",
     "obsolete": false,
@@ -66392,7 +61285,6 @@
   },
   {
     "id": 5108,
-    "entrezid": 882711,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66405,7 +61297,6 @@
   },
   {
     "id": 5109,
-    "entrezid": 882712,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66418,7 +61309,6 @@
   },
   {
     "id": 5110,
-    "entrezid": 882713,
     "description": "atu genes repressor",
     "aliases": "-",
     "obsolete": false,
@@ -66431,7 +61321,6 @@
   },
   {
     "id": 5111,
-    "entrezid": 882714,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -66444,7 +61333,6 @@
   },
   {
     "id": 5112,
-    "entrezid": 882715,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66457,7 +61345,6 @@
   },
   {
     "id": 5113,
-    "entrezid": 882716,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66470,7 +61357,6 @@
   },
   {
     "id": 5114,
-    "entrezid": 882717,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66483,7 +61369,6 @@
   },
   {
     "id": 5115,
-    "entrezid": 882718,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66496,7 +61381,6 @@
   },
   {
     "id": 5116,
-    "entrezid": 882719,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66509,7 +61393,6 @@
   },
   {
     "id": 5117,
-    "entrezid": 882720,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66522,7 +61405,6 @@
   },
   {
     "id": 5118,
-    "entrezid": 882721,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66535,7 +61417,6 @@
   },
   {
     "id": 5119,
-    "entrezid": 882722,
     "description": "trans-aconitate 2-methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -66548,7 +61429,6 @@
   },
   {
     "id": 5120,
-    "entrezid": 882723,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66561,7 +61441,6 @@
   },
   {
     "id": 5121,
-    "entrezid": 882724,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66574,7 +61453,6 @@
   },
   {
     "id": 5122,
-    "entrezid": 882725,
     "description": "ecotin",
     "aliases": "-",
     "obsolete": false,
@@ -66587,7 +61465,6 @@
   },
   {
     "id": 5123,
-    "entrezid": 882726,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66600,7 +61477,6 @@
   },
   {
     "id": 5124,
-    "entrezid": 882727,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66613,7 +61489,6 @@
   },
   {
     "id": 5125,
-    "entrezid": 882728,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66626,7 +61501,6 @@
   },
   {
     "id": 5126,
-    "entrezid": 882729,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66639,7 +61513,6 @@
   },
   {
     "id": 5127,
-    "entrezid": 882730,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66652,7 +61525,6 @@
   },
   {
     "id": 5128,
-    "entrezid": 882731,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66665,7 +61537,6 @@
   },
   {
     "id": 5129,
-    "entrezid": 882732,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66678,7 +61549,6 @@
   },
   {
     "id": 5130,
-    "entrezid": 882733,
     "description": "sulfate transporter",
     "aliases": "-",
     "obsolete": false,
@@ -66691,7 +61561,6 @@
   },
   {
     "id": 5131,
-    "entrezid": 882734,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66704,7 +61573,6 @@
   },
   {
     "id": 5132,
-    "entrezid": 882735,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66717,7 +61585,6 @@
   },
   {
     "id": 5133,
-    "entrezid": 882736,
     "description": "NAD kinase",
     "aliases": "-",
     "obsolete": false,
@@ -66730,7 +61597,6 @@
   },
   {
     "id": 5134,
-    "entrezid": 882737,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66743,7 +61609,6 @@
   },
   {
     "id": 5135,
-    "entrezid": 882738,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66756,7 +61621,6 @@
   },
   {
     "id": 5136,
-    "entrezid": 882739,
     "description": "methyl-accepting chemotaxis protein CtpH",
     "aliases": "-",
     "obsolete": false,
@@ -66769,7 +61633,6 @@
   },
   {
     "id": 5137,
-    "entrezid": 882740,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66782,7 +61645,6 @@
   },
   {
     "id": 5138,
-    "entrezid": 882741,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -66795,7 +61657,6 @@
   },
   {
     "id": 5139,
-    "entrezid": 882742,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -66808,7 +61669,6 @@
   },
   {
     "id": 5140,
-    "entrezid": 882743,
     "description": "AMP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -66821,7 +61681,6 @@
   },
   {
     "id": 5141,
-    "entrezid": 882744,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66834,7 +61693,6 @@
   },
   {
     "id": 5142,
-    "entrezid": 882745,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66847,7 +61705,6 @@
   },
   {
     "id": 5143,
-    "entrezid": 882747,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66860,7 +61717,6 @@
   },
   {
     "id": 5144,
-    "entrezid": 882748,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -66873,7 +61729,6 @@
   },
   {
     "id": 5145,
-    "entrezid": 882749,
     "description": "AMP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -66886,7 +61741,6 @@
   },
   {
     "id": 5146,
-    "entrezid": 882750,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66899,7 +61753,6 @@
   },
   {
     "id": 5147,
-    "entrezid": 882751,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66912,7 +61765,6 @@
   },
   {
     "id": 5148,
-    "entrezid": 882752,
     "description": "quinone oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -66925,7 +61777,6 @@
   },
   {
     "id": 5149,
-    "entrezid": 882753,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -66938,7 +61789,6 @@
   },
   {
     "id": 5150,
-    "entrezid": 882754,
     "description": "tRNA-dihydrouridine synthase A",
     "aliases": "-",
     "obsolete": false,
@@ -66951,7 +61801,6 @@
   },
   {
     "id": 5151,
-    "entrezid": 882755,
     "description": "transaldolase B",
     "aliases": "-",
     "obsolete": false,
@@ -66964,7 +61813,6 @@
   },
   {
     "id": 5152,
-    "entrezid": 882756,
     "description": "type II secretion system protein H",
     "aliases": "-",
     "obsolete": false,
@@ -66977,7 +61825,6 @@
   },
   {
     "id": 5153,
-    "entrezid": 882757,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -66990,7 +61837,6 @@
   },
   {
     "id": 5154,
-    "entrezid": 882758,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67003,7 +61849,6 @@
   },
   {
     "id": 5155,
-    "entrezid": 882759,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67016,7 +61861,6 @@
   },
   {
     "id": 5156,
-    "entrezid": 882760,
     "description": "serine/threonine dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -67029,7 +61873,6 @@
   },
   {
     "id": 5157,
-    "entrezid": 882761,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -67042,7 +61885,6 @@
   },
   {
     "id": 5158,
-    "entrezid": 882762,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67055,7 +61897,6 @@
   },
   {
     "id": 5159,
-    "entrezid": 882763,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67068,7 +61909,6 @@
   },
   {
     "id": 5160,
-    "entrezid": 882764,
     "description": "two-component response regulator PfeR",
     "aliases": "-",
     "obsolete": false,
@@ -67081,7 +61921,6 @@
   },
   {
     "id": 5161,
-    "entrezid": 882765,
     "description": "two-component sensor histidine kinase PfeS",
     "aliases": "-",
     "obsolete": false,
@@ -67094,7 +61933,6 @@
   },
   {
     "id": 5162,
-    "entrezid": 882766,
     "description": "type II secretion system protein M",
     "aliases": "-",
     "obsolete": false,
@@ -67107,7 +61945,6 @@
   },
   {
     "id": 5163,
-    "entrezid": 882767,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -67120,7 +61957,6 @@
   },
   {
     "id": 5164,
-    "entrezid": 882768,
     "description": "short-chain dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -67133,7 +61969,6 @@
   },
   {
     "id": 5165,
-    "entrezid": 882769,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67146,7 +61981,6 @@
   },
   {
     "id": 5166,
-    "entrezid": 882770,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67159,7 +61993,6 @@
   },
   {
     "id": 5167,
-    "entrezid": 882771,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67172,7 +62005,6 @@
   },
   {
     "id": 5168,
-    "entrezid": 882772,
     "description": "enoyl-CoA hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -67185,7 +62017,6 @@
   },
   {
     "id": 5169,
-    "entrezid": 882773,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67198,7 +62029,6 @@
   },
   {
     "id": 5170,
-    "entrezid": 882774,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67211,7 +62041,6 @@
   },
   {
     "id": 5171,
-    "entrezid": 882775,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67224,7 +62053,6 @@
   },
   {
     "id": 5172,
-    "entrezid": 882776,
     "description": "type II secretion system protein J",
     "aliases": "-",
     "obsolete": false,
@@ -67237,7 +62065,6 @@
   },
   {
     "id": 5173,
-    "entrezid": 882777,
     "description": "type II secretion system protein I",
     "aliases": "-",
     "obsolete": false,
@@ -67250,7 +62077,6 @@
   },
   {
     "id": 5174,
-    "entrezid": 882778,
     "description": "type II secretion system protein L",
     "aliases": "-",
     "obsolete": false,
@@ -67263,7 +62089,6 @@
   },
   {
     "id": 5175,
-    "entrezid": 882779,
     "description": "type II secretion system protein K",
     "aliases": "-",
     "obsolete": false,
@@ -67276,7 +62101,6 @@
   },
   {
     "id": 5176,
-    "entrezid": 882780,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67289,7 +62113,6 @@
   },
   {
     "id": 5177,
-    "entrezid": 882781,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67302,7 +62125,6 @@
   },
   {
     "id": 5178,
-    "entrezid": 882782,
     "description": "glutamate carboxypeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -67315,7 +62137,6 @@
   },
   {
     "id": 5179,
-    "entrezid": 882783,
     "description": "chemotaxis transducer",
     "aliases": "-",
     "obsolete": false,
@@ -67328,7 +62149,6 @@
   },
   {
     "id": 5180,
-    "entrezid": 882784,
     "description": "ferric enterobactin receptor",
     "aliases": "-",
     "obsolete": false,
@@ -67341,7 +62161,6 @@
   },
   {
     "id": 5181,
-    "entrezid": 882785,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67354,7 +62173,6 @@
   },
   {
     "id": 5182,
-    "entrezid": 882786,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67367,7 +62185,6 @@
   },
   {
     "id": 5183,
-    "entrezid": 882787,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67380,7 +62197,6 @@
   },
   {
     "id": 5184,
-    "entrezid": 882788,
     "description": "porin B",
     "aliases": "-",
     "obsolete": false,
@@ -67393,7 +62209,6 @@
   },
   {
     "id": 5185,
-    "entrezid": 882789,
     "description": "RNA polymerase sigma factor",
     "aliases": "-",
     "obsolete": false,
@@ -67406,7 +62221,6 @@
   },
   {
     "id": 5186,
-    "entrezid": 882790,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -67419,7 +62233,6 @@
   },
   {
     "id": 5187,
-    "entrezid": 882791,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -67432,7 +62245,6 @@
   },
   {
     "id": 5188,
-    "entrezid": 882792,
     "description": "aminopeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -67445,7 +62257,6 @@
   },
   {
     "id": 5189,
-    "entrezid": 882793,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67458,7 +62269,6 @@
   },
   {
     "id": 5190,
-    "entrezid": 882794,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67471,7 +62281,6 @@
   },
   {
     "id": 5191,
-    "entrezid": 882795,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67484,7 +62293,6 @@
   },
   {
     "id": 5192,
-    "entrezid": 882796,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -67497,7 +62305,6 @@
   },
   {
     "id": 5193,
-    "entrezid": 882797,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67510,7 +62317,6 @@
   },
   {
     "id": 5194,
-    "entrezid": 882798,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67523,7 +62329,6 @@
   },
   {
     "id": 5195,
-    "entrezid": 882799,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -67536,7 +62341,6 @@
   },
   {
     "id": 5196,
-    "entrezid": 882800,
     "description": "DNA gyrase subunit A",
     "aliases": "-",
     "obsolete": false,
@@ -67549,7 +62353,6 @@
   },
   {
     "id": 5197,
-    "entrezid": 882801,
     "description": "methylthioribose-1-phosphate isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -67562,7 +62365,6 @@
   },
   {
     "id": 5198,
-    "entrezid": 882802,
     "description": "aspartate-semialdehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -67575,7 +62377,6 @@
   },
   {
     "id": 5199,
-    "entrezid": 882803,
     "description": "aspartate-semialdehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -67588,7 +62389,6 @@
   },
   {
     "id": 5200,
-    "entrezid": 882804,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67601,7 +62401,6 @@
   },
   {
     "id": 5201,
-    "entrezid": 882805,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -67614,7 +62413,6 @@
   },
   {
     "id": 5202,
-    "entrezid": 882806,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -67627,7 +62425,6 @@
   },
   {
     "id": 5203,
-    "entrezid": 882807,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -67640,7 +62437,6 @@
   },
   {
     "id": 5204,
-    "entrezid": 882808,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67653,7 +62449,6 @@
   },
   {
     "id": 5205,
-    "entrezid": 882809,
     "description": "deaminase",
     "aliases": "-",
     "obsolete": false,
@@ -67666,7 +62461,6 @@
   },
   {
     "id": 5206,
-    "entrezid": 882810,
     "description": "protease HtpX",
     "aliases": "-",
     "obsolete": false,
@@ -67679,7 +62473,6 @@
   },
   {
     "id": 5207,
-    "entrezid": 882811,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67692,7 +62485,6 @@
   },
   {
     "id": 5208,
-    "entrezid": 882812,
     "description": "3-isopropylmalate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -67705,7 +62497,6 @@
   },
   {
     "id": 5209,
-    "entrezid": 882813,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67718,7 +62509,6 @@
   },
   {
     "id": 5210,
-    "entrezid": 882814,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67731,7 +62521,6 @@
   },
   {
     "id": 5211,
-    "entrezid": 882815,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67744,7 +62533,6 @@
   },
   {
     "id": 5212,
-    "entrezid": 882816,
     "description": "thiopurine S-methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -67757,7 +62545,6 @@
   },
   {
     "id": 5213,
-    "entrezid": 882817,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67770,7 +62557,6 @@
   },
   {
     "id": 5214,
-    "entrezid": 882818,
     "description": "isopropylmalate isomerase small subunit",
     "aliases": "-",
     "obsolete": false,
@@ -67783,7 +62569,6 @@
   },
   {
     "id": 5215,
-    "entrezid": 882819,
     "description": "secretion protein",
     "aliases": "-",
     "obsolete": false,
@@ -67796,7 +62581,6 @@
   },
   {
     "id": 5216,
-    "entrezid": 882820,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67809,7 +62593,6 @@
   },
   {
     "id": 5217,
-    "entrezid": 882821,
     "description": "transcriptional regulator CatR",
     "aliases": "-",
     "obsolete": false,
@@ -67822,7 +62605,6 @@
   },
   {
     "id": 5218,
-    "entrezid": 882822,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -67835,7 +62617,6 @@
   },
   {
     "id": 5219,
-    "entrezid": 882823,
     "description": "ATP-dependent RNA helicase",
     "aliases": "-",
     "obsolete": false,
@@ -67848,7 +62629,6 @@
   },
   {
     "id": 5220,
-    "entrezid": 882824,
     "description": "enoyl-CoA hydratase",
     "aliases": "-",
     "obsolete": false,
@@ -67861,7 +62641,6 @@
   },
   {
     "id": 5221,
-    "entrezid": 882825,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -67874,7 +62653,6 @@
   },
   {
     "id": 5222,
-    "entrezid": 882826,
     "description": "acyl-CoA thioesterase",
     "aliases": "-",
     "obsolete": false,
@@ -67887,7 +62665,6 @@
   },
   {
     "id": 5223,
-    "entrezid": 882827,
     "description": "3-isopropylmalate dehydratase large subunit",
     "aliases": "-",
     "obsolete": false,
@@ -67900,7 +62677,6 @@
   },
   {
     "id": 5224,
-    "entrezid": 882828,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -67913,7 +62689,6 @@
   },
   {
     "id": 5225,
-    "entrezid": 882829,
     "description": "glyceraldehyde 3-phosphate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -67926,7 +62701,6 @@
   },
   {
     "id": 5226,
-    "entrezid": 882830,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -67939,7 +62713,6 @@
   },
   {
     "id": 5227,
-    "entrezid": 882831,
     "description": "cobaltochelatase subunit CobN",
     "aliases": "-",
     "obsolete": false,
@@ -67952,7 +62725,6 @@
   },
   {
     "id": 5228,
-    "entrezid": 882832,
     "description": "cobalamin biosynthesis protein CobW",
     "aliases": "-",
     "obsolete": false,
@@ -67965,7 +62737,6 @@
   },
   {
     "id": 5229,
-    "entrezid": 882833,
     "description": "magnesium chelatase",
     "aliases": "-",
     "obsolete": false,
@@ -67978,7 +62749,6 @@
   },
   {
     "id": 5230,
-    "entrezid": 882834,
     "description": "phospho-2-dehydro-3-deoxyheptonate aldolase",
     "aliases": "-",
     "obsolete": false,
@@ -67991,7 +62761,6 @@
   },
   {
     "id": 5231,
-    "entrezid": 882835,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68004,7 +62773,6 @@
   },
   {
     "id": 5232,
-    "entrezid": 882836,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68017,7 +62785,6 @@
   },
   {
     "id": 5233,
-    "entrezid": 882837,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -68030,7 +62797,6 @@
   },
   {
     "id": 5234,
-    "entrezid": 882838,
     "description": "peptide synthase",
     "aliases": "-",
     "obsolete": false,
@@ -68043,7 +62809,6 @@
   },
   {
     "id": 5235,
-    "entrezid": 882839,
     "description": "extracytoplasmic-function sigma-70 factor",
     "aliases": "-",
     "obsolete": false,
@@ -68056,7 +62821,6 @@
   },
   {
     "id": 5236,
-    "entrezid": 882840,
     "description": "pyoverdine biosynthesis protein PvdG",
     "aliases": "-",
     "obsolete": false,
@@ -68069,7 +62833,6 @@
   },
   {
     "id": 5237,
-    "entrezid": 882841,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68082,7 +62845,6 @@
   },
   {
     "id": 5238,
-    "entrezid": 882842,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68095,7 +62857,6 @@
   },
   {
     "id": 5239,
-    "entrezid": 882843,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68108,7 +62869,6 @@
   },
   {
     "id": 5240,
-    "entrezid": 882844,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68121,7 +62881,6 @@
   },
   {
     "id": 5241,
-    "entrezid": 882845,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68134,7 +62893,6 @@
   },
   {
     "id": 5242,
-    "entrezid": 882846,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68147,7 +62905,6 @@
   },
   {
     "id": 5243,
-    "entrezid": 882847,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68160,7 +62917,6 @@
   },
   {
     "id": 5244,
-    "entrezid": 882848,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68173,7 +62929,6 @@
   },
   {
     "id": 5245,
-    "entrezid": 882849,
     "description": "cation-transporting P-type ATPase",
     "aliases": "-",
     "obsolete": false,
@@ -68186,7 +62941,6 @@
   },
   {
     "id": 5246,
-    "entrezid": 882850,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68199,7 +62953,6 @@
   },
   {
     "id": 5247,
-    "entrezid": 882851,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68212,7 +62965,6 @@
   },
   {
     "id": 5248,
-    "entrezid": 882852,
     "description": "bistable expression regulator BexR",
     "aliases": "-",
     "obsolete": false,
@@ -68225,7 +62977,6 @@
   },
   {
     "id": 5249,
-    "entrezid": 882853,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68238,7 +62989,6 @@
   },
   {
     "id": 5250,
-    "entrezid": 882854,
     "description": "precorrin-4 C(11)-methyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -68251,7 +63001,6 @@
   },
   {
     "id": 5251,
-    "entrezid": 882855,
     "description": "lipase",
     "aliases": "-",
     "obsolete": false,
@@ -68264,7 +63013,6 @@
   },
   {
     "id": 5252,
-    "entrezid": 882856,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68277,7 +63025,6 @@
   },
   {
     "id": 5253,
-    "entrezid": 882857,
     "description": "diaminobutyrate--2-oxoglutarate aminotransferase",
     "aliases": "-",
     "obsolete": false,
@@ -68290,7 +63037,6 @@
   },
   {
     "id": 5254,
-    "entrezid": 882858,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -68303,7 +63049,6 @@
   },
   {
     "id": 5255,
-    "entrezid": 882859,
     "description": "ferrioxamine receptor FoxA",
     "aliases": "-",
     "obsolete": false,
@@ -68316,7 +63061,6 @@
   },
   {
     "id": 5256,
-    "entrezid": 882860,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68329,7 +63073,6 @@
   },
   {
     "id": 5257,
-    "entrezid": 882861,
     "description": "trehalase",
     "aliases": "-",
     "obsolete": false,
@@ -68342,7 +63085,6 @@
   },
   {
     "id": 5258,
-    "entrezid": 882862,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -68355,7 +63097,6 @@
   },
   {
     "id": 5259,
-    "entrezid": 882863,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68368,7 +63109,6 @@
   },
   {
     "id": 5260,
-    "entrezid": 882864,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68381,7 +63121,6 @@
   },
   {
     "id": 5261,
-    "entrezid": 882865,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68394,7 +63133,6 @@
   },
   {
     "id": 5262,
-    "entrezid": 882866,
     "description": "ribosome modulation factor",
     "aliases": "-",
     "obsolete": false,
@@ -68407,7 +63145,6 @@
   },
   {
     "id": 5263,
-    "entrezid": 882867,
     "description": "dihydroorotate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -68420,7 +63157,6 @@
   },
   {
     "id": 5264,
-    "entrezid": 882868,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -68433,7 +63169,6 @@
   },
   {
     "id": 5265,
-    "entrezid": 882869,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68446,7 +63181,6 @@
   },
   {
     "id": 5266,
-    "entrezid": 882870,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68459,7 +63193,6 @@
   },
   {
     "id": 5267,
-    "entrezid": 882871,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68472,7 +63205,6 @@
   },
   {
     "id": 5268,
-    "entrezid": 882872,
     "description": "deoxyguanosinetriphosphate triphosphohydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -68485,7 +63217,6 @@
   },
   {
     "id": 5269,
-    "entrezid": 882873,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -68498,7 +63229,6 @@
   },
   {
     "id": 5270,
-    "entrezid": 882874,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68511,7 +63241,6 @@
   },
   {
     "id": 5271,
-    "entrezid": 882875,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68524,7 +63253,6 @@
   },
   {
     "id": 5272,
-    "entrezid": 882876,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68537,7 +63265,6 @@
   },
   {
     "id": 5273,
-    "entrezid": 882877,
     "description": "porin",
     "aliases": "-",
     "obsolete": false,
@@ -68550,7 +63277,6 @@
   },
   {
     "id": 5274,
-    "entrezid": 882878,
     "description": "D-alanyl-D-alanine carboxypeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -68563,7 +63289,6 @@
   },
   {
     "id": 5275,
-    "entrezid": 882879,
     "description": "ribosomal RNA large subunit methyltransferase K/L",
     "aliases": "-",
     "obsolete": false,
@@ -68576,7 +63301,6 @@
   },
   {
     "id": 5276,
-    "entrezid": 882880,
     "description": "glutathione S-transferase",
     "aliases": "-",
     "obsolete": false,
@@ -68589,7 +63313,6 @@
   },
   {
     "id": 5277,
-    "entrezid": 882881,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68602,7 +63325,6 @@
   },
   {
     "id": 5278,
-    "entrezid": 882882,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -68615,7 +63337,6 @@
   },
   {
     "id": 5279,
-    "entrezid": 882883,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68628,7 +63349,6 @@
   },
   {
     "id": 5280,
-    "entrezid": 882884,
     "description": "resistance-nodulation-cell division (RND) multidrug efflux transporter MexF",
     "aliases": "-",
     "obsolete": false,
@@ -68641,7 +63361,6 @@
   },
   {
     "id": 5281,
-    "entrezid": 882885,
     "description": "multidrug efflux outer membrane protein OprN",
     "aliases": "-",
     "obsolete": false,
@@ -68654,7 +63373,6 @@
   },
   {
     "id": 5282,
-    "entrezid": 882886,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68667,7 +63385,6 @@
   },
   {
     "id": 5283,
-    "entrezid": 882887,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -68680,7 +63397,6 @@
   },
   {
     "id": 5284,
-    "entrezid": 882888,
     "description": "resistance-nodulation-cell division (RND) efflux transporter",
     "aliases": "-",
     "obsolete": false,
@@ -68693,7 +63409,6 @@
   },
   {
     "id": 5285,
-    "entrezid": 882889,
     "description": "resistance-nodulation-cell division (RND) efflux transporter",
     "aliases": "-",
     "obsolete": false,
@@ -68706,7 +63421,6 @@
   },
   {
     "id": 5286,
-    "entrezid": 882890,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68719,7 +63433,6 @@
   },
   {
     "id": 5287,
-    "entrezid": 882891,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -68732,7 +63445,6 @@
   },
   {
     "id": 5288,
-    "entrezid": 882892,
     "description": "anthranilate dioxygenase large subunit",
     "aliases": "-",
     "obsolete": false,
@@ -68745,7 +63457,6 @@
   },
   {
     "id": 5289,
-    "entrezid": 882893,
     "description": "transcriptional regulator XylS",
     "aliases": "-",
     "obsolete": false,
@@ -68758,7 +63469,6 @@
   },
   {
     "id": 5290,
-    "entrezid": 882894,
     "description": "outer membrane protein CzcC",
     "aliases": "-",
     "obsolete": false,
@@ -68771,7 +63481,6 @@
   },
   {
     "id": 5291,
-    "entrezid": 882895,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -68784,7 +63493,6 @@
   },
   {
     "id": 5292,
-    "entrezid": 882896,
     "description": "transposase",
     "aliases": "-",
     "obsolete": false,
@@ -68797,7 +63505,6 @@
   },
   {
     "id": 5293,
-    "entrezid": 882897,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68810,7 +63517,6 @@
   },
   {
     "id": 5294,
-    "entrezid": 882898,
     "description": "ring-cleaving dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -68823,7 +63529,6 @@
   },
   {
     "id": 5295,
-    "entrezid": 882899,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -68836,7 +63541,6 @@
   },
   {
     "id": 5296,
-    "entrezid": 882900,
     "description": "sugar ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -68849,7 +63553,6 @@
   },
   {
     "id": 5297,
-    "entrezid": 882901,
     "description": "sugar ABC transporter substrate-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -68862,7 +63565,6 @@
   },
   {
     "id": 5298,
-    "entrezid": 882902,
     "description": "toluate 1,2-dioxygenase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -68875,7 +63577,6 @@
   },
   {
     "id": 5299,
-    "entrezid": 882903,
     "description": "toluate 1,2-dioxygenase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -68888,7 +63589,6 @@
   },
   {
     "id": 5300,
-    "entrezid": 882904,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -68901,7 +63601,6 @@
   },
   {
     "id": 5301,
-    "entrezid": 882905,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -68914,7 +63613,6 @@
   },
   {
     "id": 5302,
-    "entrezid": 882906,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -68927,7 +63625,6 @@
   },
   {
     "id": 5303,
-    "entrezid": 882907,
     "description": "two-component response regulator GltR",
     "aliases": "-",
     "obsolete": false,
@@ -68940,7 +63637,6 @@
   },
   {
     "id": 5304,
-    "entrezid": 882908,
     "description": "glucokinase",
     "aliases": "-",
     "obsolete": false,
@@ -68953,7 +63649,6 @@
   },
   {
     "id": 5305,
-    "entrezid": 882909,
     "description": "phosphogluconate dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -68966,7 +63661,6 @@
   },
   {
     "id": 5306,
-    "entrezid": 882910,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -68979,7 +63673,6 @@
   },
   {
     "id": 5307,
-    "entrezid": 882911,
     "description": "bacterioferritin",
     "aliases": "-",
     "obsolete": false,
@@ -68992,7 +63685,6 @@
   },
   {
     "id": 5308,
-    "entrezid": 882912,
     "description": "ECF sigma factor FoxI",
     "aliases": "-",
     "obsolete": false,
@@ -69005,7 +63697,6 @@
   },
   {
     "id": 5309,
-    "entrezid": 882913,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69018,7 +63709,6 @@
   },
   {
     "id": 5310,
-    "entrezid": 882914,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69031,7 +63721,6 @@
   },
   {
     "id": 5311,
-    "entrezid": 882915,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69044,7 +63733,6 @@
   },
   {
     "id": 5312,
-    "entrezid": 882916,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -69057,7 +63745,6 @@
   },
   {
     "id": 5313,
-    "entrezid": 882918,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69070,7 +63757,6 @@
   },
   {
     "id": 5314,
-    "entrezid": 882919,
     "description": "glutathione S-transferase",
     "aliases": "-",
     "obsolete": false,
@@ -69083,7 +63769,6 @@
   },
   {
     "id": 5315,
-    "entrezid": 882920,
     "description": "gentisate 1,2-dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -69096,7 +63781,6 @@
   },
   {
     "id": 5316,
-    "entrezid": 882921,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69109,7 +63793,6 @@
   },
   {
     "id": 5317,
-    "entrezid": 882922,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -69122,7 +63805,6 @@
   },
   {
     "id": 5318,
-    "entrezid": 882923,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -69135,7 +63817,6 @@
   },
   {
     "id": 5319,
-    "entrezid": 882924,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69148,7 +63829,6 @@
   },
   {
     "id": 5320,
-    "entrezid": 882925,
     "description": "serine hydroxymethyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -69161,7 +63841,6 @@
   },
   {
     "id": 5321,
-    "entrezid": 882926,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -69174,7 +63853,6 @@
   },
   {
     "id": 5322,
-    "entrezid": 882927,
     "description": "glycine dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -69187,7 +63865,6 @@
   },
   {
     "id": 5323,
-    "entrezid": 882928,
     "description": "glycine cleavage system protein H",
     "aliases": "-",
     "obsolete": false,
@@ -69200,7 +63877,6 @@
   },
   {
     "id": 5324,
-    "entrezid": 882929,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69213,7 +63889,6 @@
   },
   {
     "id": 5325,
-    "entrezid": 882930,
     "description": "L-serine dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -69226,7 +63901,6 @@
   },
   {
     "id": 5326,
-    "entrezid": 882931,
     "description": "reductase",
     "aliases": "-",
     "obsolete": false,
@@ -69239,7 +63913,6 @@
   },
   {
     "id": 5327,
-    "entrezid": 882932,
     "description": "electron transfer flavoprotein subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -69252,7 +63925,6 @@
   },
   {
     "id": 5328,
-    "entrezid": 882933,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69265,7 +63937,6 @@
   },
   {
     "id": 5329,
-    "entrezid": 882934,
     "description": "glycine cleavage system protein T2",
     "aliases": "-",
     "obsolete": false,
@@ -69278,7 +63949,6 @@
   },
   {
     "id": 5330,
-    "entrezid": 882935,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69291,7 +63961,6 @@
   },
   {
     "id": 5331,
-    "entrezid": 882936,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69304,7 +63973,6 @@
   },
   {
     "id": 5332,
-    "entrezid": 882937,
     "description": "resistance-nodulation-cell division (RND) efflux membrane fusion protein",
     "aliases": "-",
     "obsolete": false,
@@ -69317,7 +63985,6 @@
   },
   {
     "id": 5333,
-    "entrezid": 882938,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69330,7 +63997,6 @@
   },
   {
     "id": 5334,
-    "entrezid": 882939,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69343,7 +64009,6 @@
   },
   {
     "id": 5335,
-    "entrezid": 882940,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69356,7 +64021,6 @@
   },
   {
     "id": 5336,
-    "entrezid": 882941,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69369,7 +64033,6 @@
   },
   {
     "id": 5337,
-    "entrezid": 882942,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69382,7 +64045,6 @@
   },
   {
     "id": 5338,
-    "entrezid": 882943,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69395,7 +64057,6 @@
   },
   {
     "id": 5339,
-    "entrezid": 882944,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69408,7 +64069,6 @@
   },
   {
     "id": 5340,
-    "entrezid": 882945,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69421,7 +64081,6 @@
   },
   {
     "id": 5341,
-    "entrezid": 882946,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69434,7 +64093,6 @@
   },
   {
     "id": 5342,
-    "entrezid": 882947,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -69447,7 +64105,6 @@
   },
   {
     "id": 5343,
-    "entrezid": 882948,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69460,7 +64117,6 @@
   },
   {
     "id": 5344,
-    "entrezid": 882949,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69473,7 +64129,6 @@
   },
   {
     "id": 5345,
-    "entrezid": 882950,
     "description": "glycine betaine transmethylase",
     "aliases": "-",
     "obsolete": false,
@@ -69486,7 +64141,6 @@
   },
   {
     "id": 5346,
-    "entrezid": 882951,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69499,7 +64153,6 @@
   },
   {
     "id": 5347,
-    "entrezid": 882952,
     "description": "aminopeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -69512,7 +64165,6 @@
   },
   {
     "id": 5348,
-    "entrezid": 882953,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69525,7 +64177,6 @@
   },
   {
     "id": 5349,
-    "entrezid": 882954,
     "description": "integration host factor subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -69538,7 +64189,6 @@
   },
   {
     "id": 5350,
-    "entrezid": 882955,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69551,7 +64201,6 @@
   },
   {
     "id": 5351,
-    "entrezid": 882956,
     "description": "nitronate monooxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -69564,7 +64213,6 @@
   },
   {
     "id": 5352,
-    "entrezid": 882957,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69577,7 +64225,6 @@
   },
   {
     "id": 5353,
-    "entrezid": 882958,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69590,7 +64237,6 @@
   },
   {
     "id": 5354,
-    "entrezid": 882959,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69603,7 +64249,6 @@
   },
   {
     "id": 5355,
-    "entrezid": 882960,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69616,7 +64261,6 @@
   },
   {
     "id": 5356,
-    "entrezid": 882961,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69629,7 +64273,6 @@
   },
   {
     "id": 5357,
-    "entrezid": 882962,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69642,7 +64285,6 @@
   },
   {
     "id": 5358,
-    "entrezid": 882963,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69655,7 +64297,6 @@
   },
   {
     "id": 5359,
-    "entrezid": 882964,
     "description": "methionine aminopeptidase",
     "aliases": "-",
     "obsolete": false,
@@ -69668,7 +64309,6 @@
   },
   {
     "id": 5360,
-    "entrezid": 882965,
     "description": "DNA-specific endonuclease I",
     "aliases": "-",
     "obsolete": false,
@@ -69681,7 +64321,6 @@
   },
   {
     "id": 5361,
-    "entrezid": 882967,
     "description": "muconolactone delta-isomerase",
     "aliases": "-",
     "obsolete": false,
@@ -69694,7 +64333,6 @@
   },
   {
     "id": 5362,
-    "entrezid": 882968,
     "description": "muconate cycloisomerase I",
     "aliases": "-",
     "obsolete": false,
@@ -69707,7 +64345,6 @@
   },
   {
     "id": 5363,
-    "entrezid": 882969,
     "description": "phenylalanine--tRNA ligase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -69720,7 +64357,6 @@
   },
   {
     "id": 5364,
-    "entrezid": 882970,
     "description": "phenylalanine--tRNA ligase subunit alpha",
     "aliases": "-",
     "obsolete": false,
@@ -69733,7 +64369,6 @@
   },
   {
     "id": 5365,
-    "entrezid": 882971,
     "description": "anti-sigma factor FoxR",
     "aliases": "-",
     "obsolete": false,
@@ -69746,7 +64381,6 @@
   },
   {
     "id": 5366,
-    "entrezid": 882972,
     "description": "threonine--tRNA ligase",
     "aliases": "-",
     "obsolete": false,
@@ -69759,7 +64393,6 @@
   },
   {
     "id": 5367,
-    "entrezid": 882973,
     "description": "hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -69772,7 +64405,6 @@
   },
   {
     "id": 5368,
-    "entrezid": 882974,
     "description": "two-component response regulator",
     "aliases": "-",
     "obsolete": false,
@@ -69785,7 +64417,6 @@
   },
   {
     "id": 5369,
-    "entrezid": 882975,
     "description": "two-component sensor",
     "aliases": "-",
     "obsolete": false,
@@ -69798,7 +64429,6 @@
   },
   {
     "id": 5370,
-    "entrezid": 882976,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69811,7 +64441,6 @@
   },
   {
     "id": 5371,
-    "entrezid": 882977,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -69824,7 +64453,6 @@
   },
   {
     "id": 5372,
-    "entrezid": 882978,
     "description": "anthranilate dioxygenase small subunit",
     "aliases": "-",
     "obsolete": false,
@@ -69837,7 +64465,6 @@
   },
   {
     "id": 5373,
-    "entrezid": 882979,
     "description": "anthranilate dioxygenase reductase",
     "aliases": "-",
     "obsolete": false,
@@ -69850,7 +64477,6 @@
   },
   {
     "id": 5374,
-    "entrezid": 882980,
     "description": "molybdenum cofactor guanylyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -69863,7 +64489,6 @@
   },
   {
     "id": 5375,
-    "entrezid": 882981,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69876,7 +64501,6 @@
   },
   {
     "id": 5376,
-    "entrezid": 882982,
     "description": "50S ribosomal protein L20",
     "aliases": "-",
     "obsolete": false,
@@ -69889,7 +64513,6 @@
   },
   {
     "id": 5377,
-    "entrezid": 882983,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -69902,7 +64525,6 @@
   },
   {
     "id": 5378,
-    "entrezid": 882984,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69915,7 +64537,6 @@
   },
   {
     "id": 5379,
-    "entrezid": 882985,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69928,7 +64549,6 @@
   },
   {
     "id": 5380,
-    "entrezid": 882986,
     "description": "lipid kinase",
     "aliases": "-",
     "obsolete": false,
@@ -69941,7 +64561,6 @@
   },
   {
     "id": 5381,
-    "entrezid": 882987,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69954,7 +64573,6 @@
   },
   {
     "id": 5382,
-    "entrezid": 882988,
     "description": "tyrosine porin OpdT",
     "aliases": "-",
     "obsolete": false,
@@ -69967,7 +64585,6 @@
   },
   {
     "id": 5383,
-    "entrezid": 882989,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -69980,7 +64597,6 @@
   },
   {
     "id": 5384,
-    "entrezid": 882990,
     "description": "TonB-dependent receptor",
     "aliases": "-",
     "obsolete": false,
@@ -69993,7 +64609,6 @@
   },
   {
     "id": 5385,
-    "entrezid": 882991,
     "description": "peptidoglycan associated lipoprotein OprL",
     "aliases": "-",
     "obsolete": false,
@@ -70006,7 +64621,6 @@
   },
   {
     "id": 5386,
-    "entrezid": 882992,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70019,7 +64633,6 @@
   },
   {
     "id": 5387,
-    "entrezid": 882993,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70032,7 +64645,6 @@
   },
   {
     "id": 5388,
-    "entrezid": 882994,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70045,7 +64657,6 @@
   },
   {
     "id": 5389,
-    "entrezid": 882995,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70058,7 +64669,6 @@
   },
   {
     "id": 5390,
-    "entrezid": 882996,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70071,7 +64681,6 @@
   },
   {
     "id": 5391,
-    "entrezid": 882997,
     "description": "type III secretion protein PcrV",
     "aliases": "-",
     "obsolete": false,
@@ -70084,7 +64693,6 @@
   },
   {
     "id": 5392,
-    "entrezid": 882998,
     "description": "nucleoid-associated protein",
     "aliases": "-",
     "obsolete": false,
@@ -70097,7 +64705,6 @@
   },
   {
     "id": 5393,
-    "entrezid": 882999,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70110,7 +64717,6 @@
   },
   {
     "id": 5394,
-    "entrezid": 883000,
     "description": "zinc protease",
     "aliases": "-",
     "obsolete": false,
@@ -70123,7 +64729,6 @@
   },
   {
     "id": 5395,
-    "entrezid": 883001,
     "description": "cbb3-type cytochrome C oxidase subunit I",
     "aliases": "-",
     "obsolete": false,
@@ -70136,7 +64741,6 @@
   },
   {
     "id": 5396,
-    "entrezid": 883002,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70149,7 +64753,6 @@
   },
   {
     "id": 5397,
-    "entrezid": 883003,
     "description": "potassium-transporting ATPase subunit C",
     "aliases": "-",
     "obsolete": false,
@@ -70162,7 +64765,6 @@
   },
   {
     "id": 5398,
-    "entrezid": 883004,
     "description": "amino acid ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -70175,7 +64777,6 @@
   },
   {
     "id": 5399,
-    "entrezid": 883005,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -70188,7 +64789,6 @@
   },
   {
     "id": 5400,
-    "entrezid": 883006,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70201,7 +64801,6 @@
   },
   {
     "id": 5401,
-    "entrezid": 883007,
     "description": "transcriptional regulator CysB",
     "aliases": "-",
     "obsolete": false,
@@ -70214,7 +64813,6 @@
   },
   {
     "id": 5402,
-    "entrezid": 883008,
     "description": "ferredoxin",
     "aliases": "-",
     "obsolete": false,
@@ -70227,7 +64825,6 @@
   },
   {
     "id": 5403,
-    "entrezid": 883009,
     "description": "transcriptional regulator Anr",
     "aliases": "-",
     "obsolete": false,
@@ -70240,7 +64837,6 @@
   },
   {
     "id": 5404,
-    "entrezid": 883010,
     "description": "cbb3-type cytochrome C oxidase subunit II",
     "aliases": "-",
     "obsolete": false,
@@ -70253,7 +64849,6 @@
   },
   {
     "id": 5405,
-    "entrezid": 883011,
     "description": "potassium-transporting ATPase subunit B",
     "aliases": "-",
     "obsolete": false,
@@ -70266,7 +64861,6 @@
   },
   {
     "id": 5406,
-    "entrezid": 883012,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70279,7 +64873,6 @@
   },
   {
     "id": 5407,
-    "entrezid": 883013,
     "description": "glutaminase",
     "aliases": "-",
     "obsolete": false,
@@ -70292,7 +64885,6 @@
   },
   {
     "id": 5408,
-    "entrezid": 883014,
     "description": "two-component response regulator KdpE",
     "aliases": "-",
     "obsolete": false,
@@ -70305,7 +64897,6 @@
   },
   {
     "id": 5409,
-    "entrezid": 883015,
     "description": "cation-transporting P-type ATPase",
     "aliases": "-",
     "obsolete": false,
@@ -70318,7 +64909,6 @@
   },
   {
     "id": 5410,
-    "entrezid": 883016,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -70331,7 +64921,6 @@
   },
   {
     "id": 5411,
-    "entrezid": 883017,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -70344,7 +64933,6 @@
   },
   {
     "id": 5412,
-    "entrezid": 883018,
     "description": "signal recognition particle receptor FtsY",
     "aliases": "-",
     "obsolete": false,
@@ -70357,7 +64945,6 @@
   },
   {
     "id": 5413,
-    "entrezid": 883019,
     "description": "gluconate permease",
     "aliases": "-",
     "obsolete": false,
@@ -70370,7 +64957,6 @@
   },
   {
     "id": 5414,
-    "entrezid": 883020,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70383,7 +64969,6 @@
   },
   {
     "id": 5415,
-    "entrezid": 883021,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70396,7 +64981,6 @@
   },
   {
     "id": 5416,
-    "entrezid": 883022,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70409,7 +64993,6 @@
   },
   {
     "id": 5417,
-    "entrezid": 883023,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70422,7 +65005,6 @@
   },
   {
     "id": 5418,
-    "entrezid": 883024,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -70435,7 +65017,6 @@
   },
   {
     "id": 5419,
-    "entrezid": 883025,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70448,7 +65029,6 @@
   },
   {
     "id": 5420,
-    "entrezid": 883026,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70461,7 +65041,6 @@
   },
   {
     "id": 5421,
-    "entrezid": 883027,
     "description": "potassium-transporting ATPase subunit F",
     "aliases": "-",
     "obsolete": false,
@@ -70474,7 +65053,6 @@
   },
   {
     "id": 5422,
-    "entrezid": 883028,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70487,7 +65065,6 @@
   },
   {
     "id": 5423,
-    "entrezid": 883029,
     "description": "two-component sensor KdpD",
     "aliases": "-",
     "obsolete": false,
@@ -70500,7 +65077,6 @@
   },
   {
     "id": 5424,
-    "entrezid": 883030,
     "description": "sulfatase",
     "aliases": "-",
     "obsolete": false,
@@ -70513,7 +65089,6 @@
   },
   {
     "id": 5425,
-    "entrezid": 883031,
     "description": "cyclic pyranopterin monophosphate synthase",
     "aliases": "-",
     "obsolete": false,
@@ -70526,7 +65101,6 @@
   },
   {
     "id": 5426,
-    "entrezid": 883032,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70539,7 +65113,6 @@
   },
   {
     "id": 5427,
-    "entrezid": 883033,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70552,7 +65125,6 @@
   },
   {
     "id": 5428,
-    "entrezid": 883034,
     "description": "histidine utilization repressor HutC",
     "aliases": "-",
     "obsolete": false,
@@ -70565,7 +65137,6 @@
   },
   {
     "id": 5429,
-    "entrezid": 883035,
     "description": "malonate decarboxylase acyl carrier protein",
     "aliases": "-",
     "obsolete": false,
@@ -70578,7 +65149,6 @@
   },
   {
     "id": 5430,
-    "entrezid": 883036,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -70591,7 +65161,6 @@
   },
   {
     "id": 5431,
-    "entrezid": 883037,
     "description": "oxidoreductase Rmd",
     "aliases": "-",
     "obsolete": false,
@@ -70604,7 +65173,6 @@
   },
   {
     "id": 5432,
-    "entrezid": 883038,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70617,7 +65185,6 @@
   },
   {
     "id": 5433,
-    "entrezid": 883039,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70630,7 +65197,6 @@
   },
   {
     "id": 5434,
-    "entrezid": 883040,
     "description": "N-succinylglutamate 5-semialdehyde dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -70643,7 +65209,6 @@
   },
   {
     "id": 5435,
-    "entrezid": 883041,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70656,7 +65221,6 @@
   },
   {
     "id": 5436,
-    "entrezid": 883042,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70669,7 +65233,6 @@
   },
   {
     "id": 5437,
-    "entrezid": 883043,
     "description": "cytochrome C oxidase cbb3-type subunit CcoP",
     "aliases": "-",
     "obsolete": false,
@@ -70682,7 +65245,6 @@
   },
   {
     "id": 5438,
-    "entrezid": 883044,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70695,7 +65257,6 @@
   },
   {
     "id": 5439,
-    "entrezid": 883045,
     "description": "secretion protein",
     "aliases": "-",
     "obsolete": false,
@@ -70708,7 +65269,6 @@
   },
   {
     "id": 5440,
-    "entrezid": 883046,
     "description": "glyceraldehyde-3-phosphate dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -70721,7 +65281,6 @@
   },
   {
     "id": 5441,
-    "entrezid": 883047,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70734,7 +65293,6 @@
   },
   {
     "id": 5442,
-    "entrezid": 883048,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70747,7 +65305,6 @@
   },
   {
     "id": 5443,
-    "entrezid": 883049,
     "description": "cbb3-type cytochrome C oxidase subunit II",
     "aliases": "-",
     "obsolete": false,
@@ -70760,7 +65317,6 @@
   },
   {
     "id": 5444,
-    "entrezid": 883050,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70773,7 +65329,6 @@
   },
   {
     "id": 5445,
-    "entrezid": 883051,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -70786,7 +65341,6 @@
   },
   {
     "id": 5446,
-    "entrezid": 883052,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -70799,7 +65353,6 @@
   },
   {
     "id": 5447,
-    "entrezid": 883053,
     "description": "oxygen-independent coproporphyrinogen-III oxidase",
     "aliases": "-",
     "obsolete": false,
@@ -70812,7 +65365,6 @@
   },
   {
     "id": 5448,
-    "entrezid": 883054,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70825,7 +65377,6 @@
   },
   {
     "id": 5449,
-    "entrezid": 883055,
     "description": "potassium-transporting ATPase subunit A",
     "aliases": "-",
     "obsolete": false,
@@ -70838,7 +65389,6 @@
   },
   {
     "id": 5450,
-    "entrezid": 883056,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70851,7 +65401,6 @@
   },
   {
     "id": 5451,
-    "entrezid": 883057,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70864,7 +65413,6 @@
   },
   {
     "id": 5452,
-    "entrezid": 883058,
     "description": "drug efflux transporter",
     "aliases": "-",
     "obsolete": false,
@@ -70877,7 +65425,6 @@
   },
   {
     "id": 5453,
-    "entrezid": 883059,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70890,7 +65437,6 @@
   },
   {
     "id": 5454,
-    "entrezid": 883060,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70903,7 +65449,6 @@
   },
   {
     "id": 5455,
-    "entrezid": 883061,
     "description": "polyamine aminopropyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -70916,7 +65461,6 @@
   },
   {
     "id": 5456,
-    "entrezid": 883062,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70929,7 +65473,6 @@
   },
   {
     "id": 5457,
-    "entrezid": 883063,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70942,7 +65485,6 @@
   },
   {
     "id": 5458,
-    "entrezid": 883064,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70955,7 +65497,6 @@
   },
   {
     "id": 5459,
-    "entrezid": 883065,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -70968,7 +65509,6 @@
   },
   {
     "id": 5460,
-    "entrezid": 883066,
     "description": "cytochrome C oxidase cbb3-type subunit CcoP",
     "aliases": "-",
     "obsolete": false,
@@ -70981,7 +65521,6 @@
   },
   {
     "id": 5461,
-    "entrezid": 883067,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -70994,7 +65533,6 @@
   },
   {
     "id": 5462,
-    "entrezid": 883068,
     "description": "transcriptional regulator MtlR",
     "aliases": "-",
     "obsolete": false,
@@ -71007,7 +65545,6 @@
   },
   {
     "id": 5463,
-    "entrezid": 883069,
     "description": "multidrug efflux system protein MdtI",
     "aliases": "-",
     "obsolete": false,
@@ -71020,7 +65557,6 @@
   },
   {
     "id": 5464,
-    "entrezid": 883070,
     "description": "serine-threonine kinase Stk1",
     "aliases": "-",
     "obsolete": false,
@@ -71033,7 +65569,6 @@
   },
   {
     "id": 5465,
-    "entrezid": 883071,
     "description": "binding-protein-dependent maltose/mannitol transport protein",
     "aliases": "-",
     "obsolete": false,
@@ -71046,7 +65581,6 @@
   },
   {
     "id": 5466,
-    "entrezid": 883072,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71059,7 +65593,6 @@
   },
   {
     "id": 5467,
-    "entrezid": 883073,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71072,7 +65605,6 @@
   },
   {
     "id": 5468,
-    "entrezid": 883074,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71085,7 +65617,6 @@
   },
   {
     "id": 5469,
-    "entrezid": 883075,
     "description": "ABC transporter permease",
     "aliases": "-",
     "obsolete": false,
@@ -71098,7 +65629,6 @@
   },
   {
     "id": 5470,
-    "entrezid": 883076,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71111,7 +65641,6 @@
   },
   {
     "id": 5471,
-    "entrezid": 883077,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71124,7 +65653,6 @@
   },
   {
     "id": 5472,
-    "entrezid": 883078,
     "description": "cell division protein FtsE",
     "aliases": "-",
     "obsolete": false,
@@ -71137,7 +65665,6 @@
   },
   {
     "id": 5473,
-    "entrezid": 883079,
     "description": "biofilm formation protein PslH",
     "aliases": "-",
     "obsolete": false,
@@ -71150,7 +65677,6 @@
   },
   {
     "id": 5474,
-    "entrezid": 883080,
     "description": "transporter ExbB",
     "aliases": "-",
     "obsolete": false,
@@ -71163,7 +65689,6 @@
   },
   {
     "id": 5475,
-    "entrezid": 883081,
     "description": "secreted protein Hcp",
     "aliases": "-",
     "obsolete": false,
@@ -71176,7 +65701,6 @@
   },
   {
     "id": 5476,
-    "entrezid": 883082,
     "description": "arginine N-succinyltransferase subunit beta",
     "aliases": "-",
     "obsolete": false,
@@ -71189,7 +65713,6 @@
   },
   {
     "id": 5477,
-    "entrezid": 883083,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71202,7 +65725,6 @@
   },
   {
     "id": 5478,
-    "entrezid": 883084,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -71215,7 +65737,6 @@
   },
   {
     "id": 5479,
-    "entrezid": 883085,
     "description": "tRNA 2-thiocytidine biosynthesis protein TtcA",
     "aliases": "-",
     "obsolete": false,
@@ -71228,7 +65749,6 @@
   },
   {
     "id": 5480,
-    "entrezid": 883086,
     "description": "maltose/mannitol ABC transporter substrate-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -71241,7 +65761,6 @@
   },
   {
     "id": 5481,
-    "entrezid": 883087,
     "description": "acyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -71254,7 +65773,6 @@
   },
   {
     "id": 5482,
-    "entrezid": 883088,
     "description": "phosphomannose isomerase/mannose-1-phosphate guanylyl transferase",
     "aliases": "-",
     "obsolete": false,
@@ -71267,7 +65785,6 @@
   },
   {
     "id": 5483,
-    "entrezid": 883089,
     "description": "GDP-mannose 4,6-dehydratase",
     "aliases": "-",
     "obsolete": false,
@@ -71280,7 +65797,6 @@
   },
   {
     "id": 5484,
-    "entrezid": 883090,
     "description": "HTH-type transcriptional regulator TrpI",
     "aliases": "-",
     "obsolete": false,
@@ -71293,7 +65809,6 @@
   },
   {
     "id": 5485,
-    "entrezid": 883091,
     "description": "major facilitator superfamily transporter",
     "aliases": "-",
     "obsolete": false,
@@ -71306,7 +65821,6 @@
   },
   {
     "id": 5486,
-    "entrezid": 883092,
     "description": "cell division protein FtsX",
     "aliases": "-",
     "obsolete": false,
@@ -71319,7 +65833,6 @@
   },
   {
     "id": 5487,
-    "entrezid": 883093,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71332,7 +65845,6 @@
   },
   {
     "id": 5488,
-    "entrezid": 883094,
     "description": "DNA polymerase III subunits gamma/tau",
     "aliases": "-",
     "obsolete": false,
@@ -71345,7 +65857,6 @@
   },
   {
     "id": 5489,
-    "entrezid": 883095,
     "description": "quinolinate synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -71358,7 +65869,6 @@
   },
   {
     "id": 5490,
-    "entrezid": 883096,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71371,7 +65881,6 @@
   },
   {
     "id": 5491,
-    "entrezid": 883097,
     "description": "acid phosphatase",
     "aliases": "-",
     "obsolete": false,
@@ -71384,7 +65893,6 @@
   },
   {
     "id": 5492,
-    "entrezid": 883098,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71397,7 +65905,6 @@
   },
   {
     "id": 5493,
-    "entrezid": 883099,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -71410,7 +65917,6 @@
   },
   {
     "id": 5494,
-    "entrezid": 883100,
     "description": "translocation protein in type III secretion",
     "aliases": "-",
     "obsolete": false,
@@ -71423,7 +65929,6 @@
   },
   {
     "id": 5495,
-    "entrezid": 883101,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -71436,7 +65941,6 @@
   },
   {
     "id": 5496,
-    "entrezid": 883102,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71449,7 +65953,6 @@
   },
   {
     "id": 5497,
-    "entrezid": 883103,
     "description": "oxidoreductase",
     "aliases": "-",
     "obsolete": false,
@@ -71462,7 +65965,6 @@
   },
   {
     "id": 5498,
-    "entrezid": 883104,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71475,7 +65977,6 @@
   },
   {
     "id": 5499,
-    "entrezid": 883105,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71488,7 +65989,6 @@
   },
   {
     "id": 5500,
-    "entrezid": 883106,
     "description": "3-hydroxyacyl-CoA dehydrogenase",
     "aliases": "-",
     "obsolete": false,
@@ -71501,7 +66001,6 @@
   },
   {
     "id": 5501,
-    "entrezid": 883107,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71514,7 +66013,6 @@
   },
   {
     "id": 5502,
-    "entrezid": 883108,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -71527,7 +66025,6 @@
   },
   {
     "id": 5503,
-    "entrezid": 883109,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71540,7 +66037,6 @@
   },
   {
     "id": 5504,
-    "entrezid": 883110,
     "description": "malonate transporter MadL",
     "aliases": "-",
     "obsolete": false,
@@ -71553,7 +66049,6 @@
   },
   {
     "id": 5505,
-    "entrezid": 883111,
     "description": "pseudo",
     "aliases": "-",
     "obsolete": false,
@@ -71566,7 +66061,6 @@
   },
   {
     "id": 5506,
-    "entrezid": 883112,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71579,7 +66073,6 @@
   },
   {
     "id": 5507,
-    "entrezid": 883113,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71592,7 +66085,6 @@
   },
   {
     "id": 5508,
-    "entrezid": 883114,
     "description": "guanine deaminase",
     "aliases": "-",
     "obsolete": false,
@@ -71605,7 +66097,6 @@
   },
   {
     "id": 5509,
-    "entrezid": 883115,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -71618,7 +66109,6 @@
   },
   {
     "id": 5510,
-    "entrezid": 883116,
     "description": "ABC transporter ATP-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -71631,7 +66121,6 @@
   },
   {
     "id": 5511,
-    "entrezid": 883117,
     "description": "ABC transporter",
     "aliases": "-",
     "obsolete": false,
@@ -71644,7 +66133,6 @@
   },
   {
     "id": 5512,
-    "entrezid": 883118,
     "description": "LPS efflux transporter membrane protein",
     "aliases": "-",
     "obsolete": false,
@@ -71657,7 +66145,6 @@
   },
   {
     "id": 5513,
-    "entrezid": 883119,
     "description": "glycosyl transferase family protein",
     "aliases": "-",
     "obsolete": false,
@@ -71670,7 +66157,6 @@
   },
   {
     "id": 5514,
-    "entrezid": 883120,
     "description": "porin",
     "aliases": "-",
     "obsolete": false,
@@ -71683,7 +66169,6 @@
   },
   {
     "id": 5515,
-    "entrezid": 883121,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -71696,7 +66181,6 @@
   },
   {
     "id": 5516,
-    "entrezid": 883122,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71709,7 +66193,6 @@
   },
   {
     "id": 5517,
-    "entrezid": 883123,
     "description": "type III secretion system protein",
     "aliases": "-",
     "obsolete": false,
@@ -71722,7 +66205,6 @@
   },
   {
     "id": 5518,
-    "entrezid": 883124,
     "description": "GntR family transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -71735,7 +66217,6 @@
   },
   {
     "id": 5519,
-    "entrezid": 883125,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -71748,7 +66229,6 @@
   },
   {
     "id": 5520,
-    "entrezid": 883126,
     "description": "RNA polymerase sigma factor RpoH",
     "aliases": "-",
     "obsolete": false,
@@ -71761,7 +66241,6 @@
   },
   {
     "id": 5521,
-    "entrezid": 883127,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71774,7 +66253,6 @@
   },
   {
     "id": 5522,
-    "entrezid": 883128,
     "description": "2-dehydropantoate 2-reductase",
     "aliases": "-",
     "obsolete": false,
@@ -71787,7 +66265,6 @@
   },
   {
     "id": 5523,
-    "entrezid": 883129,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71800,7 +66277,6 @@
   },
   {
     "id": 5524,
-    "entrezid": 883130,
     "description": "allantoicase",
     "aliases": "-",
     "obsolete": false,
@@ -71813,7 +66289,6 @@
   },
   {
     "id": 5525,
-    "entrezid": 883131,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71826,7 +66301,6 @@
   },
   {
     "id": 5526,
-    "entrezid": 883132,
     "description": "cardiolipin synthetase",
     "aliases": "-",
     "obsolete": false,
@@ -71839,7 +66313,6 @@
   },
   {
     "id": 5527,
-    "entrezid": 883133,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71852,7 +66325,6 @@
   },
   {
     "id": 5528,
-    "entrezid": 883135,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71865,7 +66337,6 @@
   },
   {
     "id": 5529,
-    "entrezid": 883136,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71878,7 +66349,6 @@
   },
   {
     "id": 5530,
-    "entrezid": 883137,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71891,7 +66361,6 @@
   },
   {
     "id": 5531,
-    "entrezid": 883138,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -71904,7 +66373,6 @@
   },
   {
     "id": 5532,
-    "entrezid": 3240205,
     "description": "23S ribosomal RNA",
     "aliases": "-",
     "obsolete": false,
@@ -71917,7 +66385,6 @@
   },
   {
     "id": 5533,
-    "entrezid": 3240206,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -71930,7 +66397,6 @@
   },
   {
     "id": 5534,
-    "entrezid": 3240207,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -71943,7 +66409,6 @@
   },
   {
     "id": 5535,
-    "entrezid": 3240208,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -71956,7 +66421,6 @@
   },
   {
     "id": 5536,
-    "entrezid": 3240209,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -71969,7 +66433,6 @@
   },
   {
     "id": 5537,
-    "entrezid": 3240210,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -71982,7 +66445,6 @@
   },
   {
     "id": 5538,
-    "entrezid": 3240211,
     "description": "16S ribosomal RNA",
     "aliases": "-",
     "obsolete": false,
@@ -71995,7 +66457,6 @@
   },
   {
     "id": 5539,
-    "entrezid": 3240212,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72008,7 +66469,6 @@
   },
   {
     "id": 5540,
-    "entrezid": 3240213,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72021,7 +66481,6 @@
   },
   {
     "id": 5541,
-    "entrezid": 3240214,
     "description": "5S ribosomal RNA",
     "aliases": "-",
     "obsolete": false,
@@ -72034,7 +66493,6 @@
   },
   {
     "id": 5542,
-    "entrezid": 3240215,
     "description": "23S ribosomal RNA",
     "aliases": "-",
     "obsolete": false,
@@ -72047,7 +66505,6 @@
   },
   {
     "id": 5543,
-    "entrezid": 3240216,
     "description": "23S ribosomal RNA",
     "aliases": "-",
     "obsolete": false,
@@ -72060,7 +66517,6 @@
   },
   {
     "id": 5544,
-    "entrezid": 3240217,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72073,7 +66529,6 @@
   },
   {
     "id": 5545,
-    "entrezid": 3240218,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72086,7 +66541,6 @@
   },
   {
     "id": 5546,
-    "entrezid": 3240219,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72099,7 +66553,6 @@
   },
   {
     "id": 5547,
-    "entrezid": 3240220,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72112,7 +66565,6 @@
   },
   {
     "id": 5548,
-    "entrezid": 3240221,
     "description": "23S ribosomal RNA",
     "aliases": "-",
     "obsolete": false,
@@ -72125,7 +66577,6 @@
   },
   {
     "id": 5549,
-    "entrezid": 3240222,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72138,7 +66589,6 @@
   },
   {
     "id": 5550,
-    "entrezid": 3240223,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72151,7 +66601,6 @@
   },
   {
     "id": 5551,
-    "entrezid": 3240224,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72164,7 +66613,6 @@
   },
   {
     "id": 5552,
-    "entrezid": 3240225,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72177,7 +66625,6 @@
   },
   {
     "id": 5553,
-    "entrezid": 3240226,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72190,7 +66637,6 @@
   },
   {
     "id": 5554,
-    "entrezid": 3240227,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72203,7 +66649,6 @@
   },
   {
     "id": 5555,
-    "entrezid": 3240228,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72216,7 +66661,6 @@
   },
   {
     "id": 5556,
-    "entrezid": 3240229,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72229,7 +66673,6 @@
   },
   {
     "id": 5557,
-    "entrezid": 3240230,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72242,7 +66685,6 @@
   },
   {
     "id": 5558,
-    "entrezid": 3240231,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72255,7 +66697,6 @@
   },
   {
     "id": 5559,
-    "entrezid": 3240232,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72268,7 +66709,6 @@
   },
   {
     "id": 5560,
-    "entrezid": 3240233,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72281,7 +66721,6 @@
   },
   {
     "id": 5561,
-    "entrezid": 3240234,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72294,7 +66733,6 @@
   },
   {
     "id": 5562,
-    "entrezid": 3240235,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72307,7 +66745,6 @@
   },
   {
     "id": 5563,
-    "entrezid": 3240236,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72320,7 +66757,6 @@
   },
   {
     "id": 5564,
-    "entrezid": 3240237,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72333,7 +66769,6 @@
   },
   {
     "id": 5565,
-    "entrezid": 3240238,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72346,7 +66781,6 @@
   },
   {
     "id": 5566,
-    "entrezid": 3240239,
     "description": "16S ribosomal RNA",
     "aliases": "-",
     "obsolete": false,
@@ -72359,7 +66793,6 @@
   },
   {
     "id": 5567,
-    "entrezid": 3240240,
     "description": "5S ribosomal RNA",
     "aliases": "-",
     "obsolete": false,
@@ -72372,7 +66805,6 @@
   },
   {
     "id": 5568,
-    "entrezid": 3240241,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72385,7 +66817,6 @@
   },
   {
     "id": 5569,
-    "entrezid": 3240242,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72398,7 +66829,6 @@
   },
   {
     "id": 5570,
-    "entrezid": 3240243,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72411,7 +66841,6 @@
   },
   {
     "id": 5571,
-    "entrezid": 3240244,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72424,7 +66853,6 @@
   },
   {
     "id": 5572,
-    "entrezid": 3240245,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72437,7 +66865,6 @@
   },
   {
     "id": 5573,
-    "entrezid": 3240246,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72450,7 +66877,6 @@
   },
   {
     "id": 5574,
-    "entrezid": 3240247,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72463,7 +66889,6 @@
   },
   {
     "id": 5575,
-    "entrezid": 3240248,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72476,7 +66901,6 @@
   },
   {
     "id": 5576,
-    "entrezid": 3240249,
     "description": "5S ribosomal RNA",
     "aliases": "-",
     "obsolete": false,
@@ -72489,7 +66913,6 @@
   },
   {
     "id": 5577,
-    "entrezid": 3240250,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72502,7 +66925,6 @@
   },
   {
     "id": 5578,
-    "entrezid": 3240251,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72515,7 +66937,6 @@
   },
   {
     "id": 5579,
-    "entrezid": 3240252,
     "description": "16S ribosomal RNA",
     "aliases": "-",
     "obsolete": false,
@@ -72528,7 +66949,6 @@
   },
   {
     "id": 5580,
-    "entrezid": 3240253,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72541,7 +66961,6 @@
   },
   {
     "id": 5581,
-    "entrezid": 3240254,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72554,7 +66973,6 @@
   },
   {
     "id": 5582,
-    "entrezid": 3240255,
     "description": "miscRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72567,7 +66985,6 @@
   },
   {
     "id": 5583,
-    "entrezid": 3240256,
     "description": "5S ribosomal RNA",
     "aliases": "-",
     "obsolete": false,
@@ -72580,7 +66997,6 @@
   },
   {
     "id": 5584,
-    "entrezid": 3240257,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72593,7 +67009,6 @@
   },
   {
     "id": 5585,
-    "entrezid": 3240258,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72606,7 +67021,6 @@
   },
   {
     "id": 5586,
-    "entrezid": 3240259,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72619,7 +67033,6 @@
   },
   {
     "id": 5587,
-    "entrezid": 3240260,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72632,7 +67045,6 @@
   },
   {
     "id": 5588,
-    "entrezid": 3240261,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72645,7 +67057,6 @@
   },
   {
     "id": 5589,
-    "entrezid": 3240262,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72658,7 +67069,6 @@
   },
   {
     "id": 5590,
-    "entrezid": 3240263,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72671,7 +67081,6 @@
   },
   {
     "id": 5591,
-    "entrezid": 3240264,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72684,7 +67093,6 @@
   },
   {
     "id": 5592,
-    "entrezid": 3240265,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72697,7 +67105,6 @@
   },
   {
     "id": 5593,
-    "entrezid": 3240266,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72710,7 +67117,6 @@
   },
   {
     "id": 5594,
-    "entrezid": 3240267,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72723,7 +67129,6 @@
   },
   {
     "id": 5595,
-    "entrezid": 3240268,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72736,7 +67141,6 @@
   },
   {
     "id": 5596,
-    "entrezid": 3240269,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72749,7 +67153,6 @@
   },
   {
     "id": 5597,
-    "entrezid": 3240270,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72762,7 +67165,6 @@
   },
   {
     "id": 5598,
-    "entrezid": 3240271,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72775,7 +67177,6 @@
   },
   {
     "id": 5599,
-    "entrezid": 3240272,
     "description": "16S ribosomal RNA",
     "aliases": "-",
     "obsolete": false,
@@ -72788,7 +67189,6 @@
   },
   {
     "id": 5600,
-    "entrezid": 3240273,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72801,7 +67201,6 @@
   },
   {
     "id": 5601,
-    "entrezid": 3240274,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72814,7 +67213,6 @@
   },
   {
     "id": 5602,
-    "entrezid": 3240275,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72827,7 +67225,6 @@
   },
   {
     "id": 5603,
-    "entrezid": 3240276,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72840,7 +67237,6 @@
   },
   {
     "id": 5604,
-    "entrezid": 3240277,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72853,7 +67249,6 @@
   },
   {
     "id": 5605,
-    "entrezid": 3240278,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72866,7 +67261,6 @@
   },
   {
     "id": 5606,
-    "entrezid": 3240279,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72879,7 +67273,6 @@
   },
   {
     "id": 5607,
-    "entrezid": 3240280,
     "description": "tRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72892,7 +67285,6 @@
   },
   {
     "id": 5608,
-    "entrezid": 4179184,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72905,7 +67297,6 @@
   },
   {
     "id": 5609,
-    "entrezid": 4179185,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72918,7 +67309,6 @@
   },
   {
     "id": 5610,
-    "entrezid": 4179186,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72931,7 +67321,6 @@
   },
   {
     "id": 5611,
-    "entrezid": 4179187,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72944,7 +67333,6 @@
   },
   {
     "id": 5612,
-    "entrezid": 4179188,
     "description": "4.5S ribosomal RNA",
     "aliases": "-",
     "obsolete": false,
@@ -72957,7 +67345,6 @@
   },
   {
     "id": 5613,
-    "entrezid": 6965615,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72970,7 +67357,6 @@
   },
   {
     "id": 5614,
-    "entrezid": 6965616,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72983,7 +67369,6 @@
   },
   {
     "id": 5615,
-    "entrezid": 6965617,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -72996,7 +67381,6 @@
   },
   {
     "id": 5616,
-    "entrezid": 6965618,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73009,7 +67393,6 @@
   },
   {
     "id": 5617,
-    "entrezid": 6965619,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73022,7 +67405,6 @@
   },
   {
     "id": 5618,
-    "entrezid": 6965620,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73035,7 +67417,6 @@
   },
   {
     "id": 5619,
-    "entrezid": 6965621,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73048,7 +67429,6 @@
   },
   {
     "id": 5620,
-    "entrezid": 6965622,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73061,7 +67441,6 @@
   },
   {
     "id": 5621,
-    "entrezid": 6965623,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73074,7 +67453,6 @@
   },
   {
     "id": 5622,
-    "entrezid": 6965624,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73087,7 +67465,6 @@
   },
   {
     "id": 5623,
-    "entrezid": 6965625,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73100,7 +67477,6 @@
   },
   {
     "id": 5624,
-    "entrezid": 6965626,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73113,7 +67489,6 @@
   },
   {
     "id": 5625,
-    "entrezid": 6965627,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73126,7 +67501,6 @@
   },
   {
     "id": 5626,
-    "entrezid": 6965628,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73139,7 +67513,6 @@
   },
   {
     "id": 5627,
-    "entrezid": 6965629,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73152,7 +67525,6 @@
   },
   {
     "id": 5628,
-    "entrezid": 6965630,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73165,7 +67537,6 @@
   },
   {
     "id": 5629,
-    "entrezid": 6965631,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73178,7 +67549,6 @@
   },
   {
     "id": 5630,
-    "entrezid": 6965632,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73191,7 +67561,6 @@
   },
   {
     "id": 5631,
-    "entrezid": 9793385,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73204,7 +67573,6 @@
   },
   {
     "id": 5632,
-    "entrezid": 9793387,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73217,7 +67585,6 @@
   },
   {
     "id": 5633,
-    "entrezid": 9793388,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73230,7 +67597,6 @@
   },
   {
     "id": 5634,
-    "entrezid": 9793389,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73243,7 +67609,6 @@
   },
   {
     "id": 5635,
-    "entrezid": 9793390,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73256,7 +67621,6 @@
   },
   {
     "id": 5636,
-    "entrezid": 9793391,
     "description": "cytochrome C oxidase cbb3-type subunit CcoQ",
     "aliases": "-",
     "obsolete": false,
@@ -73269,7 +67633,6 @@
   },
   {
     "id": 5637,
-    "entrezid": 9793392,
     "description": "cytochrome C oxidase cbb3-type subunit CcoQ",
     "aliases": "-",
     "obsolete": false,
@@ -73282,7 +67645,6 @@
   },
   {
     "id": 5638,
-    "entrezid": 9793393,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73295,7 +67657,6 @@
   },
   {
     "id": 5639,
-    "entrezid": 9793394,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73308,7 +67669,6 @@
   },
   {
     "id": 5640,
-    "entrezid": 9793395,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73321,7 +67681,6 @@
   },
   {
     "id": 5641,
-    "entrezid": 9793396,
     "description": "ncRNA",
     "aliases": "-",
     "obsolete": false,
@@ -73334,7 +67693,6 @@
   },
   {
     "id": 5642,
-    "entrezid": 17373334,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73347,7 +67705,6 @@
   },
   {
     "id": 5643,
-    "entrezid": 17373335,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73360,7 +67717,6 @@
   },
   {
     "id": 5644,
-    "entrezid": 17373336,
     "description": "DOPA 4,5-dioxygenase",
     "aliases": "-",
     "obsolete": false,
@@ -73373,7 +67729,6 @@
   },
   {
     "id": 5645,
-    "entrezid": 17373337,
     "description": "transposase",
     "aliases": "-",
     "obsolete": false,
@@ -73386,7 +67741,6 @@
   },
   {
     "id": 5646,
-    "entrezid": 17373338,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73399,7 +67753,6 @@
   },
   {
     "id": 5647,
-    "entrezid": 17373339,
     "description": "transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -73412,7 +67765,6 @@
   },
   {
     "id": 5648,
-    "entrezid": 17373340,
     "description": "acetyltransferase",
     "aliases": "-",
     "obsolete": false,
@@ -73425,7 +67777,6 @@
   },
   {
     "id": 5649,
-    "entrezid": 17373341,
     "description": "amino acid ABC transporter substrate-binding protein",
     "aliases": "-",
     "obsolete": false,
@@ -73438,7 +67789,6 @@
   },
   {
     "id": 5650,
-    "entrezid": 17373342,
     "description": "AraC family transcriptional regulator",
     "aliases": "-",
     "obsolete": false,
@@ -73451,7 +67801,6 @@
   },
   {
     "id": 5651,
-    "entrezid": 17373343,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73464,7 +67813,6 @@
   },
   {
     "id": 5652,
-    "entrezid": 17373344,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73477,7 +67825,6 @@
   },
   {
     "id": 5653,
-    "entrezid": 17373345,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73490,7 +67837,6 @@
   },
   {
     "id": 5654,
-    "entrezid": 17373346,
     "description": "thioesterase",
     "aliases": "-",
     "obsolete": false,
@@ -73503,7 +67849,6 @@
   },
   {
     "id": 5655,
-    "entrezid": 17373347,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73516,7 +67861,6 @@
   },
   {
     "id": 5656,
-    "entrezid": 17373348,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73529,7 +67873,6 @@
   },
   {
     "id": 5657,
-    "entrezid": 17373349,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73542,7 +67885,6 @@
   },
   {
     "id": 5658,
-    "entrezid": 17373350,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73555,7 +67897,6 @@
   },
   {
     "id": 5659,
-    "entrezid": 17373351,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73568,7 +67909,6 @@
   },
   {
     "id": 5660,
-    "entrezid": 17373352,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73581,7 +67921,6 @@
   },
   {
     "id": 5661,
-    "entrezid": 17373353,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73594,7 +67933,6 @@
   },
   {
     "id": 5662,
-    "entrezid": 17373354,
     "description": "aldehyde-activating protein",
     "aliases": "-",
     "obsolete": false,
@@ -73607,7 +67945,6 @@
   },
   {
     "id": 5663,
-    "entrezid": 17373355,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73620,7 +67957,6 @@
   },
   {
     "id": 5664,
-    "entrezid": 17373356,
     "description": "alpha/beta hydrolase",
     "aliases": "-",
     "obsolete": false,
@@ -73633,7 +67969,6 @@
   },
   {
     "id": 5665,
-    "entrezid": 17373357,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73646,7 +67981,6 @@
   },
   {
     "id": 5666,
-    "entrezid": 17373358,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73659,7 +67993,6 @@
   },
   {
     "id": 5667,
-    "entrezid": 17373359,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73672,7 +68005,6 @@
   },
   {
     "id": 5668,
-    "entrezid": 17373360,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73685,7 +68017,6 @@
   },
   {
     "id": 5669,
-    "entrezid": 17373361,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73698,7 +68029,6 @@
   },
   {
     "id": 5670,
-    "entrezid": 17373362,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73711,7 +68041,6 @@
   },
   {
     "id": 5671,
-    "entrezid": 17373363,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73724,7 +68053,6 @@
   },
   {
     "id": 5672,
-    "entrezid": 17373364,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73737,7 +68065,6 @@
   },
   {
     "id": 5673,
-    "entrezid": 17373365,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73750,7 +68077,6 @@
   },
   {
     "id": 5674,
-    "entrezid": 17373366,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73763,7 +68089,6 @@
   },
   {
     "id": 5675,
-    "entrezid": 17373367,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73776,7 +68101,6 @@
   },
   {
     "id": 5676,
-    "entrezid": 17373368,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73789,7 +68113,6 @@
   },
   {
     "id": 5677,
-    "entrezid": 17373369,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73802,7 +68125,6 @@
   },
   {
     "id": 5678,
-    "entrezid": 17373370,
     "description": "1-aminocyclopropane-1-carboxylate deaminase",
     "aliases": "-",
     "obsolete": false,
@@ -73815,7 +68137,6 @@
   },
   {
     "id": 5679,
-    "entrezid": 17373371,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73828,7 +68149,6 @@
   },
   {
     "id": 5680,
-    "entrezid": 17373372,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73841,7 +68161,6 @@
   },
   {
     "id": 5681,
-    "entrezid": 17373373,
     "description": "type III effector protein",
     "aliases": "-",
     "obsolete": false,
@@ -73854,7 +68173,6 @@
   },
   {
     "id": 5682,
-    "entrezid": 17373374,
     "description": "copper chaperone CopZ",
     "aliases": "-",
     "obsolete": false,
@@ -73867,7 +68185,6 @@
   },
   {
     "id": 5683,
-    "entrezid": 17373375,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73880,7 +68197,6 @@
   },
   {
     "id": 5684,
-    "entrezid": 17373376,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73893,7 +68209,6 @@
   },
   {
     "id": 5685,
-    "entrezid": 17373377,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73906,7 +68221,6 @@
   },
   {
     "id": 5686,
-    "entrezid": 17373378,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73919,7 +68233,6 @@
   },
   {
     "id": 5687,
-    "entrezid": 17373379,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73932,7 +68245,6 @@
   },
   {
     "id": 5688,
-    "entrezid": 17373380,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73945,7 +68257,6 @@
   },
   {
     "id": 5689,
-    "entrezid": 17373381,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73958,7 +68269,6 @@
   },
   {
     "id": 5690,
-    "entrezid": 17373382,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73971,7 +68281,6 @@
   },
   {
     "id": 5691,
-    "entrezid": 17373383,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73984,7 +68293,6 @@
   },
   {
     "id": 5692,
-    "entrezid": 17373384,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -73997,7 +68305,6 @@
   },
   {
     "id": 5693,
-    "entrezid": 17373385,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -74010,7 +68317,6 @@
   },
   {
     "id": 5694,
-    "entrezid": 17373386,
     "description": "paraquat-inducible protein A",
     "aliases": "-",
     "obsolete": false,
@@ -74023,7 +68329,6 @@
   },
   {
     "id": 5695,
-    "entrezid": 17373387,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -74036,7 +68341,6 @@
   },
   {
     "id": 5696,
-    "entrezid": 17373388,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -74049,7 +68353,6 @@
   },
   {
     "id": 5697,
-    "entrezid": 17373389,
     "description": "hypothetical protein",
     "aliases": "-",
     "obsolete": false,
@@ -74062,7 +68365,6 @@
   },
   {
     "id": 5698,
-    "entrezid": 877568,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74075,7 +68377,6 @@
   },
   {
     "id": 5699,
-    "entrezid": 877628,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74088,7 +68389,6 @@
   },
   {
     "id": 5700,
-    "entrezid": 877635,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74101,7 +68401,6 @@
   },
   {
     "id": 5701,
-    "entrezid": 878059,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74114,7 +68413,6 @@
   },
   {
     "id": 5702,
-    "entrezid": 878256,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74127,7 +68425,6 @@
   },
   {
     "id": 5703,
-    "entrezid": 878294,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74140,7 +68437,6 @@
   },
   {
     "id": 5704,
-    "entrezid": 878506,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74153,7 +68449,6 @@
   },
   {
     "id": 5705,
-    "entrezid": 878529,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74166,7 +68461,6 @@
   },
   {
     "id": 5706,
-    "entrezid": 878825,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74179,7 +68473,6 @@
   },
   {
     "id": 5707,
-    "entrezid": 878887,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74192,7 +68485,6 @@
   },
   {
     "id": 5708,
-    "entrezid": 878910,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74205,7 +68497,6 @@
   },
   {
     "id": 5709,
-    "entrezid": 878921,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74218,7 +68509,6 @@
   },
   {
     "id": 5710,
-    "entrezid": 878934,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74231,7 +68521,6 @@
   },
   {
     "id": 5711,
-    "entrezid": 879038,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74244,7 +68533,6 @@
   },
   {
     "id": 5712,
-    "entrezid": 879215,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74257,7 +68545,6 @@
   },
   {
     "id": 5713,
-    "entrezid": 879218,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74270,7 +68557,6 @@
   },
   {
     "id": 5714,
-    "entrezid": 879582,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74283,7 +68569,6 @@
   },
   {
     "id": 5715,
-    "entrezid": 879614,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74296,7 +68581,6 @@
   },
   {
     "id": 5716,
-    "entrezid": 879684,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74309,7 +68593,6 @@
   },
   {
     "id": 5717,
-    "entrezid": 879849,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74322,7 +68605,6 @@
   },
   {
     "id": 5718,
-    "entrezid": 880072,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74335,7 +68617,6 @@
   },
   {
     "id": 5719,
-    "entrezid": 880117,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74348,7 +68629,6 @@
   },
   {
     "id": 5720,
-    "entrezid": 880897,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74361,7 +68641,6 @@
   },
   {
     "id": 5721,
-    "entrezid": 881333,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74374,7 +68653,6 @@
   },
   {
     "id": 5722,
-    "entrezid": 881757,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74387,7 +68665,6 @@
   },
   {
     "id": 5723,
-    "entrezid": 881768,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74400,7 +68677,6 @@
   },
   {
     "id": 5724,
-    "entrezid": 881874,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74413,7 +68689,6 @@
   },
   {
     "id": 5725,
-    "entrezid": 882075,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74426,7 +68701,6 @@
   },
   {
     "id": 5726,
-    "entrezid": 882096,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74439,7 +68713,6 @@
   },
   {
     "id": 5727,
-    "entrezid": 882102,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74452,7 +68725,6 @@
   },
   {
     "id": 5728,
-    "entrezid": 882239,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74465,7 +68737,6 @@
   },
   {
     "id": 5729,
-    "entrezid": 882272,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74478,7 +68749,6 @@
   },
   {
     "id": 5730,
-    "entrezid": 882556,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74491,7 +68761,6 @@
   },
   {
     "id": 5731,
-    "entrezid": 882569,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74504,7 +68773,6 @@
   },
   {
     "id": 5732,
-    "entrezid": 882629,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74517,7 +68785,6 @@
   },
   {
     "id": 5733,
-    "entrezid": 882683,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74530,7 +68797,6 @@
   },
   {
     "id": 5734,
-    "entrezid": 882746,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74543,7 +68809,6 @@
   },
   {
     "id": 5735,
-    "entrezid": 882917,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74556,7 +68821,6 @@
   },
   {
     "id": 5736,
-    "entrezid": 882966,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74569,7 +68833,6 @@
   },
   {
     "id": 5737,
-    "entrezid": 883134,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74582,7 +68845,6 @@
   },
   {
     "id": 5738,
-    "entrezid": 9793384,
     "description": "-",
     "aliases": "-",
     "obsolete": true,
@@ -74595,7 +68857,6 @@
   },
   {
     "id": 5739,
-    "entrezid": 9793386,
     "description": "-",
     "aliases": "-",
     "obsolete": true,

--- a/src/dummy-data/selected-genes.json
+++ b/src/dummy-data/selected-genes.json
@@ -1,7 +1,6 @@
 [
   {
     "id": 3177,
-    "entrezid": 880766,
     "description": "transporter",
     "aliases": "-",
     "obsolete": false,
@@ -14,7 +13,6 @@
   },
   {
     "id": 5067,
-    "entrezid": 882669,
     "description": "chloroperoxidase",
     "aliases": "-",
     "obsolete": false,

--- a/src/pages/experiment/index.js
+++ b/src/pages/experiment/index.js
@@ -44,8 +44,7 @@ let Experiment = ({ experimentList, sampleList }) => {
       details = filterKeys(details, ['maxSimilarityField']);
       if (details.samples) {
         details.samples = details.samples.map(
-          (sample) =>
-            sampleList.find((fullSample) => fullSample.id === sample) || {}
+          (sample) => sampleList.find((full) => full.id === sample) || {}
         );
         details.samples = (
           <>

--- a/src/pages/experiment/index.js
+++ b/src/pages/experiment/index.js
@@ -23,17 +23,19 @@ import './index.css';
 
 // experiment details page
 
-let Experiment = ({ experiments }) => {
+let Experiment = ({ experimentList, sampleList }) => {
   const match = useRouteMatch();
-  const accession = match.params.accession;
+  const id = match.params.id;
 
   let details;
 
-  if (isString(experiments))
-    details = experiments;
-  else if (isArray(experiments)) {
-    const found = experiments.find(
-      (experiment) => String(experiment.accession) === String(accession)
+  if (isString(experimentList))
+    details = experimentList;
+  else if (isString(sampleList))
+    details = sampleList;
+  else if (isArray(experimentList) && isArray(sampleList)) {
+    const found = experimentList.find(
+      (experiment) => String(experiment.id) === String(id)
     );
     if (!found)
       details = actionStatuses.EMPTY;
@@ -41,6 +43,10 @@ let Experiment = ({ experiments }) => {
       details = { ...found };
       details = filterKeys(details, ['maxSimilarityField']);
       if (details.samples) {
+        details.samples = details.samples.map(
+          (sample) =>
+            sampleList.find((fullSample) => fullSample.id === sample) || {}
+        );
         details.samples = (
           <>
             {details.samples.map((sample, index) => (
@@ -79,7 +85,10 @@ let Experiment = ({ experiments }) => {
   );
 };
 
-const mapStateToProps = (state) => ({ experiments: state.experiments.list });
+const mapStateToProps = (state) => ({
+  experimentList: state.experiments.list,
+  sampleList: state.samples.list
+});
 
 Experiment = connect(mapStateToProps)(Experiment);
 

--- a/src/pages/experiment/link.js
+++ b/src/pages/experiment/link.js
@@ -5,8 +5,8 @@ import Clickable from '../../components/clickable';
 // link to experiment details page
 
 const ExperimentLink = ({ experiment = {} }) => {
-  const { accession: id } = experiment;
-  const label = id || '-';
+  const { id, accession } = experiment;
+  const label = accession || id || '-';
 
   return (
     <Clickable

--- a/src/pages/experiments/search/index.js
+++ b/src/pages/experiments/search/index.js
@@ -26,7 +26,7 @@ let Search = ({ results, select, search }) => (
       });
     }}
     onKeySelect={(highlightedIndex) =>
-      select({ accession: results[highlightedIndex].accession })
+      select({ id: results[highlightedIndex].id })
     }
     SingleComponent={<Single />}
     storageKey='experimentSearch'
@@ -56,6 +56,6 @@ export const mapExperimentSearch = (search, state) => ({
 
 export const mapExperimentResult = (result, state) => ({
   ...result,
-  selected: isSelected(state.experiments.selected, result.accession),
+  selected: isSelected(state.experiments.selected, result.id),
   highlightedField: toCamelCase(result.maxSimilarityField || '')
 });

--- a/src/pages/experiments/search/single-table/index.js
+++ b/src/pages/experiments/search/single-table/index.js
@@ -34,7 +34,7 @@ let Table = ({ query, results, highlightedIndex, select }) => {
               <Clickable
                 icon={row.selected ? <RadioedIcon /> : <UnradioedIcon />}
                 button
-                onClick={() => select({ accession: row.accession })}
+                onClick={() => select({ id: row.id })}
                 aria-label='Select this experiment'
               />
             ),

--- a/src/pages/experiments/selected/index.js
+++ b/src/pages/experiments/selected/index.js
@@ -16,7 +16,7 @@ let Selected = ({ anySelected }) => (
 );
 
 const mapStateToProps = (state) => ({
-  anySelected: state.experiments.selected.accession ? true : false
+  anySelected: state.experiments.selected.id ? true : false
 });
 
 Selected = connect(mapStateToProps)(Selected);

--- a/src/pages/sample/index.js
+++ b/src/pages/sample/index.js
@@ -22,26 +22,34 @@ import './index.css';
 
 // sample details page
 
-let Sample = ({ samples }) => {
+let Sample = ({ sampleList, experimentList }) => {
   const match = useRouteMatch();
   const id = match.params.id;
 
   let details;
 
-  if (isString(samples))
-    details = samples;
-  else if (isArray(samples)) {
-    const found = samples.find((sample) => String(sample.id) === String(id));
+  if (isString(sampleList))
+    details = sampleList;
+  else if (isString(experimentList))
+    details = experimentList;
+  else if (isArray(sampleList) && isArray(experimentList)) {
+    const found = sampleList.find((sample) => String(sample.id) === String(id));
     if (!found)
       details = actionStatuses.EMPTY;
     else {
       details = { ...found };
       if (details.experiments) {
+        details.experiments = details.experiments.map(
+          (experiment) =>
+            experimentList.find(
+              (fullExperiment) => fullExperiment.id === experiment
+            ) || {}
+        );
         details.experiments = (
           <>
             {details.experiments.map((experiment, index) => (
               <Fragment key={index}>
-                <ExperimentLink experiment={{ accession: experiment }} />
+                <ExperimentLink experiment={experiment} />
                 <br />
               </Fragment>
             ))}
@@ -75,7 +83,10 @@ let Sample = ({ samples }) => {
   );
 };
 
-const mapStateToProps = (state) => ({ samples: state.samples.list });
+const mapStateToProps = (state) => ({
+  sampleList: state.samples.list,
+  experimentList: state.experiments.list
+});
 
 Sample = connect(mapStateToProps)(Sample);
 

--- a/src/pages/sample/index.js
+++ b/src/pages/sample/index.js
@@ -41,9 +41,7 @@ let Sample = ({ sampleList, experimentList }) => {
       if (details.experiments) {
         details.experiments = details.experiments.map(
           (experiment) =>
-            experimentList.find(
-              (fullExperiment) => fullExperiment.id === experiment
-            ) || {}
+            experimentList.find((full) => full.id === experiment) || {}
         );
         details.experiments = (
           <>

--- a/src/pages/signatures/activities/index.js
+++ b/src/pages/signatures/activities/index.js
@@ -50,8 +50,8 @@ export const mapActivities = (activities, state) => {
 
   // get sample info out of activities
   const findSample = (sample) => ({
-    ...sample,
-    value: activities.find((activity) => activity.sample === sample.id)?.value
+    id: sample,
+    value: activities.find((activity) => activity.sample === sample)?.value
   });
 
   // get activities by experiment
@@ -69,6 +69,7 @@ export const mapActivities = (activities, state) => {
       const range = max - min;
       // return all needed info
       return {
+        id: experiment.id,
         accession: experiment.accession,
         values,
         count: values.length,

--- a/src/pages/signatures/activities/table/index.js
+++ b/src/pages/signatures/activities/table/index.js
@@ -22,7 +22,7 @@ import './index.css';
 
 let Table = ({ bySignature = {}, byExperiment = [], sampleList }) => {
   const [background, setBackground] = useState();
-  const [selected, setSelected] = useState('');
+  const [selected, setSelected] = useState();
 
   const { values, min, max } = bySignature;
 
@@ -49,7 +49,7 @@ let Table = ({ bySignature = {}, byExperiment = [], sampleList }) => {
               return (
                 <button
                   className='barcode_button'
-                  onClick={() => setSelected(row.accession)}
+                  onClick={() => setSelected(row.id)}
                 >
                   <Canvas
                     className='barcode'
@@ -102,7 +102,7 @@ let Table = ({ bySignature = {}, byExperiment = [], sampleList }) => {
   } else {
     // get full details of selected experiment
     const experiment = byExperiment.find(
-      (experiment) => experiment.accession === selected
+      (experiment) => experiment.id === selected
     );
 
     let samples = experiment?.samples || [];
@@ -122,7 +122,7 @@ let Table = ({ bySignature = {}, byExperiment = [], sampleList }) => {
             <Clickable
               icon={<ArrowIcon className='flip_horizontal' />}
               text='Back to all experiments'
-              onClick={() => setSelected('')}
+              onClick={() => setSelected()}
               button
               flip
             />

--- a/src/reducers/experiments.js
+++ b/src/reducers/experiments.js
@@ -38,8 +38,8 @@ const reducer = produce((draft, type, payload, meta) => {
     }
 
     case 'SELECT_EXPERIMENT_FROM_URL': {
-      const { accession } = payload;
-      if (!accession)
+      const { id } = payload;
+      if (!id)
         draft.selected = {};
       else
         draft.selected = payload;
@@ -54,7 +54,7 @@ const reducer = produce((draft, type, payload, meta) => {
   // fill in details of selected from full list
   if (isArray(draft.list)) {
     const found = draft.list.find(
-      (experiment) => experiment.accession === draft.selected.accession
+      (experiment) => experiment.id === draft.selected.id
     );
     if (found && !experimentIsLoaded(draft.selected))
       draft.selected = found;
@@ -65,8 +65,7 @@ const reducer = produce((draft, type, payload, meta) => {
 
 export default reducer;
 
-export const isSelected = (selected, accession) =>
-  selected.accession === accession;
+export const isSelected = (selected, id) => selected.id === id;
 
 export const experimentIsLoaded = (experiment) =>
   experiment?.name ? true : false;

--- a/src/reducers/genes.js
+++ b/src/reducers/genes.js
@@ -161,7 +161,7 @@ export const mapGene = (gene) => {
     id,
     standardName,
     systematicName,
-    entrezid: entrezId,
+    entrezId,
     ...rest
   } = gene;
   const name = standardName || systematicName || entrezId || '-';

--- a/src/reducers/url.js
+++ b/src/reducers/url.js
@@ -35,11 +35,11 @@ export const querySync = reduxQuerySync.enhancer({
       })
     },
     'experiment': {
-      selector: (state) => state.experiments.selected.accession || undefined,
+      selector: (state) => state.experiments.selected.id || undefined,
       action: (value) => ({
         type: 'SELECT_EXPERIMENT_FROM_URL',
         payload: {
-          accession: value || null
+          id: Number(value)
         }
       })
     },


### PR DESCRIPTION
- switch from accession to id for id'ing experiments
- change experiments query from returning objects to an array of ids
- remove entrezid duplicate of entrezId