### PR TITLE
make programmatic links in svgs use react router

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adage-frontend",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "dependencies": {
     "@greenelab/hclust": "^0.0.0",
     "@stdlib/stdlib": "^0.0.91",

--- a/src/pages/experiments/activities/heatmap/index.js
+++ b/src/pages/experiments/activities/heatmap/index.js
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useEffect } from 'react';
 import { useMemo } from 'react';
 import { useContext } from 'react';
+import { useHistory } from 'react-router-dom';
 import { connect } from 'react-redux';
 import * as d3 from 'd3';
 
@@ -31,6 +32,7 @@ let Heatmap = ({ activities, group }) => {
   const [start, setStart] = useState(null);
   const { sampleOrder, signatureOrder } = useContext(OrderContext);
   const mounted = useMounted();
+  const history = useHistory();
 
   // detect prop change
   const mountedChanged = useDiff(mounted);
@@ -108,7 +110,7 @@ let Heatmap = ({ activities, group }) => {
         const location = window.location;
         const to = '/signatures';
         const search = { signature: d.signature.id };
-        window.location = getLinkPath({ location, to, search }).full;
+        history.push(getLinkPath({ location, to, search }).full);
       });
     cells.exit().remove();
   }, [
@@ -121,7 +123,8 @@ let Heatmap = ({ activities, group }) => {
     samplesChanged,
     signaturesChanged,
     width,
-    height
+    height,
+    history
   ]);
 
   // reset shift select when sample order changes

--- a/src/pages/experiments/volcano/plot/index.js
+++ b/src/pages/experiments/volcano/plot/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useEffect } from 'react';
 import { useMemo } from 'react';
+import { useHistory } from 'react-router-dom';
 import { connect } from 'react-redux';
 import * as d3 from 'd3';
 
@@ -29,6 +30,7 @@ let Plot = ({ volcano, search, pValueCutoff }) => {
   // internal state
   const mounted = useMounted();
   const [bbox, ref] = useBbox();
+  const history = useHistory();
 
   const width = Math.round(bbox?.width || 0);
   const height = Math.round(bbox?.height || 0);
@@ -131,10 +133,10 @@ let Plot = ({ volcano, search, pValueCutoff }) => {
         const location = window.location;
         const to = '/signatures';
         const search = { signature: d.id };
-        window.location = getLinkPath({ location, to, search }).full;
+        history.push(getLinkPath({ location, to, search }).full);
       });
     dot.exit().remove();
-  }, [mounted, width, height, volcano, pValueCutoff]);
+  }, [mounted, width, height, volcano, pValueCutoff, history]);
 
   return (
     <>


### PR DESCRIPTION
Use react router to programmatically change url on click of heatmap and volcano plot elements (which can't use the typical react router <Link> components), instead of setting window.location. This makes it so the whole app doesn't have to reload when clicking on these svg links, or when going backward after doing so.